### PR TITLE
Combine parser into reader

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -38,27 +38,13 @@ func main() {
 		},
 	}
 
-	// Creates N workers to handle incoming packets, parsing them,
-	// hashing them and dispatching them on to workers that do the storage.
-	parserChan := make(chan []byte)
-	for i := 0; i < conf.NumWorkers; i++ {
-		go func() {
-			defer func() {
-				server.ConsumePanic(recover())
-			}()
-			for packet := range parserChan {
-				server.HandlePacket(packet, packetPool)
-			}
-		}()
-	}
-
 	// Read forever!
 	for i := 0; i < conf.NumReaders; i++ {
 		go func() {
 			defer func() {
 				server.ConsumePanic(recover())
 			}()
-			server.ReadSocket(packetPool, parserChan)
+			server.ReadSocket(packetPool)
 		}()
 	}
 

--- a/server.go
+++ b/server.go
@@ -110,7 +110,7 @@ func (s *Server) HandlePacket(packet []byte, packetPool *sync.Pool) {
 	packetPool.Put(packet[:cap(packet)])
 }
 
-func (s *Server) ReadSocket(packetPool *sync.Pool, parserChan chan<- []byte) {
+func (s *Server) ReadSocket(packetPool *sync.Pool) {
 	// each goroutine gets its own socket
 	// if the sockets support SO_REUSEPORT, then this will cause the
 	// kernel to distribute datagrams across them, for better read
@@ -132,6 +132,6 @@ func (s *Server) ReadSocket(packetPool *sync.Pool, parserChan chan<- []byte) {
 			s.logger.WithError(err).Error("Error reading from UDP")
 			continue
 		}
-		parserChan <- buf[:n]
+		s.HandlePacket(buf[:n], packetPool)
 	}
 }


### PR DESCRIPTION
If you have enough parallel readers, the channel between readers and parsers will become a bottleneck. Now that we can parallelize readers, let's just collapse the two together.