### PR TITLE
Parallelize flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 
 * `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client.
 * `veneur.flush.post_metrics_total` - The total number of time-series points that will be submitted to Datadog via POST. Datadog's rate limiting is roughly proportional to this number.
-* `veneur.flush.content_length_bytes` - The number of bytes in a single POST body. Remember that Veneur POSTs large sets of metrics in multiple separate bodies in parallel.
+* `veneur.flush.content_length_bytes.*` - The number of bytes in a single POST body. Remember that Veneur POSTs large sets of metrics in multiple separate bodies in parallel. Uses a histogram, so there are multiple metrics generated depending on your local DogStatsD config.
 * `veneur.flush.part_duration_ns` - Time taken for the POST transaction to the Datadog API. Tagged by `part` for each sub-part `marshal` (assembling the request body) and `post` (blocking on an HTTP response from Datadog).
 * `veneur.flush.total_duration_ns` - Total time spent POSTing to Datadog, across all parallel requests. Under most circumstances, this should be roughly equal to the total `veneur.flush.part_duration_ns`. If it's not, then some of the POSTs are happening in sequence, which suggests some kind of goroutine scheduling issue.
 * `veneur.flush.error_total` - Number of metrics dropped from errors attempting to POST to Datadog. If you're getting errors POSTing, this metric tells you how much damage those errors are causing to your metrics pipeline.

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -17,7 +17,7 @@ var (
 
 type packet struct {
 	buf []byte
-	ip  string
+	ip  net.IP
 }
 
 func main() {
@@ -95,7 +95,7 @@ func main() {
 		New: func() interface{} {
 			return packet{
 				buf: make([]byte, veneur.Config.MetricMaxLength),
-				ip:  "",
+				ip:  nil,
 			}
 		},
 	}
@@ -126,7 +126,7 @@ func main() {
 				workers[uniqueSenderIPDigest%uint32(veneur.Config.NumWorkers)].WorkChan <- veneur.Metric{
 					Name:       "veneur.unique_sender_ips",
 					Digest:     uniqueSenderIPDigest,
-					Value:      packetbuf.ip,
+					Value:      packetbuf.ip.String(),
 					SampleRate: 1.0,
 					Type:       "set",
 				}
@@ -149,7 +149,7 @@ func main() {
 			continue
 		}
 		packetbuf.buf = packetbuf.buf[:n]
-		packetbuf.ip = addr.IP.String()
+		packetbuf.ip = addr.IP
 		parserChan <- packetbuf
 	}
 }

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -87,7 +87,7 @@ func main() {
 				}).Debug("Flushing")
 				metrics = append(metrics, w.Flush(veneur.Config.Interval))
 			}
-			veneur.Flush(metrics)
+			veneur.Flush(metrics, veneur.Config.FlushLimit)
 		}
 	}()
 

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type VeneurConfig struct {
 	Tags                []string      `yaml:"tags"`
 	SentryDSN           string        `yaml:"sentry_dsn"`
 	HistCounters        bool          `yaml:"publish_histogram_counters"`
+	FlushLimit          int           `yaml:"flush_max_per_body"`
 }
 
 // Config is the global config that we'll use once it's inited.

--- a/flusher.go
+++ b/flusher.go
@@ -40,8 +40,8 @@ func Flush(postMetrics [][]DDMetric, metricLimit int) {
 	// we compute the chunks using rounding-up integer division
 	workers := ((totalCount - 1) / metricLimit) + 1
 	chunkSize := ((totalCount - 1) / workers) + 1
-	log.WithField("workers", workers).Info("Worker count chosen")
-	log.WithField("chunkSize", chunkSize).Info("Chunk size chosen")
+	log.WithField("workers", workers).Debug("Worker count chosen")
+	log.WithField("chunkSize", chunkSize).Debug("Chunk size chosen")
 	var wg sync.WaitGroup
 	flushStart := time.Now()
 	for i := 0; i < workers; i++ {

--- a/flusher.go
+++ b/flusher.go
@@ -40,6 +40,8 @@ func Flush(postMetrics [][]DDMetric, metricLimit int) {
 	// we compute the chunks using rounding-up integer division
 	workers := ((totalCount - 1) / metricLimit) + 1
 	chunkSize := ((totalCount - 1) / workers) + 1
+	log.WithField("workers", workers).Info("Worker count chosen")
+	log.WithField("chunkSize", chunkSize).Info("Chunk size chosen")
 	var wg sync.WaitGroup
 	flushStart := time.Now()
 	for i := 0; i < workers; i++ {

--- a/flusher.go
+++ b/flusher.go
@@ -85,7 +85,7 @@ func flushPart(metricSlice []DDMetric, wg *sync.WaitGroup) {
 	)
 	// Len reports the unread length, so we have to record this before it's POSTed
 	bodyLength := reqBody.Len()
-	Stats.Gauge("flush.content_length_bytes", float64(bodyLength), nil, 1.0)
+	Stats.Histogram("flush.content_length_bytes", float64(bodyLength), nil, 1.0)
 
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", Config.APIHostname, Config.Key), &reqBody)
 	if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -152,23 +152,23 @@ func (w *Worker) Flush(interval time.Duration) []DDMetric {
 		1.0,
 	)
 
-	Stats.Count("flush.metrics_total", int64(len(counters)), []string{"metric_type:counter"}, 1.0)
+	Stats.Count("worker.metrics_flushed_total", int64(len(counters)), []string{"metric_type:counter"}, 1.0)
 	for _, v := range counters {
 		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}
-	Stats.Count("flush.metrics_total", int64(len(gauges)), []string{"metric_type:gauge"}, 1.0)
+	Stats.Count("worker.metrics_flushed_total", int64(len(gauges)), []string{"metric_type:gauge"}, 1.0)
 	for _, v := range gauges {
 		postMetrics = append(postMetrics, v.Flush()...)
 	}
-	Stats.Count("flush.metrics_total", int64(len(histograms)), []string{"metric_type:histogram"}, 1.0)
+	Stats.Count("worker.metrics_flushed_total", int64(len(histograms)), []string{"metric_type:histogram"}, 1.0)
 	for _, v := range histograms {
 		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}
-	Stats.Count("flush.metrics_total", int64(len(sets)), []string{"metric_type:set"}, 1.0)
+	Stats.Count("worker.metrics_flushed_total", int64(len(sets)), []string{"metric_type:set"}, 1.0)
 	for _, v := range sets {
 		postMetrics = append(postMetrics, v.Flush()...)
 	}
-	Stats.Count("flush.metrics_total", int64(len(timers)), []string{"metric_type:timer"}, 1.0)
+	Stats.Count("worker.metrics_flushed_total", int64(len(timers)), []string{"metric_type:timer"}, 1.0)
 	for _, v := range timers {
 		postMetrics = append(postMetrics, v.Flush(interval)...)
 	}


### PR DESCRIPTION
Turns out datadog applies the uncompressed rate limit to a compressed payload, _after_ it gets decompressed. Effectively rate limits are O(number of metrics). We have to parallelize the POST process to get faster.

This commit adjusts some metric names, see the readme. We produce a lot of metrics at flush time and I wanted to get a clearer distinction between metrics from workers, metrics from the main flush routine, and metrics from parallel flush-lets.

Performance does not appear to be significantly impacted, but I don't think I can generate enough metrics in a load test to trigger multiple flushes at once.