### PR TITLE
Dogstatsd sets contain strings, not floats or ints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
 * `num_workers` - The number of worker goroutines to start.
 * `read_buffer_size_bytes` - The size of the receive buffer for the UDP socket. Defaults to 2MB, as having a lot of buffer prevents packet drops during flush!
-* `sample_rate` - The rate at which to sample Veneur's internal metrics. Assuming you're doing a lot of metrics!
 * `set_size` - The cardinality of the set you'll using with sets. Too small will cause decreased accuracy.
 * `set_accuracy` - The approximate accuracy of set's approximations. More accuracy uses more memory.
 * `stats_address` - The address to send internally generated metrics. Probably `127.0.0.1:8125` to send to a local DogStatsD

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -26,9 +26,6 @@ func main() {
 		log.WithError(err).Fatal("Error reading config file")
 	}
 
-	// Parse the command-line flags.
-	flag.Parse()
-
 	if veneur.Config.Debug {
 		log.SetLevel(log.DebugLevel)
 		log.WithField("config", veneur.Config).Debug("Starting with config")

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/gphat/veneur"
+	"github.com/stripe/veneur"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -23,7 +23,6 @@ type VeneurConfig struct {
 	SetAccuracy         float64       `yaml:"set_accuracy"`
 	UDPAddr             string        `yaml:"udp_address"`
 	NumWorkers          int           `yaml:"num_workers"`
-	SampleRate          float64       `yaml:"sample_rate"`
 	StatsAddr           string        `yaml:"stats_address"`
 	Tags                []string      `yaml:"tags"`
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -44,10 +44,10 @@ func TestParserTimer(t *testing.T) {
 
 func TestParserSet(t *testing.T) {
 	ReadConfig("example.yaml")
-	m, _ := ParseMetric([]byte("a.b.c:1|s"))
+	m, _ := ParseMetric([]byte("a.b.c:foo|s"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, float64(1), m.Value, "Value")
+	assert.Equal(t, "foo", m.Value, "Value")
 	assert.Equal(t, "set", m.Type, "Type")
 }
 
@@ -84,6 +84,10 @@ func TestParserWithSampleRate(t *testing.T) {
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")
 	assert.Contains(t, valueError.Error(), "Invalid integer", "Invalid integer error missing")
+
+	_, valueError = ParseMetric([]byte("a.b.c:1|g|@0.1"))
+	assert.NotNil(t, valueError, "No errors when parsing")
+	assert.Contains(t, valueError.Error(), "sample rate", "Sample rate error missing")
 }
 
 func TestParserWithSampleRateAndTags(t *testing.T) {

--- a/samplers.go
+++ b/samplers.go
@@ -1,7 +1,6 @@
 package veneur
 
 import (
-	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -18,13 +17,6 @@ type DDMetric struct {
 	MetricType string        `json:"type"`
 	Hostname   string        `json:"host"`
 	Interval   int32         `json:"interval,omitempty"`
-}
-
-// Sampler is a thing that takes samples and does something with them
-// to be flushed later.
-type Sampler interface {
-	Sample(float64, float32)
-	Flush() []DDMetric
 }
 
 // Counter is an accumulator
@@ -100,11 +92,8 @@ type Set struct {
 
 // Sample checks if the supplied value has is already in the filter. If not, it increments
 // the counter!
-func (s *Set) Sample(sample float64, sampleRate float32) {
-	byteSample := make([]byte, 4)
-	binary.LittleEndian.PutUint32(byteSample, uint32(sample))
-	if !s.filter.Test(byteSample) {
-		s.filter.Add(byteSample)
+func (s *Set) Sample(sample string, sampleRate float32) {
+	if !s.filter.TestAndAddString(sample) {
 		s.value++
 	}
 }

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -83,14 +83,14 @@ func TestSet(t *testing.T) {
 	assert.Len(t, s.tags, 1, "Tag count")
 	assert.Equal(t, "a:b", s.tags[0], "First tag")
 
-	s.Sample(5, 1.0)
+	s.Sample("5", 1.0)
 
-	s.Sample(5, 1.0)
+	s.Sample("5", 1.0)
 
-	s.Sample(123, 1.0)
+	s.Sample("123", 1.0)
 
-	s.Sample(2147483647, 1.0)
-	s.Sample(-2147483648, 1.0)
+	s.Sample("2147483647", 1.0)
+	s.Sample("-2147483648", 1.0)
 
 	metrics := s.Flush()
 	assert.Len(t, metrics, 1, "Flush")

--- a/worker.go
+++ b/worker.go
@@ -70,35 +70,35 @@ func (w *Worker) ProcessMetric(m *Metric) {
 			log.WithField("name", m.Name).Debug("New counter")
 			w.counters[m.Digest] = NewCounter(m.Name, m.Tags)
 		}
-		w.counters[m.Digest].Sample(m.Value, m.SampleRate)
+		w.counters[m.Digest].Sample(m.Value.(float64), m.SampleRate)
 	case "gauge":
 		_, present := w.gauges[m.Digest]
 		if !present {
 			log.WithField("name", m.Name).Debug("New gauge")
 			w.gauges[m.Digest] = NewGauge(m.Name, m.Tags)
 		}
-		w.gauges[m.Digest].Sample(m.Value, m.SampleRate)
+		w.gauges[m.Digest].Sample(m.Value.(float64), m.SampleRate)
 	case "histogram":
 		_, present := w.histograms[m.Digest]
 		if !present {
 			log.WithField("name", m.Name).Debug("New histogram")
 			w.histograms[m.Digest] = NewHist(m.Name, m.Tags, Config.Percentiles)
 		}
-		w.histograms[m.Digest].Sample(m.Value, m.SampleRate)
+		w.histograms[m.Digest].Sample(m.Value.(float64), m.SampleRate)
 	case "set":
 		_, present := w.sets[m.Digest]
 		if !present {
 			log.WithField("name", m.Name).Debug("New set")
 			w.sets[m.Digest] = NewSet(m.Name, m.Tags, Config.SetSize, Config.SetAccuracy)
 		}
-		w.sets[m.Digest].Sample(m.Value, m.SampleRate)
+		w.sets[m.Digest].Sample(m.Value.(string), m.SampleRate)
 	case "timer":
 		_, present := w.timers[m.Digest]
 		if !present {
 			log.WithField("name", m.Name).Debug("New timer")
 			w.timers[m.Digest] = NewHist(m.Name, m.Tags, Config.Percentiles)
 		}
-		w.timers[m.Digest].Sample(m.Value, m.SampleRate)
+		w.timers[m.Digest].Sample(m.Value.(float64), m.SampleRate)
 	default:
 		log.WithField("type", m.Type).Error("Unknown metric type")
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -10,7 +10,7 @@ func TestWorker(t *testing.T) {
 	ReadConfig("example.yaml")
 	w := NewWorker(1)
 
-	m := Metric{Name: "a.b.c", Value: 1, Digest: 12345, Type: "counter", SampleRate: 1.0}
+	m := Metric{Name: "a.b.c", Value: 1.0, Digest: 12345, Type: "counter", SampleRate: 1.0}
 	w.ProcessMetric(&m)
 
 	ddmetrics := w.Flush()


### PR DESCRIPTION
Okay, I'm not proud of this implementation, but it's quick and straightforward, which I think fits in well with the state of the rest of the code. Essentially we treat metric values as `interface{}` and type-assert out the real values before sampling.

I thought of two other ways to implement this, feel free to comment if you think they're preferable. I can quickly prototype out the code and we can argue about what looks/does not look good.

- tagged union: add a `MetricValue` struct consisting of a string, a float64 and a bool to differentiate them. Make the `Metric.Value` into a `MetricValue`, and then check the union's flag everywhere to decide which type is inside.
- full-on java-esque solution with stronger type safety: create a general `Metric` interface that supports name, digest, tags and type methods. Then implement the interface for three different structs: sampled metric (float64 value, has sample rate), unsampled metric (float64 value, no sample rate) and string metric (string value, no sample rate). The worker can type switch to find out which type of metric it is.

Anyway I oscillated between all the implementations before deciding that the change was too small to justify any more dragging of feet. Let me know if you disagree with the implementation strategy.

cc @antifuchs 