### PR TITLE
Remove unique IP set metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 * `veneur.flush.worker_duration_ns` - Per-worker timing — tagged by `worker` - for flush. This is important as it is the time in which the worker holds a lock and is unavailable for other work.
 * `veneur.worker.metrics_processed_total` - Total number of metric packets processed between flushes by workers, tagged by `worker`. This helps you find hot spots where a single worker is handling a lot of metrics. The sum across all workers should be approximately proportional to the number of packets received.
 * `veneur.worker.metrics_flushed_total` - Total number of metrics flushed at each flush time, tagged by `metric_type`. A "metric", in this context, refers to a unique combination of name, tags and metric type. You can use this metric to detect when your clients are introducing new instrumentation, or when you acquire new clients.
-* `veneur.unique_sender_ips` - The number of unique IPs that have submitted metrics to Veneur. This is another way to detect a sudden increase in the number of clients.
 
 # Status
 


### PR DESCRIPTION
basically a revert of the old commit. Shame that it had nontrivial performance impact, but that was kind of inevitable for a metric that was getting generated on every single packet.