### PR TITLE
Add SO_REUSEPORT support on linux

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type VeneurConfig struct {
 	SetAccuracy         float64       `yaml:"set_accuracy"`
 	UDPAddr             string        `yaml:"udp_address"`
 	NumWorkers          int           `yaml:"num_workers"`
+	NumReaders          int           `yaml:"num_readers"`
 	StatsAddr           string        `yaml:"stats_address"`
 	Tags                []string      `yaml:"tags"`
 	SentryDSN           string        `yaml:"sentry_dsn"`

--- a/example.yaml
+++ b/example.yaml
@@ -1,11 +1,14 @@
 ---
 api_hostname: https://app.datadoghq.com
 metric_max_length: 4096
+flush_max_per_body: 25000
+publish_histogram_counters: true
 debug: true
 interval: "10s"
 key: "farts"
 listen: ":8126"
-num_workers: 4
+num_workers: 96
+num_readers: 4
 percentiles:
   - 0.5
   - 0.75

--- a/socket.go
+++ b/socket.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package veneur
+
+import (
+	"net"
+)
+
+func NewSocket(addr *net.UDPAddr, recvBuf int) (net.PacketConn, error) {
+	serverConn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if err := serverConn.SetReadBuffer(recvBuf); err != nil {
+		return nil, err
+	}
+	return serverConn, nil
+}

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -1,0 +1,48 @@
+package veneur
+
+import (
+	"net"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// see also https://github.com/jbenet/go-reuseport/blob/master/impl_unix.go#L279
+func NewSocket(addr *net.UDPAddr, recvBuf int) (net.PacketConn, error) {
+	sockFD, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|syscall.SOCK_CLOEXEC|syscall.SOCK_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// unix.SO_REUSEPORT is not defined on linux 386/amd64, see
+	// https://github.com/golang/go/issues/16075
+	if err := unix.SetsockoptInt(sockFD, unix.SOL_SOCKET, 0xf, 1); err != nil {
+		return nil, err
+	}
+	if err := unix.SetsockoptInt(sockFD, unix.SOL_SOCKET, unix.SO_RCVBUF, recvBuf); err != nil {
+		return nil, err
+	}
+
+	sockaddr := unix.SockaddrInet4{
+		Port: addr.Port,
+	}
+	if copied := copy(sockaddr.Addr[:], addr.IP); copied != net.IPv4len {
+		panic("did not copy enough bytes of ip address")
+	}
+	if err := unix.Bind(sockFD, &sockaddr); err != nil {
+		return nil, err
+	}
+
+	osFD := os.NewFile(uintptr(sockFD), "veneursock")
+	// this will close the FD we passed to NewFile
+	defer osFD.Close()
+
+	// however, FilePacketConn duplicates the FD, so closing the File's FD does
+	// not affect this object's FD
+	ret, err := net.FilePacketConn(osFD)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/socket_test.go
+++ b/socket_test.go
@@ -1,0 +1,29 @@
+package veneur
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSocket(t *testing.T) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:8200")
+	assert.NoError(t, err, "should have constructed udp address correctly")
+
+	sock, err := NewSocket(addr, 2*1024*1024)
+	assert.NoError(t, err, "should have constructed socket correctly")
+
+	client, err := net.DialUDP("udp", nil, addr)
+	assert.NoError(t, err, "should have connected to socket")
+
+	_, err = client.Write([]byte("hello world"))
+	assert.NoError(t, err, "should have written to socket")
+
+	b := make([]byte, 15)
+	n, laddr, err := sock.ReadFrom(b)
+	assert.NoError(t, err, "should have read from socket")
+	assert.Equal(t, n, 11, "should have read 11 bytes from socket")
+	assert.Equal(t, "hello world", string(b[:n]), "should have gotten message from socket")
+	assert.Equal(t, client.LocalAddr().String(), laddr.String(), "should have gotten message from client's address")
+}


### PR DESCRIPTION
I keep saying there's no big performance wins left and somehow I keep being wrong??

SO_REUSEPORT dodges the userspace mutex on Go socket objects and lets the kernel multiplex datagrams more evenly between goroutines. This makes it possible for us to parallelize reading. Having a few more goroutines on the socket has big impacts for packet drop rate.

On a c3.2xlarge (red line marks SO_REUSEPORT turned on):
<img width="1339" alt="screen shot 2016-06-16 at 15 05 36" src="https://cloud.githubusercontent.com/assets/4285049/16134709/93f144a6-33d3-11e6-8915-58d742e6278f.png">

On a c3.8xlarge:
<img width="1336" alt="screen shot 2016-06-16 at 15 06 32" src="https://cloud.githubusercontent.com/assets/4285049/16134733/b684edce-33d3-11e6-9be8-7c013a053a29.png">

On a c3.4xlarge:
<img width="1344" alt="screen shot 2016-06-16 at 15 07 18" src="https://cloud.githubusercontent.com/assets/4285049/16134740/d1ef914a-33d3-11e6-98dd-622fdb8c6471.png">

This is unfortunately platform-sensitive and right now `x/sys/unix` does not export all the constants we need. We only use Linux in prod ofc so it's not a practical issue for us, but the code could probably be better. It also only supports IPv4, mainly because working with raw sockaddr objects is a bit more annoying if we want to support both. Oh well.