### PR TITLE
Remove several references to Config

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -85,7 +85,7 @@ func main() {
 					"worker": i,
 					"tick":   t,
 				}).Debug("Flushing")
-				metrics = append(metrics, w.Flush())
+				metrics = append(metrics, w.Flush(veneur.Config.Interval))
 			}
 			fstart := time.Now()
 			veneur.Flush(metrics)

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -171,6 +171,9 @@ func handlePacket(workers []*veneur.Worker, packet []byte) {
 		veneur.Stats.Count("packet.error_total", 1, nil, 1.0)
 		return
 	}
+	if len(veneur.Config.Tags) > 0 {
+		m.Tags = append(m.Tags, veneur.Config.Tags...)
+	}
 
 	// We're ready to have a worker process this packet, so add it
 	// to the work queue.

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -47,7 +47,7 @@ func main() {
 	log.WithField("number", veneur.Config.NumWorkers).Info("Starting workers")
 	workers := make([]*veneur.Worker, veneur.Config.NumWorkers)
 	for i := 0; i < veneur.Config.NumWorkers; i++ {
-		worker := veneur.NewWorker(i + 1)
+		worker := veneur.NewWorker(i+1, veneur.Config.Percentiles, veneur.Config.SetSize, veneur.Config.SetAccuracy)
 		worker.Start()
 		workers[i] = worker
 	}

--- a/flusher.go
+++ b/flusher.go
@@ -21,6 +21,9 @@ func Flush(postMetrics [][]DDMetric) {
 	for _, metrics := range postMetrics {
 		finalMetrics = append(finalMetrics, metrics...)
 	}
+	for i := range finalMetrics {
+		finalMetrics[i].Hostname = Config.Hostname
+	}
 	// Check to see if we have anything to do
 	if totalCount > 0 {
 		// TODO Watch this error

--- a/parser.go
+++ b/parser.go
@@ -104,9 +104,6 @@ func ParseMetric(packet []byte) (*Metric, error) {
 			ret.Tags = tags
 		}
 	}
-	if len(Config.Tags) > 0 {
-		ret.Tags = append(ret.Tags, Config.Tags...)
-	}
 
 	ret.Digest = h.Sum32()
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -58,7 +58,7 @@ func TestParserWithTags(t *testing.T) {
 	assert.Equal(t, "a.b.c", m.Name, "Name")
 	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
-	assert.Equal(t, 3, len(m.Tags), "# of Tags")
+	assert.Equal(t, 2, len(m.Tags), "# of Tags")
 
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")
@@ -69,7 +69,7 @@ func TestParserWithConfigTags(t *testing.T) {
 	ReadConfig("example.yaml")
 	m, _ := ParseMetric([]byte("a.b.c:1|c|#foo:bar,baz:gorch"))
 	assert.NotNil(t, m, "Got nil metric!")
-	assert.Len(t, m.Tags, 3, "Tags")
+	assert.Len(t, m.Tags, 2, "Tags")
 }
 
 func TestParserWithSampleRate(t *testing.T) {
@@ -98,7 +98,7 @@ func TestParserWithSampleRateAndTags(t *testing.T) {
 	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
 	assert.Equal(t, float32(0.1), m.SampleRate, "Sample Rate")
-	assert.Len(t, m.Tags, 3, "Tags")
+	assert.Len(t, m.Tags, 2, "Tags")
 
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")

--- a/samplers.go
+++ b/samplers.go
@@ -41,7 +41,6 @@ func (c *Counter) Flush() []DDMetric {
 		Value:      [1][2]float64{{float64(time.Now().Unix()), rate}},
 		Tags:       c.tags,
 		MetricType: "rate",
-		Hostname:   Config.Hostname,
 		Interval:   int32(Config.Interval.Seconds()),
 	}}
 }
@@ -73,7 +72,6 @@ func (g *Gauge) Flush() []DDMetric {
 		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(v)}},
 		Tags:       g.tags,
 		MetricType: "gauge",
-		Hostname:   Config.Hostname,
 	}}
 }
 
@@ -119,7 +117,6 @@ func (s *Set) Flush() []DDMetric {
 		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(v)}},
 		Tags:       s.tags,
 		MetricType: "gauge",
