### PR TITLE
Adjust error message for broken packets.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -72,7 +72,7 @@ func ParseMetric(packet []byte) (*Metric, error) {
 	} else {
 		v, err := strconv.ParseFloat(string(data[0]), 64)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid integer for metric value: %s", parts[1])
+			return nil, fmt.Errorf("Invalid number for metric value: %s", parts[1])
 		}
 		ret.Value = v
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -62,7 +62,7 @@ func TestParserWithTags(t *testing.T) {
 
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")
-	assert.Contains(t, valueError.Error(), "Invalid integer", "Invalid integer error missing")
+	assert.Contains(t, valueError.Error(), "Invalid number", "Invalid number error missing")
 }
 
 func TestParserWithConfigTags(t *testing.T) {
@@ -83,7 +83,7 @@ func TestParserWithSampleRate(t *testing.T) {
 
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")
-	assert.Contains(t, valueError.Error(), "Invalid integer", "Invalid integer error missing")
+	assert.Contains(t, valueError.Error(), "Invalid number", "Invalid number error missing")
 
 	_, valueError = ParseMetric([]byte("a.b.c:1|g|@0.1"))
 	assert.NotNil(t, valueError, "No errors when parsing")
@@ -102,7 +102,7 @@ func TestParserWithSampleRateAndTags(t *testing.T) {
 
 	_, valueError := ParseMetric([]byte("a.b.c:fart|c"))
 	assert.NotNil(t, valueError, "No errors when parsing")
-	assert.Contains(t, valueError.Error(), "Invalid integer", "Invalid integer error missing")
+	assert.Contains(t, valueError.Error(), "Invalid number", "Invalid number error missing")
 }
 
 func TestInvalidPackets(t *testing.T) {


### PR DESCRIPTION
### What's this PR do?
Fixes the error message to be more accurate.

### Motivation
We used to only accept integers and this got left in. :)

### Notes
Found via sentry error.

### How To Deploy
* Merge
* Deploy with `henson --prod veneur-srv`

### How to Measure Success
Monitor the Veneur dashboard.

### How to Rollback
Revert, merge, repeat `How To Deploy`

