### PR TITLE
Add timer just for POST operation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 * `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client.
 * `veneur.flush.error_total` - Number of errors when attempting to POST metrics to Datadog.
 * `veneur.flush.metrics_total` - Total number of metrics flushed at each flush time, tagged by `metric_type`.
-* `veneur.flush.transaction_duration_ns` - Time taken to POST metrics to Datadog.
+* `veneur.flush.http_duration_ns` - Time taken for the POST operation to the Datadog API.
+* `veneur.flush.transaction_duration_ns` - Time taken to prepare metrics and POST metrics to the Datadog API (includes `veneur.flush.http_duration_ns`).
 * `veneur.flush.worker_duration_ns` - Per-worker timing — tagged by `worker` - for flush. This is important as it is the time in which the worker holds a lock and is unavailable for other work.
 * `veneur.worker.metrics_processed_total` - Total number of metrics processed between flushes by workers, tagged by `worker`. This helps you find hot spots where a single worker is handling a lot of metrics.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Specifically the streaming approximate histograms
 Datadog's DogStatsD — and StatsD — uses an exact histogram which retains all samples and is reset every flush period. This means that there is a loss of precision when using Veneur, but
 the resulting percentile values are meant to be more representative of a global view.
 
+Veneur's timers and histograms do not emit an `avg` metric. Averages suck.
+
 ## Approximate Sets
 
 Veneur uses [Bloom filters](https://github.com/willf/bloom) for approximate unique sets. Configured via `set_size` and `set_accuracy`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 * `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client.
 * `veneur.flush.error_total` - Number of errors when attempting to POST metrics to Datadog.
 * `veneur.flush.metrics_total` - Total number of metrics flushed at each flush time, tagged by `metric_type`.
-* `veneur.flush.http_duration_ns` - Time taken for the POST operation to the Datadog API.
-* `veneur.flush.transaction_duration_ns` - Time taken to prepare metrics and POST metrics to the Datadog API (includes `veneur.flush.http_duration_ns`).
+* `veneur.flush.part_duration_ns` - Time taken for the POST transaction to the Datadog API. Tagged by `part` for each sub-part `prepare`, `json`, `compress` and `post`.
 * `veneur.flush.worker_duration_ns` - Per-worker timing — tagged by `worker` - for flush. This is important as it is the time in which the worker holds a lock and is unavailable for other work.
 * `veneur.worker.metrics_processed_total` - Total number of metrics processed between flushes by workers, tagged by `worker`. This helps you find hot spots where a single worker is handling a lot of metrics.
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -87,14 +87,7 @@ func main() {
 				}).Debug("Flushing")
 				metrics = append(metrics, w.Flush(veneur.Config.Interval))
 			}
-			fstart := time.Now()
 			veneur.Flush(metrics)
-			veneur.Stats.TimeInMilliseconds(
-				"flush.transaction_duration_ns",
-				float64(time.Now().Sub(fstart).Nanoseconds()),
-				nil,
-				1.0,
-			)
 		}
 	}()
 