-		Hostname:   Config.Hostname,
 	}}
 }
 
@@ -176,7 +173,6 @@ func (h *Histo) Flush() []DDMetric {
 			Value:      [1][2]float64{{now, rate}},
 			Tags:       h.tags,
 			MetricType: "rate",
-			Hostname:   Config.Hostname,
 			Interval:   int32(Config.Interval.Seconds()),
 		},
 		{
@@ -184,14 +180,12 @@ func (h *Histo) Flush() []DDMetric {
 			Value:      [1][2]float64{{now, h.max}},
 			Tags:       h.tags,
 			MetricType: "gauge",
-			Hostname:   Config.Hostname,
 		},
 		{
 			Name:       fmt.Sprintf("%s.min", h.name),
 			Value:      [1][2]float64{{now, h.min}},
 			Tags:       h.tags,
 			MetricType: "gauge",
-			Hostname:   Config.Hostname,
 		},
 	}
 
@@ -204,7 +198,6 @@ func (h *Histo) Flush() []DDMetric {
 				Value:      [1][2]float64{{now, h.value.Quantile(p)}},
 				Tags:       h.tags,
 				MetricType: "gauge",
-				Hostname:   Config.Hostname,
 			},
 		)
 	}

--- a/samplers.go
+++ b/samplers.go
@@ -33,15 +33,15 @@ func (c *Counter) Sample(sample float64, sampleRate float32) {
 
 // Flush takes the current state of the counter, generates a
 // DDMetric then clears it.
-func (c *Counter) Flush() []DDMetric {
-	rate := float64(c.value) / Config.Interval.Seconds()
+func (c *Counter) Flush(interval time.Duration) []DDMetric {
+	rate := float64(c.value) / interval.Seconds()
 	c.value = 0
 	return []DDMetric{{
 		Name:       c.name,
 		Value:      [1][2]float64{{float64(time.Now().Unix()), rate}},
 		Tags:       c.tags,
 		MetricType: "rate",
-		Interval:   int32(Config.Interval.Seconds()),
+		Interval:   int32(interval.Seconds()),
 	}}
 }
 
@@ -164,16 +164,16 @@ func NewHist(name string, tags []string, percentiles []float64) *Histo {
 
 // Flush generates DDMetrics for the current state of the
 // Histo.
-func (h *Histo) Flush() []DDMetric {
+func (h *Histo) Flush(interval time.Duration) []DDMetric {
 	now := float64(time.Now().Unix())
-	rate := float64(h.count) / Config.Interval.Seconds()
+	rate := float64(h.count) / interval.Seconds()
 	metrics := []DDMetric{
 		{
 			Name:       fmt.Sprintf("%s.count", h.name),
 			Value:      [1][2]float64{{now, rate}},
 			Tags:       h.tags,
 			MetricType: "rate",
-			Interval:   int32(Config.Interval.Seconds()),
+			Interval:   int32(interval.Seconds()),
 		},
 		{
 			Name:       fmt.Sprintf("%s.max", h.name),

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -2,6 +2,7 @@ package veneur
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +16,7 @@ func TestCounterEmpty(t *testing.T) {
 	assert.Len(t, c.tags, 1, "Tag length")
 	assert.Equal(t, c.tags[0], "a:b", "Tag contents")
 
-	metrics := c.Flush()
+	metrics := c.Flush(10 * time.Second)
 	assert.Len(t, metrics, 1, "Flushes 1 metric")
 
 	m1 := metrics[0]
@@ -34,7 +35,7 @@ func TestCounterRate(t *testing.T) {
 	c.Sample(5, 1.0)
 
 	// The counter returns an array with a single tuple of timestamp,value
-	metrics := c.Flush()
+	metrics := c.Flush(10 * time.Second)
 	assert.Equal(t, 0.5, metrics[0].Value[0][1], "Metric value")
 }
 
@@ -45,7 +46,7 @@ func TestCounterSampleRate(t *testing.T) {
 	c.Sample(5, 0.5)
 
 	// The counter returns an array with a single tuple of timestamp,value
-	metrics := c.Flush()
+	metrics := c.Flush(10 * time.Second)
 	assert.Equal(t, float64(1), metrics[0].Value[0][1], "Metric value")
 }
 
@@ -118,7 +119,7 @@ func TestHisto(t *testing.T) {
 	h.Sample(20, 1.0)
 	h.Sample(25, 1.0)
 
-	metrics := h.Flush()
+	metrics := h.Flush(10 * time.Second)
 	// We get lots of metrics back for histograms!
 	assert.Len(t, metrics, 4, "Flushed metrics length")
 
@@ -178,7 +179,7 @@ func TestHistoSampleRate(t *testing.T) {
 	h.Sample(20, 0.5)
 	h.Sample(25, 0.5)
 
-	metrics := h.Flush()
+	metrics := h.Flush(10 * time.Second)
 	assert.Len(t, metrics, 4, "Metrics flush length")
 
 	// First the count

--- a/worker.go
+++ b/worker.go
@@ -108,7 +108,7 @@ func (w *Worker) ProcessMetric(m *Metric) {
 }
 
 // Flush generates DDMetrics to emit.
-func (w *Worker) Flush() []DDMetric {
+func (w *Worker) Flush(interval time.Duration) []DDMetric {
 	// We preallocate a reasonably sized slice such that hopefully we won't need to reallocate.
 	postMetrics := make([]DDMetric, 0,
 		// Number of each metric, with 3 + percentiles for histograms (count, max, min)
@@ -144,7 +144,7 @@ func (w *Worker) Flush() []DDMetric {
 
 	Stats.Count("flush.metrics_total", int64(len(counters)), []string{"metric_type:counter"}, 1.0)
 	for _, v := range counters {
-		postMetrics = append(postMetrics, v.Flush()...)
+		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}
 	Stats.Count("flush.metrics_total", int64(len(gauges)), []string{"metric_type:gauge"}, 1.0)
 	for _, v := range gauges {
@@ -152,7 +152,7 @@ func (w *Worker) Flush() []DDMetric {
 	}
 	Stats.Count("flush.metrics_total", int64(len(histograms)), []string{"metric_type:histogram"}, 1.0)
 	for _, v := range histograms {
-		postMetrics = append(postMetrics, v.Flush()...)
+		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}
 	Stats.Count("flush.metrics_total", int64(len(sets)), []string{"metric_type:set"}, 1.0)
 	for _, v := range sets {
@@ -160,7 +160,7 @@ func (w *Worker) Flush() []DDMetric {
 	}
 	Stats.Count("flush.metrics_total", int64(len(timers)), []string{"metric_type:timer"}, 1.0)
 	for _, v := range timers {
-		postMetrics = append(postMetrics, v.Flush()...)
+		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}
 
 	return postMetrics

--- a/worker_test.go
+++ b/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestWorker(t *testing.T) {
 	ReadConfig("example.yaml")
-	w := NewWorker(1)
+	w := NewWorker(1, Config.Percentiles, Config.SetSize, Config.SetAccuracy)
 
 	m := Metric{Name: "a.b.c", Value: 1.0, Digest: 12345, Type: "counter", SampleRate: 1.0}
 	w.ProcessMetric(&m)

--- a/worker_test.go
+++ b/worker_test.go
@@ -13,9 +13,9 @@ func TestWorker(t *testing.T) {
 	m := Metric{Name: "a.b.c", Value: 1.0, Digest: 12345, Type: "counter", SampleRate: 1.0}
 	w.ProcessMetric(&m)
 
-	ddmetrics := w.Flush()
+	ddmetrics := w.Flush(Config.Interval)
 	assert.Len(t, ddmetrics, 1, "Number of flushed metrics")
 
-	nometrics := w.Flush()
+	nometrics := w.Flush(Config.Interval)
 	assert.Len(t, nometrics, 0, "Should flush no metrics")
 }


### PR DESCRIPTION
I'm planning on eliminating all global variables from the `veneur` package, so the first step is to disentangle scattered uses of the global configuration struct. I'm debating whether to completely deglobalize `flusher.go` as well, at the moment I'm leaning towards leaving it as is and refactoring it into a method of another structure later.

style critique welcome, cc @antifuchs 