### PR TITLE
Make histogram counters optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `interval` - How often to flush. Something like 10s seems good.
 * `key` - Your Datadog API key
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s
+* `publish_histogram_counters` - Veneur can publish a counter, `$name.count`, for how many samples a histogram has received. Note that this counter, like every other metric passing through veneur, will be attached to Veneur's own host.
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
 * `num_workers` - The number of worker goroutines to start.
 * `read_buffer_size_bytes` - The size of the receive buffer for the UDP socket. Defaults to 2MB, as having a lot of buffer prevents packet drops during flush!

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -47,7 +47,7 @@ func main() {
 	log.WithField("number", veneur.Config.NumWorkers).Info("Starting workers")
 	workers := make([]*veneur.Worker, veneur.Config.NumWorkers)
 	for i := 0; i < veneur.Config.NumWorkers; i++ {
-		worker := veneur.NewWorker(i+1, veneur.Config.Percentiles, veneur.Config.SetSize, veneur.Config.SetAccuracy)
+		worker := veneur.NewWorker(i+1, veneur.Config.Percentiles, veneur.Config.HistCounters, veneur.Config.SetSize, veneur.Config.SetAccuracy)
 		worker.Start()
 		workers[i] = worker
 	}

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type VeneurConfig struct {
 	StatsAddr           string        `yaml:"stats_address"`
 	Tags                []string      `yaml:"tags"`
 	SentryDSN           string        `yaml:"sentry_dsn"`
+	HistCounters        bool          `yaml:"publish_histogram_counters"`
 }
 
 // Config is the global config that we'll use once it's inited.

--- a/flusher.go
+++ b/flusher.go
@@ -70,10 +70,11 @@ func Flush(postMetrics [][]DDMetric) {
 		log.WithError(err).Error("Error reading response body")
 	}
 	resultFields := log.Fields{
-		"status":   resp.Status,
-		"headers":  resp.Header,
-		"request":  string(postJSON),
-		"response": string(body),
+		"status":           resp.Status,
+		"request_headers":  req.Header,
+		"response_headers": resp.Header,
+		"request":          string(postJSON),
+		"response":         string(body),
 	}
 
 	if resp.StatusCode != http.StatusAccepted {

--- a/worker_test.go
+++ b/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestWorker(t *testing.T) {
 	ReadConfig("example.yaml")
-	w := NewWorker(1, Config.Percentiles, Config.SetSize, Config.SetAccuracy)
+	w := NewWorker(1, Config.Percentiles, Config.HistCounters, Config.SetSize, Config.SetAccuracy)
 
 	m := Metric{Name: "a.b.c", Value: 1.0, Digest: 12345, Type: "counter", SampleRate: 1.0}
 	w.ProcessMetric(&m)


### PR DESCRIPTION
Tested this in QA; with the option on, counters disappeared, but all the other parts remained.