--- a/flusher.go
+++ b/flusher.go
@@ -15,7 +15,6 @@ import (
 // Flush takes the slices of metrics, combines then and marshals them to json
 // for posting to Datadog.
 func Flush(postMetrics [][]DDMetric) {
-	pstart := time.Now()
 	totalCount := 0
 	for _, metrics := range postMetrics {
 		totalCount += len(metrics)
@@ -27,12 +26,6 @@ func Flush(postMetrics [][]DDMetric) {
 	for i := range finalMetrics {
 		finalMetrics[i].Hostname = Config.Hostname
 	}
-	Stats.TimeInMilliseconds(
-		"flush.part_duration_ns",
-		float64(time.Now().Sub(pstart).Nanoseconds()),
-		[]string{"part:prepare"},
-		1.0,
-	)
 
 	// Check to see if we have anything to do
 	if totalCount == 0 {

--- a/flusher.go
+++ b/flusher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -47,7 +48,14 @@ func Flush(postMetrics [][]DDMetric) {
 	// make sure to flush remaining compressed bytes to the buffer
 	compressor.Close()
 
+	fstart := time.Now()
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", Config.APIHostname, Config.Key), &reqBody)
+	Stats.TimeInMilliseconds(
+		"flush.http_duration_ns",
+		float64(time.Now().Sub(fstart).Nanoseconds()),
+		nil,
+		1.0,
+	)
 	if err != nil {
 		Stats.Count("flush.error_total", int64(totalCount), []string{"cause:construct"}, 1.0)
 		log.WithError(err).Error("Error constructing POST request")

--- a/flusher.go
+++ b/flusher.go
@@ -15,6 +15,7 @@ import (
 // Flush takes the slices of metrics, combines then and marshals them to json
 // for posting to Datadog.
 func Flush(postMetrics [][]DDMetric) {
+	pstart := time.Now()
 	totalCount := 0
 	for _, metrics := range postMetrics {
 		totalCount += len(metrics)
@@ -26,34 +27,55 @@ func Flush(postMetrics [][]DDMetric) {
 	for i := range finalMetrics {
 		finalMetrics[i].Hostname = Config.Hostname
 	}
+	Stats.TimeInMilliseconds(
+		"flush.part_duration_ns",
+		float64(time.Now().Sub(pstart).Nanoseconds()),
+		[]string{"part:prepare"},
+		1.0,
+	)
+
 	// Check to see if we have anything to do
 	if totalCount == 0 {
 		log.Info("Nothing to flush, skipping.")
 		return
 	}
 
+	jstart := time.Now()
 	postJSON, err := json.Marshal(map[string][]DDMetric{
 		"series": finalMetrics,
 	})
+	Stats.TimeInMilliseconds(
+		"flush.part_duration_ns",
+		float64(time.Now().Sub(jstart).Nanoseconds()),
+		[]string{"part:json"},
+		1.0,
+	)
 	if err != nil {
 		Stats.Count("flush.error_total", int64(totalCount), []string{"cause:json"}, 1.0)
 		log.WithError(err).Error("Error rendering JSON request body")
 		return
 	}
 
+	cstart := time.Now()
 	var reqBody bytes.Buffer
 	compressor := zlib.NewWriter(&reqBody)
 	// bytes.Buffer never errors
 	compressor.Write(postJSON)
 	// make sure to flush remaining compressed bytes to the buffer
 	compressor.Close()
+	Stats.TimeInMilliseconds(
+		"flush.part_duration_ns",
+		float64(time.Now().Sub(cstart).Nanoseconds()),
+		[]string{"part:compress"},
+		1.0,
+	)
 
 	fstart := time.Now()
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", Config.APIHostname, Config.Key), &reqBody)
 	Stats.TimeInMilliseconds(
-		"flush.http_duration_ns",
+		"flush.part_duration_ns",
 		float64(time.Now().Sub(fstart).Nanoseconds()),
-		nil,
+		[]string{"part:post"},
 		1.0,
 	)
 	if err != nil {

--- a/flusher.go
+++ b/flusher.go
@@ -72,12 +72,6 @@ func Flush(postMetrics [][]DDMetric) {
 
 	fstart := time.Now()
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", Config.APIHostname, Config.Key), &reqBody)
-	Stats.TimeInMilliseconds(
-		"flush.part_duration_ns",
-		float64(time.Now().Sub(fstart).Nanoseconds()),
-		[]string{"part:post"},
-		1.0,
-	)
 	if err != nil {
 		Stats.Count("flush.error_total", int64(totalCount), []string{"cause:construct"}, 1.0)
 		log.WithError(err).Error("Error constructing POST request")
@@ -92,6 +86,13 @@ func Flush(postMetrics [][]DDMetric) {
 		log.WithError(err).Error("Error writing POST request")
 		return
 	}
+	Stats.TimeInMilliseconds(
+		"flush.part_duration_ns",
+		float64(time.Now().Sub(fstart).Nanoseconds()),
+		[]string{"part:post"},
+		1.0,
+	)
+
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
### What's this PR do?
Adds a timer with tagged "parts" that covers the full flush transaction, timing prepartion, JSON marshaling, compression and the HTTP component. Removes `http_duration_ns` metric.

### Motivation
As it stands we're including all the overhead of metric preparation, serialization and compression with the POST. Maybe some of our "lag" is there?

### How to Measure Success
Look for new metric `veneur.flush.part_duration_ns` in Datadog.

### How to Rollback
Revert, merge, repeat `How To Deploy`