### PR TITLE
Add basic HTTP server to veneur

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s
 * `publish_histogram_counters` - Veneur can publish a counter, `$name.count`, for how many samples a histogram has received. Note that this counter, like every other metric passing through veneur, will be attached to Veneur's own host.
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
+* `http_address` - The address to serve HTTP healthchecks and other endpoints. If you're under einhorn, you probably want `einhorn@0`.
 * `num_workers` - The number of worker goroutines to start.
 * `num_readers` - The number of reader goroutines to start. Veneur supports SO_REUSEPORT on Linux to scale to multiple readers. On other platforms, this should always be 1; other values will probably cause errors at startup. See below.
 * `read_buffer_size_bytes` - The size of the receive buffer for the UDP socket. Defaults to 2MB, as having a lot of buffer prevents packet drops during flush!

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -48,8 +48,15 @@ func main() {
 		}()
 	}
 
-	ticker := time.NewTicker(conf.Interval)
-	for range ticker.C {
-		server.Flush(conf.Interval, conf.FlushLimit)
-	}
+	go func() {
+		defer func() {
+			server.ConsumePanic(recover())
+		}()
+		ticker := time.NewTicker(conf.Interval)
+		for range ticker.C {
+			server.Flush(conf.Interval, conf.FlushLimit)
+		}
+	}()
+
+	server.HTTPServe()
 }

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Percentiles         []float64     `yaml:"percentiles"`
 	ReadBufferSizeBytes int           `yaml:"read_buffer_size_bytes"`
 	UDPAddr             string        `yaml:"udp_address"`
+	HTTPAddr            string        `yaml:"http_address"`
 	NumWorkers          int           `yaml:"num_workers"`
 	NumReaders          int           `yaml:"num_readers"`
 	StatsAddr           string        `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -6,7 +6,6 @@ publish_histogram_counters: true
 debug: true
 interval: "10s"
 key: "farts"
-listen: ":8126"
 num_workers: 96
 num_readers: 4
 percentiles:
@@ -19,5 +18,6 @@ tags:
  - "foo:bar"
 #  - "baz:gorch"
 udp_address: "localhost:8126"
+http_address: "einhorn@0"
 # Defaults to the os.Hostname()!
 # hostname: foobar

--- a/henson/restart
+++ b/henson/restart
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-svc -t /etc/service/veneur-srv
+svc -h /etc/service/veneur-srv

--- a/http.go
+++ b/http.go
@@ -1,0 +1,17 @@
+package veneur
+
+import (
+	"net/http"
+
+	"goji.io"
+	"goji.io/pat"
+	"golang.org/x/net/context"
+)
+
+func (s *Server) Handler() http.Handler {
+	mux := goji.NewMux()
+	mux.HandleFuncC(pat.Get("/healthcheck"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok\n"))
+	})
+	return mux
+}

--- a/vendor/github.com/zenazn/goji/LICENSE
+++ b/vendor/github.com/zenazn/goji/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014, 2015, 2016 Carl Jackson (carl@avtok.com)
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/zenazn/goji/bind/bind.go
+++ b/vendor/github.com/zenazn/goji/bind/bind.go
@@ -1,0 +1,145 @@
+/*
+Package bind provides a convenient way to bind to sockets. It exposes a flag in
+the default flag set named "bind" which provides syntax to bind TCP and UNIX
+sockets. It also supports binding to arbitrary file descriptors passed by a
+parent (for instance, systemd), and for binding to Einhorn sockets (including
+Einhorn ACK support).
+
+If the value passed to bind contains a colon, as in ":8000" or "127.0.0.1:9001",
+it will be treated as a TCP address. If it begins with a "/" or a ".", it will
+be treated as a path to a UNIX socket. If it begins with the string "fd@", as in
+"fd@3", it will be treated as a file descriptor (useful for use with systemd,
+for instance). If it begins with the string "einhorn@", as in "einhorn@0", the
+corresponding einhorn socket will be used.
+
+If an option is not explicitly passed, the implementation will automatically
+select between using "einhorn@0", "fd@3", and ":8000", depending on whether
+Einhorn or systemd (or neither) is detected.
+
+This package is a teensy bit magical, and goes out of its way to Do The Right
+Thing in many situations, including in both development and production. If
+you're looking for something less magical, you'd probably be better off just
+calling net.Listen() the old-fashioned way.
+*/
+package bind
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var bind string
+
+func init() {
+	einhornInit()
+	systemdInit()
+}
+
+// WithFlag adds a standard flag to the global flag instance that allows
+// configuration of the default socket. Users who call Default() must call this
+// function before flags are parsed, for example in an init() block.
+//
+// When selecting the default bind string, this function will examine its
+// environment for hints about what port to bind to, selecting the GOJI_BIND
+// environment variable, Einhorn, systemd, the PORT environment variable, and
+// the port 8000, in order. In most cases, this means that the default behavior
+// of the default socket will be reasonable for use in your circumstance.
+func WithFlag() {
+	defaultBind := ":8000"
+	if s := Sniff(); s != "" {
+		defaultBind = s
+	}
+	flag.StringVar(&bind, "bind", defaultBind,
+		`Address to bind on. If this value has a colon, as in ":8000" or
+		"127.0.0.1:9001", it will be treated as a TCP address. If it
+		begins with a "/" or a ".", it will be treated as a path to a
+		UNIX socket. If it begins with the string "fd@", as in "fd@3",
+		it will be treated as a file descriptor (useful for use with
+		systemd, for instance). If it begins with the string "einhorn@",
+		as in "einhorn@0", the corresponding einhorn socket will be
+		used. If an option is not explicitly passed, the implementation
+		will automatically select among "einhorn@0" (Einhorn), "fd@3"
+		(systemd), and ":8000" (fallback) based on its environment.`)
+}
+
+// Sniff attempts to select a sensible default bind string by examining its
+// environment. It examines the GOJI_BIND environment variable, Einhorn,
+// systemd, and the PORT environment variable, in that order, selecting the
+// first plausible option. It returns the empty string if no sensible default
+// could be extracted from the environment.
+func Sniff() string {
+	if bind := os.Getenv("GOJI_BIND"); bind != "" {
+		return bind
+	} else if usingEinhorn() {
+		return "einhorn@0"
+	} else if usingSystemd() {
+		return "fd@3"
+	} else if port := os.Getenv("PORT"); port != "" {
+		return ":" + port
+	}
+	return ""
+}
+
+func listenTo(bind string) (net.Listener, error) {
+	if strings.Contains(bind, ":") {
+		return net.Listen("tcp", bind)
+	} else if strings.HasPrefix(bind, ".") || strings.HasPrefix(bind, "/") {
+		return net.Listen("unix", bind)
+	} else if strings.HasPrefix(bind, "fd@") {
+		fd, err := strconv.Atoi(bind[3:])
+		if err != nil {
+			return nil, fmt.Errorf("error while parsing fd %v: %v",
+				bind, err)
+		}
+		f := os.NewFile(uintptr(fd), bind)
+		defer f.Close()
+		return net.FileListener(f)
+	} else if strings.HasPrefix(bind, "einhorn@") {
+		fd, err := strconv.Atoi(bind[8:])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error while parsing einhorn %v: %v", bind, err)
+		}
+		return einhornBind(fd)
+	}
+
+	return nil, fmt.Errorf("error while parsing bind arg %v", bind)
+}
+
+// Socket parses and binds to the specified address. If Socket encounters an
+// error while parsing or binding to the given socket it will exit by calling
+// log.Fatal.
+func Socket(bind string) net.Listener {
+	l, err := listenTo(bind)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return l
+}
+
+// Default parses and binds to the default socket as given to us by the flag
+// module. If there was an error parsing or binding to that socket, Default will
+// exit by calling `log.Fatal`.
+func Default() net.Listener {
+	return Socket(bind)
+}
+
+// I'm not sure why you'd ever want to call Ready() more than once, but we may
+// as well be safe against it...
+var ready sync.Once
+
+// Ready notifies the environment (for now, just Einhorn) that the process is
+// ready to receive traffic. Should be called at the last possible moment to
+// maximize the chances that a faulty process exits before signaling that it's
+// ready.
+func Ready() {
+	ready.Do(func() {
+		einhornAck()
+	})
+}

--- a/vendor/github.com/zenazn/goji/bind/einhorn.go
+++ b/vendor/github.com/zenazn/goji/bind/einhorn.go
@@ -1,0 +1,91 @@
+// +build !windows
+
+package bind
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+const tooBigErr = "bind: einhorn@%d not found (einhorn only passed %d fds)"
+const bindErr = "bind: could not bind einhorn@%d: not running under einhorn"
+const einhornErr = "bind: einhorn environment initialization error"
+const ackErr = "bind: error ACKing to einhorn: %v"
+
+var einhornNumFds int
+
+func envInt(val string) (int, error) {
+	return strconv.Atoi(os.Getenv(val))
+}
+
+// Unfortunately this can't be a normal init function, because their execution
+// order is undefined, and we need to run before the init() in bind.go.
+func einhornInit() {
+	mpid, err := envInt("EINHORN_MASTER_PID")
+	if err != nil || mpid != os.Getppid() {
+		return
+	}
+
+	einhornNumFds, err = envInt("EINHORN_FD_COUNT")
+	if err != nil {
+		einhornNumFds = 0
+		return
+	}
+
+	// Prevent einhorn's fds from leaking to our children
+	for i := 0; i < einhornNumFds; i++ {
+		syscall.CloseOnExec(einhornFdMap(i))
+	}
+}
+
+func usingEinhorn() bool {
+	return einhornNumFds > 0
+}
+
+func einhornFdMap(n int) int {
+	name := fmt.Sprintf("EINHORN_FD_%d", n)
+	fno, err := envInt(name)
+	if err != nil {
+		log.Fatal(einhornErr)
+	}
+	return fno
+}
+
+func einhornBind(n int) (net.Listener, error) {
+	if !usingEinhorn() {
+		return nil, fmt.Errorf(bindErr, n)
+	}
+	if n >= einhornNumFds || n < 0 {
+		return nil, fmt.Errorf(tooBigErr, n, einhornNumFds)
+	}
+
+	fno := einhornFdMap(n)
+	f := os.NewFile(uintptr(fno), fmt.Sprintf("einhorn@%d", n))
+	defer f.Close()
+	return net.FileListener(f)
+}
+
+// Fun story: this is actually YAML, not JSON.
+const ackMsg = `{"command": "worker:ack", "pid": %d}` + "\n"
+
+func einhornAck() {
+	if !usingEinhorn() {
+		return
+	}
+	log.Print("bind: ACKing to einhorn")
+
+	ctl, err := net.Dial("unix", os.Getenv("EINHORN_SOCK_PATH"))
+	if err != nil {
+		log.Fatalf(ackErr, err)
+	}
+	defer ctl.Close()
+
+	_, err = fmt.Fprintf(ctl, ackMsg, os.Getpid())
+	if err != nil {
+		log.Fatalf(ackErr, err)
+	}
+}

--- a/vendor/github.com/zenazn/goji/bind/einhorn_stub.go
+++ b/vendor/github.com/zenazn/goji/bind/einhorn_stub.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package bind
+
+import (
+	"net"
+)
+
+func einhornInit()                             {}
+func einhornAck()                              {}
+func einhornBind(fd int) (net.Listener, error) { return nil, nil }
+func usingEinhorn() bool                       { return false }

--- a/vendor/github.com/zenazn/goji/bind/systemd.go
+++ b/vendor/github.com/zenazn/goji/bind/systemd.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package bind
+
+import (
+	"os"
+	"syscall"
+)
+
+const systemdMinFd = 3
+
+var systemdNumFds int
+
+// Unfortunately this can't be a normal init function, because their execution
+// order is undefined, and we need to run before the init() in bind.go.
+func systemdInit() {
+	pid, err := envInt("LISTEN_PID")
+	if err != nil || pid != os.Getpid() {
+		return
+	}
+
+	systemdNumFds, err = envInt("LISTEN_FDS")
+	if err != nil {
+		systemdNumFds = 0
+		return
+	}
+
+	// Prevent fds from leaking to our children
+	for i := 0; i < systemdNumFds; i++ {
+		syscall.CloseOnExec(systemdMinFd + i)
+	}
+}
+
+func usingSystemd() bool {
+	return systemdNumFds > 0
+}

--- a/vendor/github.com/zenazn/goji/bind/systemd_stub.go
+++ b/vendor/github.com/zenazn/goji/bind/systemd_stub.go
@@ -1,0 +1,6 @@
+// +build windows
+
+package bind
+
+func systemdInit()       {}
+func usingSystemd() bool { return false }

--- a/vendor/github.com/zenazn/goji/graceful/clone.go
+++ b/vendor/github.com/zenazn/goji/graceful/clone.go
@@ -1,0 +1,11 @@
+// +build !go1.6
+
+package graceful
+
+import "crypto/tls"
+
+// see clone16.go
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	c := *cfg
+	return &c
+}

--- a/vendor/github.com/zenazn/goji/graceful/clone16.go
+++ b/vendor/github.com/zenazn/goji/graceful/clone16.go
@@ -1,0 +1,34 @@
+// +build go1.6
+
+package graceful
+
+import "crypto/tls"
+
+// cloneTLSConfig was taken from the Go standard library's net/http package. We
+// need it because tls.Config objects now contain a sync.Once.
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return &tls.Config{
+		Rand:                     cfg.Rand,
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		SessionTicketsDisabled:   cfg.SessionTicketsDisabled,
+		SessionTicketKey:         cfg.SessionTicketKey,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
+}

--- a/vendor/github.com/zenazn/goji/graceful/einhorn.go
+++ b/vendor/github.com/zenazn/goji/graceful/einhorn.go
@@ -1,0 +1,21 @@
+// +build !windows
+
+package graceful
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func init() {
+	// This is a little unfortunate: goji/bind already knows whether we're
+	// running under einhorn, but we don't want to introduce a dependency
+	// between the two packages. Since the check is short enough, inlining
+	// it here seems "fine."
+	mpid, err := strconv.Atoi(os.Getenv("EINHORN_MASTER_PID"))
+	if err != nil || mpid != os.Getppid() {
+		return
+	}
+	stdSignals = append(stdSignals, syscall.SIGUSR2)
+}

--- a/vendor/github.com/zenazn/goji/graceful/graceful.go
+++ b/vendor/github.com/zenazn/goji/graceful/graceful.go
@@ -1,0 +1,62 @@
+/*
+Package graceful implements graceful shutdown for HTTP servers by closing idle
+connections after receiving a signal. By default, this package listens for
+interrupts (i.e., SIGINT), but when it detects that it is running under Einhorn
+it will additionally listen for SIGUSR2 as well, giving your application
+automatic support for graceful restarts/code upgrades.
+*/
+package graceful
+
+import (
+	"net"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/zenazn/goji/graceful/listener"
+)
+
+// WrapListener wraps an arbitrary net.Listener for use with graceful shutdowns.
+// In the background, it uses the listener sub-package to Wrap the listener in
+// Deadline mode. If another mode of operation is desired, you should call
+// listener.Wrap yourself: this function is smart enough to not double-wrap
+// listeners.
+func WrapListener(l net.Listener) net.Listener {
+	if lt, ok := l.(*listener.T); ok {
+		appendListener(lt)
+		return lt
+	}
+
+	lt := listener.Wrap(l, listener.Deadline)
+	appendListener(lt)
+	return lt
+}
+
+func appendListener(l *listener.T) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	listeners = append(listeners, l)
+}
+
+const errClosing = "use of closed network connection"
+
+// During graceful shutdown, calls to Accept will start returning errors. This
+// is inconvenient, since we know these sorts of errors are peaceful, so we
+// silently swallow them.
+func peacefulError(err error) error {
+	if atomic.LoadInt32(&closing) == 0 {
+		return err
+	}
+	// Unfortunately Go doesn't really give us a better way to select errors
+	// than this, so *shrug*.
+	if oe, ok := err.(*net.OpError); ok {
+		errOp := "accept"
+		if runtime.GOOS == "windows" {
+			errOp = "AcceptEx"
+		}
+		if oe.Op == errOp && oe.Err.Error() == errClosing {
+			return nil
+		}
+	}
+	return err
+}

--- a/vendor/github.com/zenazn/goji/graceful/listener/conn.go
+++ b/vendor/github.com/zenazn/goji/graceful/listener/conn.go
@@ -1,0 +1,151 @@
+package listener
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+type conn struct {
+	net.Conn
+
+	shard *shard
+	mode  mode
+
+	mu       sync.Mutex // Protects the state machine below
+	busy     bool       // connection is in use (i.e., not idle)
+	closed   bool       // connection is closed
+	disowned bool       // if true, this connection is no longer under our management
+}
+
+// This intentionally looks a lot like the one in package net.
+var errClosing = errors.New("use of closed network connection")
+
+func (c *conn) init() error {
+	c.shard.wg.Add(1)
+	if shouldExit := c.shard.track(c); shouldExit {
+		c.Close()
+		return errClosing
+	}
+	return nil
+}
+
+func (c *conn) Read(b []byte) (n int, err error) {
+	defer func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if c.disowned {
+			return
+		}
+
+		// This protects against a Close/Read race. We're not really
+		// concerned about the general case (it's fundamentally racy),
+		// but are mostly trying to prevent a race between a new request
+		// getting read off the wire in one thread while the connection
+		// is being gracefully shut down in another.
+		if c.closed && err == nil {
+			n = 0
+			err = errClosing
+			return
+		}
+
+		if c.mode != Manual && !c.busy && !c.closed {
+			c.busy = true
+			c.shard.markInUse(c)
+		}
+	}()
+
+	return c.Conn.Read(b)
+}
+
+func (c *conn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.disowned {
+		return c.Conn.Close()
+	} else if c.closed {
+		return errClosing
+	}
+
+	c.closed = true
+	c.shard.disown(c)
+	defer c.shard.wg.Done()
+
+	return c.Conn.Close()
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	if !c.disowned && c.mode == Deadline {
+		defer c.markIdle()
+	}
+	c.mu.Unlock()
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *conn) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(c.Conn, r)
+}
+
+func (c *conn) markIdle() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.busy {
+		return
+	}
+	c.busy = false
+
+	if exit := c.shard.markIdle(c); exit && !c.closed && !c.disowned {
+		c.closed = true
+		c.shard.disown(c)
+		defer c.shard.wg.Done()
+		c.Conn.Close()
+		return
+	}
+}
+
+func (c *conn) markInUse() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.busy && !c.closed && !c.disowned {
+		c.busy = true
+		c.shard.markInUse(c)
+	}
+}
+
+func (c *conn) closeIfIdle() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.busy && !c.closed && !c.disowned {
+		c.closed = true
+		c.shard.disown(c)
+		defer c.shard.wg.Done()
+		return c.Conn.Close()
+	}
+
+	return nil
+}
+
+var errAlreadyDisowned = errors.New("listener: conn already disowned")
+
+func (c *conn) disown() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.disowned {
+		return errAlreadyDisowned
+	}
+
+	c.shard.disown(c)
+	c.disowned = true
+	c.shard.wg.Done()
+
+	return nil
+}

--- a/vendor/github.com/zenazn/goji/graceful/listener/listener.go
+++ b/vendor/github.com/zenazn/goji/graceful/listener/listener.go
@@ -1,0 +1,178 @@
+/*
+Package listener provides a way to incorporate graceful shutdown to any
+net.Listener.
+
+This package provides low-level primitives, not a high-level API. If you're
+looking for a package that provides graceful shutdown for HTTP servers, I
+recommend this package's parent package, github.com/zenazn/goji/graceful.
+*/
+package listener
+
+import (
+	"errors"
+	"net"
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+type mode int8
+
+const (
+	// Manual mode is completely manual: users must use use MarkIdle and
+	// MarkInUse to indicate when connections are busy servicing requests or
+	// are eligible for termination.
+	Manual mode = iota
+	// Automatic mode is what most users probably want: calling Read on a
+	// connection will mark it as in use, but users must manually call
+	// MarkIdle to indicate when connections may be safely closed.
+	Automatic
+	// Deadline mode is like automatic mode, except that calling
+	// SetReadDeadline on a connection will also mark it as being idle. This
+	// is useful for many servers like net/http, where SetReadDeadline is
+	// used to implement read timeouts on new requests.
+	Deadline
+)
+
+// Wrap a net.Listener, returning a net.Listener which supports idle connection
+// tracking and shutdown. Listeners can be placed in to one of three modes,
+// exported as variables from this package: most users will probably want the
+// "Automatic" mode.
+func Wrap(l net.Listener, m mode) *T {
+	t := &T{
+		l:    l,
+		mode: m,
+		// To keep the expected contention rate constant we'd have to
+		// grow this as numcpu**2. In practice, CPU counts don't
+		// generally grow without bound, and contention is probably
+		// going to be small enough that nobody cares anyways.
+		shards: make([]shard, 2*runtime.NumCPU()),
+	}
+	for i := range t.shards {
+		t.shards[i].init(t)
+	}
+	return t
+}
+
+// T is the type of this package's graceful listeners.
+type T struct {
+	mu sync.Mutex
+	l  net.Listener
+
+	// TODO(carl): a count of currently outstanding connections.
+	connCount uint64
+	shards    []shard
+
+	mode mode
+}
+
+var _ net.Listener = &T{}
+
+// Accept waits for and returns the next connection to the listener. The
+// returned net.Conn's idleness is tracked, and idle connections can be closed
+// from the associated T.
+func (t *T) Accept() (net.Conn, error) {
+	c, err := t.l.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	connID := atomic.AddUint64(&t.connCount, 1)
+	shard := &t.shards[int(connID)%len(t.shards)]
+	wc := &conn{
+		Conn:  c,
+		shard: shard,
+		mode:  t.mode,
+	}
+
+	if err = wc.init(); err != nil {
+		return nil, err
+	}
+	return wc, nil
+}
+
+// Addr returns the wrapped listener's network address.
+func (t *T) Addr() net.Addr {
+	return t.l.Addr()
+}
+
+// Close closes the wrapped listener.
+func (t *T) Close() error {
+	return t.l.Close()
+}
+
+// CloseIdle closes all connections that are currently marked as being idle. It,
+// however, makes no attempt to wait for in-use connections to die, or to close
+// connections which become idle in the future. Call this function if you're
+// interested in shedding useless connections, but otherwise wish to continue
+// serving requests.
+func (t *T) CloseIdle() error {
+	for i := range t.shards {
+		t.shards[i].closeConns(false, false)
+	}
+	// Not sure if returning errors is actually useful here :/
+	return nil
+}
+
+// Drain immediately closes all idle connections, prevents new connections from
+// being accepted, and waits for all outstanding connections to finish.
+//
+// Once a listener has been drained, there is no way to re-enable it. You
+// probably want to Close the listener before draining it, otherwise new
+// connections will be accepted and immediately closed.
+func (t *T) Drain() error {
+	for i := range t.shards {
+		t.shards[i].closeConns(false, true)
+	}
+	for i := range t.shards {
+		t.shards[i].wait()
+	}
+	return nil
+}
+
+// DrainAll closes all connections currently tracked by this listener (both idle
+// and in-use connections), and prevents new connections from being accepted.
+// Disowned connections are not closed.
+func (t *T) DrainAll() error {
+	for i := range t.shards {
+		t.shards[i].closeConns(true, true)
+	}
+	for i := range t.shards {
+		t.shards[i].wait()
+	}
+	return nil
+}
+
+var errNotManaged = errors.New("listener: passed net.Conn is not managed by this package")
+
+// Disown causes a connection to no longer be tracked by the listener. The
+// passed connection must have been returned by a call to Accept from this
+// listener.
+func Disown(c net.Conn) error {
+	if cn, ok := c.(*conn); ok {
+		return cn.disown()
+	}
+	return errNotManaged
+}
+
+// MarkIdle marks the given connection as being idle, and therefore eligible for
+// closing at any time. The passed connection must have been returned by a call
+// to Accept from this listener.
+func MarkIdle(c net.Conn) error {
+	if cn, ok := c.(*conn); ok {
+		cn.markIdle()
+		return nil
+	}
+	return errNotManaged
+}
+
+// MarkInUse marks this connection as being in use, removing it from the set of
+// connections which are eligible for closing. The passed connection must have
+// been returned by a call to Accept from this listener.
+func MarkInUse(c net.Conn) error {
+	if cn, ok := c.(*conn); ok {
+		cn.markInUse()
+		return nil
+	}
+	return errNotManaged
+}

--- a/vendor/github.com/zenazn/goji/graceful/listener/shard.go
+++ b/vendor/github.com/zenazn/goji/graceful/listener/shard.go
@@ -1,0 +1,98 @@
+package listener
+
+import "sync"
+
+type shard struct {
+	l *T
+
+	mu    sync.Mutex
+	idle  map[*conn]struct{}
+	all   map[*conn]struct{}
+	wg    sync.WaitGroup
+	drain bool
+}
+
+// We pretty aggressively preallocate set entries in the hopes that we never
+// have to allocate memory with the lock held. This is definitely a premature
+// optimization and is probably misguided, but luckily it costs us essentially
+// nothing.
+const prealloc = 2048
+
+func (s *shard) init(l *T) {
+	s.l = l
+	s.idle = make(map[*conn]struct{}, prealloc)
+	s.all = make(map[*conn]struct{}, prealloc)
+}
+
+func (s *shard) track(c *conn) (shouldClose bool) {
+	s.mu.Lock()
+	if s.drain {
+		s.mu.Unlock()
+		return true
+	}
+	s.all[c] = struct{}{}
+	s.idle[c] = struct{}{}
+	s.mu.Unlock()
+	return false
+}
+
+func (s *shard) disown(c *conn) {
+	s.mu.Lock()
+	delete(s.all, c)
+	delete(s.idle, c)
+	s.mu.Unlock()
+}
+
+func (s *shard) markIdle(c *conn) (shouldClose bool) {
+	s.mu.Lock()
+	if s.drain {
+		s.mu.Unlock()
+		return true
+	}
+	s.idle[c] = struct{}{}
+	s.mu.Unlock()
+	return false
+}
+
+func (s *shard) markInUse(c *conn) {
+	s.mu.Lock()
+	delete(s.idle, c)
+	s.mu.Unlock()
+}
+
+func (s *shard) closeConns(all, drain bool) {
+	s.mu.Lock()
+	if drain {
+		s.drain = true
+	}
+	set := make(map[*conn]struct{}, len(s.all))
+	if all {
+		for c := range s.all {
+			set[c] = struct{}{}
+		}
+	} else {
+		for c := range s.idle {
+			set[c] = struct{}{}
+		}
+	}
+	// We have to drop the shard lock here to avoid deadlock: we cannot
+	// acquire the shard lock after the connection lock, and the closeIfIdle
+	// call below will grab a connection lock.
+	s.mu.Unlock()
+
+	for c := range set {
+		// This might return an error (from Close), but I don't think we
+		// can do anything about it, so let's just pretend it didn't
+		// happen. (I also expect that most errors returned in this way
+		// are going to be pretty boring)
+		if all {
+			c.Close()
+		} else {
+			c.closeIfIdle()
+		}
+	}
+}
+
+func (s *shard) wait() {
+	s.wg.Wait()
+}

--- a/vendor/github.com/zenazn/goji/graceful/middleware.go
+++ b/vendor/github.com/zenazn/goji/graceful/middleware.go
@@ -1,0 +1,103 @@
+// +build !go1.3
+
+package graceful
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/zenazn/goji/graceful/listener"
+)
+
+// Middleware provides functionality similar to net/http.Server's
+// SetKeepAlivesEnabled in Go 1.3, but in Go 1.2.
+func middleware(h http.Handler) http.Handler {
+	if h == nil {
+		return nil
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, cn := w.(http.CloseNotifier)
+		_, fl := w.(http.Flusher)
+		_, hj := w.(http.Hijacker)
+		_, rf := w.(io.ReaderFrom)
+
+		bw := basicWriter{ResponseWriter: w}
+
+		if cn && fl && hj && rf {
+			h.ServeHTTP(&fancyWriter{bw}, r)
+		} else {
+			h.ServeHTTP(&bw, r)
+		}
+		if !bw.headerWritten {
+			bw.maybeClose()
+		}
+	})
+}
+
+type basicWriter struct {
+	http.ResponseWriter
+	headerWritten bool
+}
+
+func (b *basicWriter) maybeClose() {
+	b.headerWritten = true
+	if atomic.LoadInt32(&closing) != 0 {
+		b.ResponseWriter.Header().Set("Connection", "close")
+	}
+}
+
+func (b *basicWriter) WriteHeader(code int) {
+	b.maybeClose()
+	b.ResponseWriter.WriteHeader(code)
+}
+
+func (b *basicWriter) Write(buf []byte) (int, error) {
+	if !b.headerWritten {
+		b.maybeClose()
+	}
+	return b.ResponseWriter.Write(buf)
+}
+
+func (b *basicWriter) Unwrap() http.ResponseWriter {
+	return b.ResponseWriter
+}
+
+// Optimize for the common case of a ResponseWriter that supports all three of
+// CloseNotifier, Flusher, and Hijacker.
+type fancyWriter struct {
+	basicWriter
+}
+
+func (f *fancyWriter) CloseNotify() <-chan bool {
+	cn := f.basicWriter.ResponseWriter.(http.CloseNotifier)
+	return cn.CloseNotify()
+}
+func (f *fancyWriter) Flush() {
+	fl := f.basicWriter.ResponseWriter.(http.Flusher)
+	fl.Flush()
+}
+func (f *fancyWriter) Hijack() (c net.Conn, b *bufio.ReadWriter, e error) {
+	hj := f.basicWriter.ResponseWriter.(http.Hijacker)
+	c, b, e = hj.Hijack()
+
+	if e == nil {
+		e = listener.Disown(c)
+	}
+
+	return
+}
+func (f *fancyWriter) ReadFrom(r io.Reader) (int64, error) {
+	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
+	if !f.basicWriter.headerWritten {
+		f.basicWriter.maybeClose()
+	}
+	return rf.ReadFrom(r)
+}
+
+var _ http.CloseNotifier = &fancyWriter{}
+var _ http.Flusher = &fancyWriter{}
+var _ http.Hijacker = &fancyWriter{}
+var _ io.ReaderFrom = &fancyWriter{}

--- a/vendor/github.com/zenazn/goji/graceful/serve.go
+++ b/vendor/github.com/zenazn/goji/graceful/serve.go
@@ -1,0 +1,33 @@
+// +build !go1.3
+
+package graceful
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/zenazn/goji/graceful/listener"
+)
+
+// About 200 years, also known as "forever"
+const forever time.Duration = 200 * 365 * 24 * time.Hour
+
+// Serve behaves like the method on net/http.Server with the same name.
+func (srv *Server) Serve(l net.Listener) error {
+	// Spawn a shadow http.Server to do the actual servering. We do this
+	// because we need to sketch on some of the parameters you passed in,
+	// and it's nice to keep our sketching to ourselves.
+	shadow := *(*http.Server)(srv)
+
+	if shadow.ReadTimeout == 0 {
+		shadow.ReadTimeout = forever
+	}
+	shadow.Handler = middleware(shadow.Handler)
+
+	wrap := listener.Wrap(l, listener.Deadline)
+	appendListener(wrap)
+
+	err := shadow.Serve(wrap)
+	return peacefulError(err)
+}

--- a/vendor/github.com/zenazn/goji/graceful/serve13.go
+++ b/vendor/github.com/zenazn/goji/graceful/serve13.go
@@ -1,0 +1,76 @@
+// +build go1.3
+
+package graceful
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/zenazn/goji/graceful/listener"
+)
+
+// This is a slightly hacky shim to disable keepalives when shutting a server
+// down. We could have added extra functionality in listener or signal.go to
+// deal with this case, but this seems simpler.
+type gracefulServer struct {
+	net.Listener
+	s *http.Server
+}
+
+func (g gracefulServer) Close() error {
+	g.s.SetKeepAlivesEnabled(false)
+	return g.Listener.Close()
+}
+
+// A chaining http.ConnState wrapper
+type connState func(net.Conn, http.ConnState)
+
+func (c connState) Wrap(nc net.Conn, s http.ConnState) {
+	// There are a few other states defined, most notably StateActive.
+	// Unfortunately it doesn't look like it's possible to make use of
+	// StateActive to implement graceful shutdown, since StateActive is set
+	// after a complete request has been read off the wire with an intent to
+	// process it. If we were to race a graceful shutdown against a
+	// connection that was just read off the wire (but not yet in
+	// StateActive), we would accidentally close the connection out from
+	// underneath an active request.
+	//
+	// We already needed to work around this for Go 1.2 by shimming out a
+	// full net.Conn object, so we can just fall back to the old behavior
+	// there.
+	//
+	// I started a golang-nuts thread about this here:
+	// https://groups.google.com/forum/#!topic/golang-nuts/Xi8yjBGWfCQ
+	// I'd be very eager to find a better way to do this, so reach out to me
+	// if you have any ideas.
+	switch s {
+	case http.StateIdle:
+		if err := listener.MarkIdle(nc); err != nil {
+			log.Printf("error marking conn as idle: %v", err)
+		}
+	case http.StateHijacked:
+		if err := listener.Disown(nc); err != nil {
+			log.Printf("error disowning hijacked conn: %v", err)
+		}
+	}
+	if c != nil {
+		c(nc, s)
+	}
+}
+
+// Serve behaves like the method on net/http.Server with the same name.
+func (srv *Server) Serve(l net.Listener) error {
+	// Spawn a shadow http.Server to do the actual servering. We do this
+	// because we need to sketch on some of the parameters you passed in,
+	// and it's nice to keep our sketching to ourselves.
+	shadow := *(*http.Server)(srv)
+	shadow.ConnState = connState(shadow.ConnState).Wrap
+
+	l = gracefulServer{l, &shadow}
+	wrap := listener.Wrap(l, listener.Automatic)
+	appendListener(wrap)
+
+	err := shadow.Serve(wrap)
+	return peacefulError(err)
+}

--- a/vendor/github.com/zenazn/goji/graceful/server.go
+++ b/vendor/github.com/zenazn/goji/graceful/server.go
@@ -1,0 +1,108 @@
+package graceful
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Most of the code here is lifted straight from net/http
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+// A Server is exactly the same as an http.Server, but provides more graceful
+// implementations of its methods.
+type Server http.Server
+
+// ListenAndServe behaves like the method on net/http.Server with the same name.
+func (srv *Server) ListenAndServe() error {
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	return srv.Serve(tcpKeepAliveListener{ln.(*net.TCPListener)})
+}
+
+// ListenAndServeTLS behaves like the method on net/http.Server with the same
+// name. Unlike the method of the same name on http.Server, this function
+// defaults to enforcing TLS 1.0 or higher in order to address the POODLE
+// vulnerability. Users who wish to enable SSLv3 must do so by supplying a
+// TLSConfig explicitly.
+func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS10,
+	}
+	if srv.TLSConfig != nil {
+		config = cloneTLSConfig(srv.TLSConfig)
+	}
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	var err error
+	config.Certificates = make([]tls.Certificate, 1)
+	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
+	return srv.Serve(tlsListener)
+}
+
+// ListenAndServe behaves exactly like the net/http function of the same name.
+func ListenAndServe(addr string, handler http.Handler) error {
+	server := &Server{Addr: addr, Handler: handler}
+	return server.ListenAndServe()
+}
+
+// ListenAndServeTLS behaves almost exactly like the net/http function of the
+// same name. Unlike net/http, however, this function defaults to enforcing TLS
+// 1.0 or higher in order to address the POODLE vulnerability. Users who wish to
+// enable SSLv3 must do so by explicitly instantiating a server with an
+// appropriately configured TLSConfig property.
+func ListenAndServeTLS(addr, certfile, keyfile string, handler http.Handler) error {
+	server := &Server{Addr: addr, Handler: handler}
+	return server.ListenAndServeTLS(certfile, keyfile)
+}
+
+// Serve mostly behaves like the net/http function of the same name, except that
+// if the passed listener is a net.TCPListener, TCP keep-alives are enabled on
+// accepted connections.
+func Serve(l net.Listener, handler http.Handler) error {
+	if tl, ok := l.(*net.TCPListener); ok {
+		l = tcpKeepAliveListener{tl}
+	}
+	server := &Server{Handler: handler}
+	return server.Serve(l)
+}

--- a/vendor/github.com/zenazn/goji/graceful/signal.go
+++ b/vendor/github.com/zenazn/goji/graceful/signal.go
@@ -1,0 +1,197 @@
+package graceful
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/zenazn/goji/graceful/listener"
+)
+
+var mu sync.Mutex // protects everything that follows
+var listeners = make([]*listener.T, 0)
+var prehooks = make([]func(), 0)
+var posthooks = make([]func(), 0)
+var closing int32
+var doubleKick, timeout time.Duration
+
+var wait = make(chan struct{})
+var stdSignals = []os.Signal{os.Interrupt}
+var sigchan = make(chan os.Signal, 1)
+
+// HandleSignals installs signal handlers for a set of standard signals. By
+// default, this set only includes keyboard interrupts, however when the package
+// detects that it is running under Einhorn, a SIGUSR2 handler is installed as
+// well.
+func HandleSignals() {
+	AddSignal(stdSignals...)
+}
+
+// AddSignal adds the given signal to the set of signals that trigger a graceful
+// shutdown.
+func AddSignal(sig ...os.Signal) {
+	signal.Notify(sigchan, sig...)
+}
+
+// ResetSignals resets the list of signals that trigger a graceful shutdown.
+func ResetSignals() {
+	signal.Stop(sigchan)
+}
+
+// PreHook registers a function to be called before any of this package's normal
+// shutdown actions. All listeners will be called in the order they were added,
+// from a single goroutine.
+func PreHook(f func()) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	prehooks = append(prehooks, f)
+}
+
+// PostHook registers a function to be called after all of this package's normal
+// shutdown actions. All listeners will be called in the order they were added,
+// from a single goroutine, and are guaranteed to be called after all listening
+// connections have been closed, but before Wait() returns.
+//
+// If you've Hijacked any connections that must be gracefully shut down in some
+// other way (since this library disowns all hijacked connections), it's
+// reasonable to use a PostHook to signal and wait for them.
+func PostHook(f func()) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	posthooks = append(posthooks, f)
+}
+
+// Shutdown manually triggers a shutdown from your application. Like Wait,
+// blocks until all connections have gracefully shut down.
+func Shutdown() {
+	shutdown(false)
+}
+
+// ShutdownNow triggers an immediate shutdown from your application. All
+// connections (not just those that are idle) are immediately closed, even if
+// they are in the middle of serving a request.
+func ShutdownNow() {
+	shutdown(true)
+}
+
+// DoubleKickWindow sets the length of the window during which two back-to-back
+// signals are treated as an especially urgent or forceful request to exit
+// (i.e., ShutdownNow instead of Shutdown). Signals delivered more than this
+// duration apart are treated as separate requests to exit gracefully as usual.
+//
+// Setting DoubleKickWindow to 0 disables the feature.
+func DoubleKickWindow(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+
+	doubleKick = d
+}
+
+// Timeout sets the maximum amount of time package graceful will wait for
+// connections to gracefully shut down after receiving a signal. After this
+// timeout, connections will be forcefully shut down (similar to calling
+// ShutdownNow).
+//
+// Setting Timeout to 0 disables the feature.
+func Timeout(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+
+	timeout = d
+}
+
+// Wait for all connections to gracefully shut down. This is commonly called at
+// the bottom of the main() function to prevent the program from exiting
+// prematurely.
+func Wait() {
+	<-wait
+}
+
+func init() {
+	go sigLoop()
+}
+func sigLoop() {
+	var last time.Time
+	for {
+		<-sigchan
+		now := time.Now()
+		mu.Lock()
+		force := doubleKick != 0 && now.Sub(last) < doubleKick
+		if t := timeout; t != 0 && !force {
+			go func() {
+				time.Sleep(t)
+				shutdown(true)
+			}()
+		}
+		mu.Unlock()
+		go shutdown(force)
+		last = now
+	}
+}
+
+var preOnce, closeOnce, forceOnce, postOnce, notifyOnce sync.Once
+
+func shutdown(force bool) {
+	preOnce.Do(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, f := range prehooks {
+			f()
+		}
+	})
+
+	if force {
+		forceOnce.Do(func() {
+			closeListeners(force)
+		})
+	} else {
+		closeOnce.Do(func() {
+			closeListeners(force)
+		})
+	}
+
+	postOnce.Do(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, f := range posthooks {
+			f()
+		}
+	})
+
+	notifyOnce.Do(func() {
+		close(wait)
+	})
+}
+
+func closeListeners(force bool) {
+	atomic.StoreInt32(&closing, 1)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	wg.Add(len(listeners))
+
+	for _, l := range listeners {
+		go func(l *listener.T) {
+			defer wg.Done()
+			l.Close()
+			if force {
+				l.DrainAll()
+			} else {
+				l.Drain()
+			}
+		}(l)
+	}
+}

--- a/vendor/goji.io/LICENSE
+++ b/vendor/goji.io/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015, 2016 Carl Jackson (carl@avtok.com)
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/goji.io/README.md
+++ b/vendor/goji.io/README.md
@@ -1,0 +1,88 @@
+Goji
+====
+
+[![GoDoc](https://godoc.org/goji.io?status.svg)](https://godoc.org/goji.io) [![Build Status](https://travis-ci.org/goji/goji.svg?branch=master)](https://travis-ci.org/goji/goji)
+
+Goji is a HTTP request multiplexer, similar to [`net/http.ServeMux`][servemux].
+It compares incoming requests to a list of registered [Patterns][pattern], and
+dispatches to the [Handler][handler] that corresponds to the first matching
+Pattern. Goji also supports [Middleware][middleware] (composable shared
+functionality applied to every request) and uses the de facto standard
+[`x/net/context`][context] to store request-scoped values.
+
+[servemux]: https://golang.org/pkg/net/http/#ServeMux
+[pattern]: https://godoc.org/goji.io#Pattern
+[handler]: https://godoc.org/goji.io#Handler
+[middleware]: https://godoc.org/goji.io#Mux.Use
+[context]: https://godoc.org/golang.org/x/net/context
+
+
+Quick Start
+-----------
+
+```go
+package main
+
+import (
+        "fmt"
+        "net/http"
+
+        "goji.io"
+        "goji.io/pat"
+        "golang.org/x/net/context"
+)
+
+func hello(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+        name := pat.Param(ctx, "name")
+        fmt.Fprintf(w, "Hello, %s!", name)
+}
+
+func main() {
+        mux := goji.NewMux()
+        mux.HandleFuncC(pat.Get("/hello/:name"), hello)
+
+        http.ListenAndServe("localhost:8000", mux)
+}
+```
+
+Please refer to [Goji's GoDoc Documentation][godoc] for a full API reference.
+
+[godoc]: https://godoc.org/goji.io
+
+
+Stability
+---------
+
+Goji's API is stable, and guarantees to never break compatibility with existing
+code (under similar rules to the Go project's [guidelines][compat]). Goji is
+suitable for use in production.
+
+One possible exception to the above compatibility guarantees surrounds the
+inclusion of the `x/net/context` package in the standard library for Go 1.7.
+When this happens, Goji may switch its package imports to use the standard
+library's version of the package. Note that, while this is a backwards
+incompatible change, the impact on clients is expected to be minimal:
+applications will simply have to change the import path of the `context`
+package. More discussion about this migration can be found on the Goji mailing
+list.
+
+[compat]: https://golang.org/doc/go1compat
+
+
+Community / Contributing
+------------------------
+
+Goji maintains a mailing list, [gojiberries][berries], where you should feel
+welcome to ask questions about the project (no matter how simple!), to announce
+projects or libraries built on top of Goji, or to talk about Goji more
+generally. Goji's author (Carl Jackson) also loves to hear from users directly
+at his personal email address, which is available on his GitHub profile page.
+
+Contributions to Goji are welcome, however please be advised that due to Goji's
+stability guarantees interface changes are unlikely to be accepted.
+
+All interactions in the Goji community will be held to the high standard of the
+broader Go community's [Code of Conduct][conduct].
+
+[berries]: https://groups.google.com/forum/#!forum/gojiberries
+[conduct]: https://golang.org/conduct

--- a/vendor/goji.io/dispatch.go
+++ b/vendor/goji.io/dispatch.go
@@ -1,0 +1,19 @@
+package goji
+
+import (
+	"net/http"
+
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+type dispatch struct{}
+
+func (d dispatch) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	h := ctx.Value(internal.Handler)
+	if h == nil {
+		http.NotFound(w, r)
+	} else {
+		h.(Handler).ServeHTTPC(ctx, w, r)
+	}
+}

--- a/vendor/goji.io/goji.go
+++ b/vendor/goji.io/goji.go
@@ -1,0 +1,94 @@
+/*
+Package goji is a minimalistic and flexible HTTP request multiplexer.
+
+Goji itself has very few features: it is first and foremost a standard set of
+interfaces for writing web applications. Several subpackages are distributed
+with Goji to provide standard production-ready implementations of several of the
+interfaces, however users are also encouraged to implement the interfaces on
+their own, especially if their needs are unusual.
+*/
+package goji
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+/*
+Pattern determines whether a given request matches some criteria. Goji users
+looking for a concrete type that implements this interface should consider
+Goji's "pat" sub-package, which implements a small domain specific language for
+HTTP routing.
+
+Patterns typically only examine a small portion of incoming requests, most
+commonly the HTTP method and the URL's RawPath. As an optimization, Goji can
+elide calls to your Pattern for requests it knows cannot match. Pattern authors
+who wish to take advantage of this functionality (and in some cases an
+asymptotic performance improvement) can augment their Pattern implementations
+with any of the following methods:
+
+	// HTTPMethods returns a set of HTTP methods that this Pattern matches,
+	// or nil if it's not possible to determine which HTTP methods might be
+	// matched. Put another way, requests with HTTP methods not in the
+	// returned set are guaranteed to never match this Pattern.
+	HTTPMethods() map[string]struct{}
+
+	// PathPrefix returns a string which all RawPaths that match this
+	// Pattern must have as a prefix. Put another way, requests with
+	// RawPaths that do not contain the returned string as a prefix are
+	// guaranteed to never match this Pattern.
+	PathPrefix() string
+
+The presence or lack of these performance improvements should be viewed as an
+implementation detail and are not part of Goji's API compatibility guarantee. It
+is the responsibility of Pattern authors to ensure that their Match function
+always returns correct results, even if these optimizations are not performed.
+
+All operations on Patterns must be safe for concurrent use by multiple
+goroutines.
+*/
+type Pattern interface {
+	// Match examines the request and request context to determine if the
+	// request is a match. If so, it returns a non-nil context.Context
+	// (likely one derived from the input Context, and perhaps simply the
+	// input Context unchanged). The returned context may be used to store
+	// request-scoped data, such as variables extracted from the Request.
+	//
+	// Match must not mutate the passed request.
+	Match(context.Context, *http.Request) context.Context
+}
+
+/*
+Handler is a context-aware variant of net/http.Handler. It has the same
+semantics as http.Handler, except that a request-scoped context is additionally
+passed to the handler function.
+*/
+type Handler interface {
+	ServeHTTPC(context.Context, http.ResponseWriter, *http.Request)
+}
+
+/*
+HandlerFunc is a context-aware variant of net/http.HandlerFunc. It has the same
+semantics as http.HandlerFunc, except that a request-scoped context is
+additionally passed to the function.
+
+HandlerFunc implements both the Handler and http.Handler interfaces.
+*/
+type HandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
+
+/*
+ServeHTTP implements net/http.Handler. It calls the underlying function with a
+context of context.TODO in order to ease the conversion of non-context-aware
+Handlers to context-aware ones using static analysis.
+*/
+func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h(context.TODO(), w, r)
+}
+
+/*
+ServeHTTPC implements Handler.
+*/
+func (h HandlerFunc) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	h(ctx, w, r)
+}

--- a/vendor/goji.io/handle.go
+++ b/vendor/goji.io/handle.go
@@ -1,0 +1,67 @@
+package goji
+
+import (
+	"net/http"
+
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+/*
+Handle adds a new route to the Mux. Requests that match the given Pattern will
+be dispatched to the given http.Handler. If the http.Handler also supports
+Handler, that interface will be used instead.
+
+Routing is performed in the order in which routes are added: the first route
+with a matching Pattern will be used. In particular, Goji guarantees that
+routing is performed in a manner that is indistinguishable from the following
+algorithm:
+
+	// Assume routes is a slice that every call to Handle appends to
+	for route := range routes {
+		// For performance, Patterns can opt out of this call to Match.
+		// See the documentation for Pattern for more.
+		if ctx2 := route.pattern.Match(ctx, r); ctx2 != nil {
+			route.handler.ServeHTTPC(ctx2, w, r)
+			break
+		}
+	}
+
+It is not safe to concurrently register routes from multiple goroutines, or to
+register routes concurrently with requests.
+*/
+func (m *Mux) Handle(p Pattern, h http.Handler) {
+	gh, ok := h.(Handler)
+	if !ok {
+		gh = internal.ContextWrapper{Handler: h}
+	}
+	m.router.add(p, gh)
+}
+
+/*
+HandleFunc adds a new route to the Mux. It is equivalent to calling Handle on a
+handler wrapped with http.HandlerFunc, and is provided only for convenience.
+*/
+func (m *Mux) HandleFunc(p Pattern, h func(http.ResponseWriter, *http.Request)) {
+	m.Handle(p, http.HandlerFunc(h))
+}
+
+/*
+HandleC adds a new context-aware route to the Mux. See the documentation for
+Handle for more information about the semantics of routing.
+
+It is not safe to concurrently register routes from multiple goroutines, or to
+register routes concurrently with requests.
+*/
+func (m *Mux) HandleC(p Pattern, h Handler) {
+	m.router.add(p, h)
+}
+
+/*
+HandleFuncC adds a new context-aware route to the Mux. It is equivalent to
+calling HandleC on a handler wrapped with HandlerFunc, and is provided for
+convenience.
+*/
+func (m *Mux) HandleFuncC(p Pattern, h func(context.Context, http.ResponseWriter, *http.Request)) {
+	m.HandleC(p, HandlerFunc(h))
+}

--- a/vendor/goji.io/internal/context.go
+++ b/vendor/goji.io/internal/context.go
@@ -1,0 +1,17 @@
+package internal
+
+// ContextKey is a type used for Goji's context.Context keys.
+type ContextKey int
+
+var (
+	// Path is the context key used to store the path Goji uses for its
+	// PathPrefix optimization.
+	Path interface{} = ContextKey(0)
+	// Pattern is the context key used to store the Pattern that Goji last
+	// matched.
+	Pattern interface{} = ContextKey(1)
+	// Handler is the context key used to store the Handler that Goji last
+	// mached (and will therefore dispatch to at the end of the middleware
+	// stack).
+	Handler interface{} = ContextKey(2)
+)

--- a/vendor/goji.io/internal/http.go
+++ b/vendor/goji.io/internal/http.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// ContextWrapper is a standard bridge type from http.Handlers to context-aware
+// Handlers. It is included here so that the middleware subpackage can use it to
+// unwrap Handlers.
+type ContextWrapper struct {
+	http.Handler
+}
+
+// ServeHTTPC implements goji.Handler.
+func (c ContextWrapper) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	c.Handler.ServeHTTP(w, r)
+}

--- a/vendor/goji.io/internal/internal.go
+++ b/vendor/goji.io/internal/internal.go
@@ -1,0 +1,13 @@
+/*
+Package internal is a private package that allows Goji to expose a less
+confusing interface to its users. This package must not be used outside of Goji;
+every piece of its functionality has been exposed by one of Goji's subpackages.
+
+The problem this package solves is to allow Goji to internally agree on types
+and secret values between its packages without introducing import cycles. Goji
+needs to agree on these types and values in order to organize its public API
+into audience-specific subpackages (for instance, a package for pattern authors,
+a package for middleware authors, and a main package for routing users) without
+exposing implementation details in any of the packages.
+*/
+package internal

--- a/vendor/goji.io/middleware.go
+++ b/vendor/goji.io/middleware.go
@@ -1,0 +1,115 @@
+package goji
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+/*
+Use appends a middleware to the Mux's middleware stack.
+
+Middleware are composable pieces of functionality that augment Handlers. Common
+examples of middleware include request loggers, authentication checkers, and
+metrics gatherers.
+
+Middleware are evaluated in the reverse order in which they were added, but the
+resulting Handlers execute in "normal" order (i.e., the Handler returned by the
+first Middleware to be added gets called first).
+
+For instance, given middleware A, B, and C, added in that order, Goji will
+behave similarly to this snippet:
+
+	augmentedHandler := A(B(C(yourHandler)))
+	augmentedHandler.ServeHTTPC(ctx, w, r)
+
+Assuming each of A, B, and C look something like this:
+
+	func A(inner goji.Handler) goji.Handler {
+		log.Print("A: called")
+		mw := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			log.Print("A: before")
+			inner.ServeHTTPC(ctx, w, r)
+			log.Print("A: after")
+		}
+		return goji.HandlerFunc(mw)
+	}
+
+we'd expect to see the following in the log:
+
+	C: called
+	B: called
+	A: called
+	---
+	A: before
+	B: before
+	C: before
+	yourHandler: called
+	C: after
+	B: after
+	A: after
+
+Note that augmentedHandler may be called many times. Put another way, you will
+see many invocations of the portion of the log below the divider, and perhaps
+only see the portion above the divider a single time. Also note that as an
+implementation detail, net/http-style middleware will be called once per
+request, even though the Goji-style middleware around them might only ever be
+called a single time.
+
+Middleware in Goji is called after routing has been performed. Therefore it is
+possible to examine any routing information placed into the context by Patterns,
+or to view or modify the Handler that will be routed to. Middleware authors
+should read the documentation for the "middleware" subpackage for more
+information about how this is done.
+
+The http.Handler returned by the given middleware must be safe for concurrent
+use by multiple goroutines. It is not safe to concurrently register middleware
+from multiple goroutines, or to register middleware concurrently with requests.
+*/
+func (m *Mux) Use(middleware func(http.Handler) http.Handler) {
+	m.middleware = append(m.middleware, func(h Handler) Handler {
+		return outerBridge{middleware, h}
+	})
+	m.buildChain()
+}
+
+/*
+UseC appends a context-aware middleware to the Mux's middleware stack. See the
+documentation for Use for more information about the semantics of middleware.
+
+The Handler returned by the given middleware must be safe for concurrent use by
+multiple goroutines. It is not safe to concurrently register middleware from
+multiple goroutines, or to register middleware concurrently with requests.
+*/
+func (m *Mux) UseC(middleware func(Handler) Handler) {
+	m.middleware = append(m.middleware, middleware)
+	m.buildChain()
+}
+
+// Pre-compile a Handler for us to use during dispatch. Yes, this means that
+// adding middleware is quadratic, but it (a) happens during configuration time,
+// not at "runtime", and (b) n should ~always be small.
+func (m *Mux) buildChain() {
+	m.handler = dispatch{}
+	for i := len(m.middleware) - 1; i >= 0; i-- {
+		m.handler = m.middleware[i](m.handler)
+	}
+}
+
+type innerBridge struct {
+	inner Handler
+	ctx   context.Context
+}
+
+func (b innerBridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	b.inner.ServeHTTPC(b.ctx, w, r)
+}
+
+type outerBridge struct {
+	mware func(http.Handler) http.Handler
+	inner Handler
+}
+
+func (b outerBridge) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	b.mware(innerBridge{b.inner, ctx}).ServeHTTP(w, r)
+}

--- a/vendor/goji.io/mux.go
+++ b/vendor/goji.io/mux.go
@@ -1,0 +1,91 @@
+package goji
+
+import (
+	"net/http"
+
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+/*
+Mux is a HTTP multiplexer / router similar to net/http.ServeMux.
+
+Muxes multiplex traffic between many Handlers by selecting the first applicable
+Pattern. They then call a common middleware stack, finally passing control to
+the selected Handler. See the documentation on the Handle function for more
+information about how routing is performed, the documentation on the Pattern
+type for more information about request matching, and the documentation for the
+Use method for more about middleware.
+
+Muxes cannot be configured concurrently from multiple goroutines, nor can they
+be configured concurrently with requests.
+*/
+type Mux struct {
+	handler    Handler
+	middleware []func(Handler) Handler
+	router     router
+	root       bool
+}
+
+/*
+NewMux returns a new Mux with no configured middleware or routes.
+*/
+func NewMux() *Mux {
+	m := SubMux()
+	m.root = true
+	return m
+}
+
+/*
+SubMux returns a new Mux with no configured middleware or routes, and which
+inherits routing information from the passed context. This is especially useful
+when using one Mux as a Handler registered to another "parent" Mux.
+
+For example, a common pattern is to organize applications in a way that mirrors
+the structure of its URLs: a photo-sharing site might have URLs that start with
+"/users/" and URLs that start with "/albums/", and might be organized using
+three Muxes:
+
+	root := NewMux()
+	users := SubMux()
+	root.HandleC(pat.New("/users/*"), users)
+	albums := SubMux()
+	root.HandleC(pat.New("/albums/*"), albums)
+
+	// e.g., GET /users/carl
+	users.HandleC(pat.Get("/:name"), renderProfile)
+	// e.g., POST /albums/
+	albums.HandleC(pat.Post("/"), newAlbum)
+*/
+func SubMux() *Mux {
+	m := &Mux{}
+	m.buildChain()
+	return m
+}
+
+/*
+ServeHTTP implements net/http.Handler. It uses context.TODO as the root context
+in order to ease the conversion of non-context-aware Handlers to context-aware
+ones using static analysis.
+
+Users who know that their mux sits at the top of the request hierarchy should
+consider creating a small helper http.Handler that calls this Mux's ServeHTTPC
+function with context.Background.
+*/
+func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.ServeHTTPC(context.TODO(), w, r)
+}
+
+/*
+ServeHTTPC implements Handler.
+*/
+func (m *Mux) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	if m.root {
+		ctx = context.WithValue(ctx, internal.Path, r.URL.EscapedPath())
+	}
+	ctx = m.router.route(ctx, r)
+	m.handler.ServeHTTPC(ctx, w, r)
+}
+
+var _ http.Handler = &Mux{}
+var _ Handler = &Mux{}

--- a/vendor/goji.io/pat/match.go
+++ b/vendor/goji.io/pat/match.go
@@ -1,0 +1,51 @@
+package pat
+
+import (
+	"sort"
+
+	"goji.io/internal"
+	"goji.io/pattern"
+	"golang.org/x/net/context"
+)
+
+type match struct {
+	context.Context
+	pat     *Pattern
+	matches []string
+}
+
+func (m match) Value(key interface{}) interface{} {
+	switch key {
+	case pattern.AllVariables:
+		var vs map[pattern.Variable]interface{}
+		if vsi := m.Context.Value(key); vsi == nil {
+			if len(m.pat.pats) == 0 {
+				return nil
+			}
+			vs = make(map[pattern.Variable]interface{}, len(m.matches))
+		} else {
+			vs = vsi.(map[pattern.Variable]interface{})
+		}
+
+		for _, p := range m.pat.pats {
+			vs[p.name] = m.matches[p.idx]
+		}
+		return vs
+	case internal.Path:
+		if len(m.matches) == len(m.pat.pats)+1 {
+			return m.matches[len(m.matches)-1]
+		}
+		return ""
+	}
+
+	if k, ok := key.(pattern.Variable); ok {
+		i := sort.Search(len(m.pat.pats), func(i int) bool {
+			return m.pat.pats[i].name >= k
+		})
+		if i < len(m.pat.pats) && m.pat.pats[i].name == k {
+			return m.matches[m.pat.pats[i].idx]
+		}
+	}
+
+	return m.Context.Value(key)
+}

--- a/vendor/goji.io/pat/methods.go
+++ b/vendor/goji.io/pat/methods.go
@@ -1,0 +1,51 @@
+package pat
+
+/*
+Delete returns a Pat route that only matches the DELETE HTTP method.
+*/
+func Delete(pat string) *Pattern {
+	return newWithMethods(pat, "DELETE")
+}
+
+/*
+Get returns a Pat route that only matches the GET and HEAD HTTP method. HEAD
+requests are handled transparently by net/http.
+*/
+func Get(pat string) *Pattern {
+	return newWithMethods(pat, "GET", "HEAD")
+}
+
+/*
+Head returns a Pat route that only matches the HEAD HTTP method.
+*/
+func Head(pat string) *Pattern {
+	return newWithMethods(pat, "HEAD")
+}
+
+/*
+Options returns a Pat route that only matches the OPTIONS HTTP method.
+*/
+func Options(pat string) *Pattern {
+	return newWithMethods(pat, "OPTIONS")
+}
+
+/*
+Patch returns a Pat route that only matches the PATCH HTTP method.
+*/
+func Patch(pat string) *Pattern {
+	return newWithMethods(pat, "PATCH")
+}
+
+/*
+Post returns a Pat route that only matches the POST HTTP method.
+*/
+func Post(pat string) *Pattern {
+	return newWithMethods(pat, "POST")
+}
+
+/*
+Put returns a Pat route that only matches the PUT HTTP method.
+*/
+func Put(pat string) *Pattern {
+	return newWithMethods(pat, "PUT")
+}

--- a/vendor/goji.io/pat/pat.go
+++ b/vendor/goji.io/pat/pat.go
@@ -1,0 +1,302 @@
+/*
+Package pat is a URL-matching domain-specific language for Goji.
+
+
+Quick Reference
+
+The following table gives an overview of the language this package accepts. See
+the subsequent sections for a more detailed explanation of what each pattern
+does.
+
+	Pattern			Matches			Does Not Match
+
+	/			/			/hello
+
+	/hello			/hello			/hi
+							/hello/
+
+	/user/:name		/user/carl		/user/carl/photos
+				/user/alice		/user/carl/
+							/user/
+
+	/:file.:ext		/data.json		/.json
+				/info.txt		/data.
+				/data.tar.gz		/data.json/download
+
+	/user/*			/user/			/user
+				/user/carl
+				/user/carl/photos
+
+
+Static Paths
+
+Most URL paths may be specified directly: the pattern "/hello" matches URLs with
+precisely that path ("/hello/", for instance, is treated as distinct).
+
+Note that this package operates on raw (i.e., escaped) paths (see the
+documentation for net/url.URL.EscapedPath). In order to match a character that
+can appear escaped in a URL path, use its percent-encoded form.
+
+
+Named Matches
+
+Named matches allow URL paths to contain any value in a particular path segment.
+Such matches are denoted by a leading ":", for example ":name" in the rule
+"/user/:name", and permit any non-empty value in that position. For instance, in
+the previous "/user/:name" example, the path "/user/carl" is matched, while
+"/user/" or "/user/carl/" (note the trailing slash) are not matched. Pat rules
+can contain any number of named matches.
+
+Named matches set URL variables by comparing pattern names to the segments they
+matched. In our "/user/:name" example, a request for "/user/carl" would bind the
+"name" variable to the value "carl". Use the Param function to extract these
+variables from the request context. Variable names in a single pattern must be
+unique.
+
+Matches are ordinarily delimited by slashes ("/"), but several other characters
+are accepted as delimiters (with slightly different semantics): the period
+("."), semicolon (";"), and comma (",") characters. For instance, given the
+pattern "/:file.:ext", the request "/data.json" would match, binding "file" to
+"data" and "ext" to "json". Note that these special characters are treated
+slightly differently than slashes: the above pattern also matches the path
+"/data.tar.gz", with "ext" getting set to "tar.gz"; and the pattern "/:file"
+matches names with dots in them (like "data.json").
+
+
+Prefix Matches
+
+Pat can also match prefixes of routes using wildcards. Prefix wildcard routes
+end with "/*", and match just the path segments preceding the asterisk. For
+instance, the pattern "/user/*" will match "/user/" and "/user/carl/photos" but
+not "/user" (note the lack of a trailing slash).
+
+The unmatched suffix, including the leading slash ("/"), are placed into the
+request context, which allows subsequent routing (e.g., a subrouter) to continue
+from where this pattern left off. For instance, in the "/user/*" pattern from
+above, a request for "/user/carl/photos" will consume the "/user" prefix,
+leaving the path "/carl/photos" for subsequent patterns to handle. A subrouter
+pattern for "/:name/photos" would match this remaining path segment, for
+instance.
+*/
+package pat
+
+import (
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"goji.io/pattern"
+	"golang.org/x/net/context"
+)
+
+type patNames []struct {
+	name pattern.Variable
+	idx  int
+}
+
+func (p patNames) Len() int {
+	return len(p)
+}
+func (p patNames) Less(i, j int) bool {
+	return p[i].name < p[j].name
+}
+func (p patNames) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+/*
+Pattern implements goji.Pattern using a path-matching domain specific language.
+See the package documentation for more information about the semantics of this
+object.
+*/
+type Pattern struct {
+	raw     string
+	methods map[string]struct{}
+	// These are parallel arrays of each pattern string (sans ":"), the
+	// breaks each expect afterwords (used to support e.g., "." dividers),
+	// and the string literals in between every pattern. There is always one
+	// more literal than pattern, and they are interleaved like this:
+	// <literal> <pattern> <literal> <pattern> <literal> etc...
+	pats     patNames
+	breaks   []byte
+	literals []string
+	wildcard bool
+}
+
+// "Break characters" are characters that can end patterns. They are not allowed
+// to appear in pattern names. "/" was chosen because it is the standard path
+// separator, and "." was chosen because it often delimits file extensions. ";"
+// and "," were chosen because Section 3.3 of RFC 3986 suggests their use.
+const bc = "/.;,"
+
+var patternRe = regexp.MustCompile(`[` + bc + `]:([^` + bc + `]+)`)
+
+/*
+New returns a new Pattern from the given Pat route. See the package
+documentation for more information about what syntax is accepted by this
+function.
+*/
+func New(pat string) *Pattern {
+	p := &Pattern{raw: pat}
+
+	if strings.HasSuffix(pat, "/*") {
+		pat = pat[:len(pat)-1]
+		p.wildcard = true
+	}
+
+	matches := patternRe.FindAllStringSubmatchIndex(pat, -1)
+	numMatches := len(matches)
+	p.pats = make(patNames, numMatches)
+	p.breaks = make([]byte, numMatches)
+	p.literals = make([]string, numMatches+1)
+
+	n := 0
+	for i, match := range matches {
+		a, b := match[2], match[3]
+		p.literals[i] = pat[n : a-1] // Need to leave off the colon
+		p.pats[i].name = pattern.Variable(pat[a:b])
+		p.pats[i].idx = i
+		if b == len(pat) {
+			p.breaks[i] = '/'
+		} else {
+			p.breaks[i] = pat[b]
+		}
+		n = b
+	}
+	p.literals[numMatches] = pat[n:]
+
+	sort.Sort(p.pats)
+
+	return p
+}
+
+func newWithMethods(pat string, methods ...string) *Pattern {
+	p := New(pat)
+
+	methodSet := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		methodSet[method] = struct{}{}
+	}
+	p.methods = methodSet
+
+	return p
+}
+
+/*
+Match runs the Pat pattern on the given request, returning a non-nil context if
+the request matches the request.
+
+This function satisfies goji.Pattern.
+*/
+func (p *Pattern) Match(ctx context.Context, r *http.Request) context.Context {
+	if p.methods != nil {
+		if _, ok := p.methods[r.Method]; !ok {
+			return nil
+		}
+	}
+
+	// Check Path
+	path := pattern.Path(ctx)
+	var scratch []string
+	if p.wildcard {
+		scratch = make([]string, len(p.pats)+1)
+	} else if len(p.pats) > 0 {
+		scratch = make([]string, len(p.pats))
+	}
+
+	for i := range p.pats {
+		sli := p.literals[i]
+		if !strings.HasPrefix(path, sli) {
+			return nil
+		}
+		path = path[len(sli):]
+
+		m := 0
+		bc := p.breaks[i]
+		for ; m < len(path); m++ {
+			if path[m] == bc || path[m] == '/' {
+				break
+			}
+		}
+		if m == 0 {
+			// Empty strings are not matches, otherwise routes like
+			// "/:foo" would match the path "/"
+			return nil
+		}
+		scratch[i] = path[:m]
+		path = path[m:]
+	}
+
+	// There's exactly one more literal than pat.
+	tail := p.literals[len(p.pats)]
+	if p.wildcard {
+		if !strings.HasPrefix(path, tail) {
+			return nil
+		}
+		scratch[len(p.pats)] = path[len(tail)-1:]
+	} else if path != tail {
+		return nil
+	}
+
+	for i := range p.pats {
+		var err error
+		scratch[i], err = unescape(scratch[i])
+		if err != nil {
+			// If we encounter an encoding error here, there's
+			// really not much we can do about it with our current
+			// API, and I'm not really interested in supporting
+			// clients that misencode URLs anyways.
+			return nil
+		}
+	}
+
+	return &match{ctx, p, scratch}
+}
+
+/*
+PathPrefix returns a string prefix that the Paths of all requests that this
+Pattern accepts must contain.
+
+This function satisfies goji's PathPrefix Pattern optimization.
+*/
+func (p *Pattern) PathPrefix() string {
+	return p.literals[0]
+}
+
+/*
+HTTPMethods returns a set of HTTP methods that all requests that this
+Pattern matches must be in, or nil if it's not possible to determine
+which HTTP methods might be matched.
+
+This function satisfies goji's HTTPMethods Pattern optimization.
+*/
+func (p *Pattern) HTTPMethods() map[string]struct{} {
+	return p.methods
+}
+
+/*
+String returns the pattern string that was used to create this Pattern.
+*/
+func (p *Pattern) String() string {
+	return p.raw
+}
+
+/*
+Param returns the bound parameter with the given name. For instance, given the
+route:
+
+	/user/:name
+
+and the URL Path:
+
+	/user/carl
+
+a call to Param(ctx, "name") would return the string "carl". It is the caller's
+responsibility to ensure that the variable has been bound. Attempts to access
+variables that have not been set (or which have been invalidly set) are
+considered programmer errors and will trigger a panic.
+*/
+func Param(ctx context.Context, name string) string {
+	return ctx.Value(pattern.Variable(name)).(string)
+}

--- a/vendor/goji.io/pat/url.go
+++ b/vendor/goji.io/pat/url.go
@@ -1,0 +1,70 @@
+package pat
+
+import "net/url"
+
+// Stolen (with modifications) from net/url in the Go stdlib
+
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+func unescape(s string) (string, error) {
+	// Count %, check that they're well-formed.
+	n := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			n++
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				s = s[i:]
+				if len(s) > 3 {
+					s = s[:3]
+				}
+				return "", url.EscapeError(s)
+			}
+			i += 3
+		default:
+			i++
+		}
+	}
+
+	if n == 0 {
+		return s, nil
+	}
+
+	t := make([]byte, len(s)-2*n)
+	j := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			t[j] = unhex(s[i+1])<<4 | unhex(s[i+2])
+			j++
+			i += 3
+		default:
+			t[j] = s[i]
+			j++
+			i++
+		}
+	}
+	return string(t), nil
+}

--- a/vendor/goji.io/pattern.go
+++ b/vendor/goji.io/pattern.go
@@ -1,0 +1,13 @@
+package goji
+
+// httpMethods is an internal interface for the HTTPMethods pattern
+// optimization. See the documentation on Pattern for more.
+type httpMethods interface {
+	HTTPMethods() map[string]struct{}
+}
+
+// pathPrefix is an internal interface for the PathPrefix pattern optimization.
+// See the documentation on Pattern for more.
+type pathPrefix interface {
+	PathPrefix() string
+}

--- a/vendor/goji.io/pattern/pattern.go
+++ b/vendor/goji.io/pattern/pattern.go
@@ -1,0 +1,66 @@
+/*
+Package pattern contains utilities for Goji Pattern authors.
+
+Goji users should not import this package. Instead, use the utilities provided
+by your Pattern package. If you are looking for an implementation of Pattern,
+try Goji's pat subpackage, which contains a simple domain specific language for
+specifying routes.
+
+For Pattern authors, use of this subpackage is entirely optional. Nevertheless,
+authors who wish to take advantage of Goji's PathPrefix optimization or who wish
+to standardize on a few common interfaces may find this package useful.
+*/
+package pattern
+
+import (
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+/*
+Variable is a standard type for the names of Pattern-bound variables, e.g.
+variables extracted from the URL. Pass the name of a variable, cast to this
+type, to context.Context.Value to retrieve the value bound to that name.
+*/
+type Variable string
+
+type allVariables struct{}
+
+/*
+AllVariables is a standard value which, when passed to context.Context.Value,
+returns all variable bindings present in the context, with bindings in newer
+contexts overriding values deeper in the stack. The concrete type
+
+	map[Variable]interface{}
+
+is used for this purpose. If no variables are bound, nil should be returned
+instead of an empty map.
+*/
+var AllVariables = allVariables{}
+
+/*
+Path returns the path that the Goji router uses to perform the PathPrefix
+optimization. While this function does not distinguish between the absence of a
+path and an empty path, Goji will automatically extract a path from the request
+if none is present.
+
+By convention, paths are stored in their escaped form (i.e., the value returned
+by net/url.URL.EscapedPath, and not URL.Path) to ensure that Patterns have as
+much discretion as possible (e.g., to behave differently for '/' and '%2f').
+*/
+func Path(ctx context.Context) string {
+	pi := ctx.Value(internal.Path)
+	if pi == nil {
+		return ""
+	}
+	return pi.(string)
+}
+
+/*
+SetPath returns a new context in which the given path is used by the Goji Router
+when performing the PathPrefix optimization. See Path for more information about
+the intended semantics of this path.
+*/
+func SetPath(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, internal.Path, path)
+}

--- a/vendor/goji.io/router.go
+++ b/vendor/goji.io/router.go
@@ -1,0 +1,25 @@
+package goji
+
+import (
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+type match struct {
+	context.Context
+	p Pattern
+	h Handler
+}
+
+func (m match) Value(key interface{}) interface{} {
+	switch key {
+	case internal.Pattern:
+		return m.p
+	case internal.Handler:
+		return m.h
+	default:
+		return m.Context.Value(key)
+	}
+}
+
+var _ context.Context = match{}

--- a/vendor/goji.io/router_simple.go
+++ b/vendor/goji.io/router_simple.go
@@ -1,0 +1,33 @@
+// +build goji_router_simple
+
+package goji
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+/*
+This is the simplest correct router implementation for Goji.
+*/
+
+type router []route
+
+type route struct {
+	Pattern
+	Handler
+}
+
+func (rt *router) add(p Pattern, h Handler) {
+	*rt = append(*rt, route{p, h})
+}
+
+func (rt *router) route(ctx context.Context, r *http.Request) context.Context {
+	for _, route := range *rt {
+		if ctx := route.Match(ctx, r); ctx != nil {
+			return &match{ctx, route.Pattern, route.Handler}
+		}
+	}
+	return &match{Context: ctx}
+}

--- a/vendor/goji.io/router_trie.go
+++ b/vendor/goji.io/router_trie.go
@@ -1,0 +1,172 @@
+// +build !goji_router_simple
+
+package goji
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"goji.io/internal"
+	"golang.org/x/net/context"
+)
+
+type router struct {
+	routes   []route
+	methods  map[string]*trieNode
+	wildcard trieNode
+}
+
+type route struct {
+	Pattern
+	Handler
+}
+
+type child struct {
+	prefix string
+	node   *trieNode
+}
+
+type trieNode struct {
+	routes   []int
+	children []child
+}
+
+func (rt *router) add(p Pattern, h Handler) {
+	i := len(rt.routes)
+	rt.routes = append(rt.routes, route{p, h})
+
+	var prefix string
+	if pp, ok := p.(pathPrefix); ok {
+		prefix = pp.PathPrefix()
+	}
+
+	var methods map[string]struct{}
+	if hm, ok := p.(httpMethods); ok {
+		methods = hm.HTTPMethods()
+	}
+	if methods == nil {
+		rt.wildcard.add(prefix, i)
+		for _, sub := range rt.methods {
+			sub.add(prefix, i)
+		}
+	} else {
+		if rt.methods == nil {
+			rt.methods = make(map[string]*trieNode)
+		}
+
+		for method := range methods {
+			if _, ok := rt.methods[method]; !ok {
+				rt.methods[method] = rt.wildcard.clone()
+			}
+			rt.methods[method].add(prefix, i)
+		}
+	}
+}
+
+func (rt *router) route(ctx context.Context, r *http.Request) context.Context {
+	tn := &rt.wildcard
+	if tn2, ok := rt.methods[r.Method]; ok {
+		tn = tn2
+	}
+
+	path := ctx.Value(internal.Path).(string)
+	for path != "" {
+		i := sort.Search(len(tn.children), func(i int) bool {
+			return path[0] <= tn.children[i].prefix[0]
+		})
+		if i == len(tn.children) || !strings.HasPrefix(path, tn.children[i].prefix) {
+			break
+		}
+
+		path = path[len(tn.children[i].prefix):]
+		tn = tn.children[i].node
+	}
+	for _, i := range tn.routes {
+		if ctx := rt.routes[i].Match(ctx, r); ctx != nil {
+			return &match{ctx, rt.routes[i].Pattern, rt.routes[i].Handler}
+		}
+	}
+	return &match{Context: ctx}
+}
+
+// We can be a teensy bit more efficient here: we're maintaining a sorted list,
+// so we know exactly where to insert the new element. But since that involves
+// more bookkeeping and makes the code messier, let's cross that bridge when we
+// come to it.
+type byPrefix []child
+
+func (b byPrefix) Len() int {
+	return len(b)
+}
+func (b byPrefix) Less(i, j int) bool {
+	return b[i].prefix < b[j].prefix
+}
+func (b byPrefix) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func longestPrefix(a, b string) string {
+	mlen := len(a)
+	if len(b) < mlen {
+		mlen = len(b)
+	}
+	for i := 0; i < mlen; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:mlen]
+}
+
+func (tn *trieNode) add(prefix string, idx int) {
+	if len(prefix) == 0 {
+		tn.routes = append(tn.routes, idx)
+		for i := range tn.children {
+			tn.children[i].node.add(prefix, idx)
+		}
+		return
+	}
+
+	ch := prefix[0]
+	i := sort.Search(len(tn.children), func(i int) bool {
+		return ch <= tn.children[i].prefix[0]
+	})
+
+	if i == len(tn.children) || ch != tn.children[i].prefix[0] {
+		routes := append([]int(nil), tn.routes...)
+		tn.children = append(tn.children, child{
+			prefix: prefix,
+			node:   &trieNode{routes: append(routes, idx)},
+		})
+	} else {
+		lp := longestPrefix(prefix, tn.children[i].prefix)
+
+		if tn.children[i].prefix == lp {
+			tn.children[i].node.add(prefix[len(lp):], idx)
+			return
+		}
+
+		split := new(trieNode)
+		split.children = []child{
+			{tn.children[i].prefix[len(lp):], tn.children[i].node},
+		}
+		split.routes = append([]int(nil), tn.routes...)
+		split.add(prefix[len(lp):], idx)
+
+		tn.children[i].prefix = lp
+		tn.children[i].node = split
+	}
+
+	sort.Sort(byPrefix(tn.children))
+}
+
+func (tn *trieNode) clone() *trieNode {
+	clone := new(trieNode)
+	clone.routes = append(clone.routes, tn.routes...)
+	clone.children = append(clone.children, tn.children...)
+	for i := range clone.children {
+		clone.children[i].node = tn.children[i].node.clone()
+	}
+	return clone
+}

--- a/vendor/golang.org/x/net/LICENSE
+++ b/vendor/golang.org/x/net/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/net/PATENTS
+++ b/vendor/golang.org/x/net/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/net/context/context.go
+++ b/vendor/golang.org/x/net/context/context.go
@@ -1,0 +1,156 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package context defines the Context type, which carries deadlines,
+// cancelation signals, and other request-scoped values across API boundaries
+// and between processes.
+//
+// Incoming requests to a server should create a Context, and outgoing calls to
+// servers should accept a Context.  The chain of function calls between must
+// propagate the Context, optionally replacing it with a modified copy created
+// using WithDeadline, WithTimeout, WithCancel, or WithValue.
+//
+// Programs that use Contexts should follow these rules to keep interfaces
+// consistent across packages and enable static analysis tools to check context
+// propagation:
+//
+// Do not store Contexts inside a struct type; instead, pass a Context
+// explicitly to each function that needs it.  The Context should be the first
+// parameter, typically named ctx:
+//
+// 	func DoSomething(ctx context.Context, arg Arg) error {
+// 		// ... use ctx ...
+// 	}
+//
+// Do not pass a nil Context, even if a function permits it.  Pass context.TODO
+// if you are unsure about which Context to use.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+//
+// The same Context may be passed to functions running in different goroutines;
+// Contexts are safe for simultaneous use by multiple goroutines.
+//
+// See http://blog.golang.org/context for example code for a server that uses
+// Contexts.
+package context // import "golang.org/x/net/context"
+
+import "time"
+
+// A Context carries a deadline, a cancelation signal, and other values across
+// API boundaries.
+//
+// Context's methods may be called by multiple goroutines simultaneously.
+type Context interface {
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled.  Deadline returns ok==false when no deadline is
+	// set.  Successive calls to Deadline return the same results.
+	Deadline() (deadline time.Time, ok bool)
+
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled.  Done may return nil if this context can
+	// never be canceled.  Successive calls to Done return the same value.
+	//
+	// WithCancel arranges for Done to be closed when cancel is called;
+	// WithDeadline arranges for Done to be closed when the deadline
+	// expires; WithTimeout arranges for Done to be closed when the timeout
+	// elapses.
+	//
+	// Done is provided for use in select statements:
+	//
+	//  // Stream generates values with DoSomething and sends them to out
+	//  // until DoSomething returns an error or ctx.Done is closed.
+	//  func Stream(ctx context.Context, out chan<- Value) error {
+	//  	for {
+	//  		v, err := DoSomething(ctx)
+	//  		if err != nil {
+	//  			return err
+	//  		}
+	//  		select {
+	//  		case <-ctx.Done():
+	//  			return ctx.Err()
+	//  		case out <- v:
+	//  		}
+	//  	}
+	//  }
+	//
+	// See http://blog.golang.org/pipelines for more examples of how to use
+	// a Done channel for cancelation.
+	Done() <-chan struct{}
+
+	// Err returns a non-nil error value after Done is closed.  Err returns
+	// Canceled if the context was canceled or DeadlineExceeded if the
+	// context's deadline passed.  No other values for Err are defined.
+	// After Done is closed, successive calls to Err return the same value.
+	Err() error
+
+	// Value returns the value associated with this context for key, or nil
+	// if no value is associated with key.  Successive calls to Value with
+	// the same key returns the same result.
+	//
+	// Use context values only for request-scoped data that transits
+	// processes and API boundaries, not for passing optional parameters to
+	// functions.
+	//
+	// A key identifies a specific value in a Context.  Functions that wish
+	// to store values in Context typically allocate a key in a global
+	// variable then use that key as the argument to context.WithValue and
+	// Context.Value.  A key can be any type that supports equality;
+	// packages should define keys as an unexported type to avoid
+	// collisions.
+	//
+	// Packages that define a Context key should provide type-safe accessors
+	// for the values stores using that key:
+	//
+	// 	// Package user defines a User type that's stored in Contexts.
+	// 	package user
+	//
+	// 	import "golang.org/x/net/context"
+	//
+	// 	// User is the type of value stored in the Contexts.
+	// 	type User struct {...}
+	//
+	// 	// key is an unexported type for keys defined in this package.
+	// 	// This prevents collisions with keys defined in other packages.
+	// 	type key int
+	//
+	// 	// userKey is the key for user.User values in Contexts.  It is
+	// 	// unexported; clients use user.NewContext and user.FromContext
+	// 	// instead of using this key directly.
+	// 	var userKey key = 0
+	//
+	// 	// NewContext returns a new Context that carries value u.
+	// 	func NewContext(ctx context.Context, u *User) context.Context {
+	// 		return context.WithValue(ctx, userKey, u)
+	// 	}
+	//
+	// 	// FromContext returns the User value stored in ctx, if any.
+	// 	func FromContext(ctx context.Context) (*User, bool) {
+	// 		u, ok := ctx.Value(userKey).(*User)
+	// 		return u, ok
+	// 	}
+	Value(key interface{}) interface{}
+}
+
+// Background returns a non-nil, empty Context. It is never canceled, has no
+// values, and has no deadline.  It is typically used by the main function,
+// initialization, and tests, and as the top-level Context for incoming
+// requests.
+func Background() Context {
+	return background
+}
+
+// TODO returns a non-nil, empty Context.  Code should use context.TODO when
+// it's unclear which Context to use or it is not yet available (because the
+// surrounding function has not yet been extended to accept a Context
+// parameter).  TODO is recognized by static analysis tools that determine
+// whether Contexts are propagated correctly in a program.
+func TODO() Context {
+	return todo
+}
+
+// A CancelFunc tells an operation to abandon its work.
+// A CancelFunc does not wait for the work to stop.
+// After the first call, subsequent calls to a CancelFunc do nothing.
+type CancelFunc func()

--- a/vendor/golang.org/x/net/context/go17.go
+++ b/vendor/golang.org/x/net/context/go17.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package context
+
+import (
+	"context" // standard library's context, as of Go 1.7
+	"time"
+)
+
+var (
+	todo       = context.TODO()
+	background = context.Background()
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = context.Canceled
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = context.DeadlineExceeded
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	ctx, f := context.WithCancel(parent)
+	return ctx, CancelFunc(f)
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d.  If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent.  The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	ctx, f := context.WithDeadline(parent, deadline)
+	return ctx, CancelFunc(f)
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return context.WithValue(parent, key, val)
+}

--- a/vendor/golang.org/x/net/context/pre_go17.go
+++ b/vendor/golang.org/x/net/context/pre_go17.go
@@ -1,0 +1,300 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package context
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// An emptyCtx is never canceled, has no values, and has no deadline.  It is not
+// struct{}, since vars of this type must have distinct addresses.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	switch e {
+	case background:
+		return "context.Background"
+	case todo:
+		return "context.TODO"
+	}
+	return "unknown empty Context"
+}
+
+var (
+	background = new(emptyCtx)
+	todo       = new(emptyCtx)
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = errors.New("context canceled")
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = errors.New("context deadline exceeded")
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	c := newCancelCtx(parent)
+	propagateCancel(parent, c)
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// newCancelCtx returns an initialized cancelCtx.
+func newCancelCtx(parent Context) *cancelCtx {
+	return &cancelCtx{
+		Context: parent,
+		done:    make(chan struct{}),
+	}
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent Context, child canceler) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	if p, ok := parentCancelCtx(parent); ok {
+		p.mu.Lock()
+		if p.err != nil {
+			// parent has already been canceled
+			child.cancel(false, p.err)
+		} else {
+			if p.children == nil {
+				p.children = make(map[canceler]bool)
+			}
+			p.children[child] = true
+		}
+		p.mu.Unlock()
+	} else {
+		go func() {
+			select {
+			case <-parent.Done():
+				child.cancel(false, parent.Err())
+			case <-child.Done():
+			}
+		}()
+	}
+}
+
+// parentCancelCtx follows a chain of parent references until it finds a
+// *cancelCtx.  This function understands how each of the concrete types in this
+// package represents its parent.
+func parentCancelCtx(parent Context) (*cancelCtx, bool) {
+	for {
+		switch c := parent.(type) {
+		case *cancelCtx:
+			return c, true
+		case *timerCtx:
+			return c.cancelCtx, true
+		case *valueCtx:
+			parent = c.Context
+		default:
+			return nil, false
+		}
+	}
+}
+
+// removeChild removes a context from its parent.
+func removeChild(parent Context, child canceler) {
+	p, ok := parentCancelCtx(parent)
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	if p.children != nil {
+		delete(p.children, child)
+	}
+	p.mu.Unlock()
+}
+
+// A canceler is a context type that can be canceled directly.  The
+// implementations are *cancelCtx and *timerCtx.
+type canceler interface {
+	cancel(removeFromParent bool, err error)
+	Done() <-chan struct{}
+}
+
+// A cancelCtx can be canceled.  When canceled, it also cancels any children
+// that implement canceler.
+type cancelCtx struct {
+	Context
+
+	done chan struct{} // closed by the first cancel call.
+
+	mu       sync.Mutex
+	children map[canceler]bool // set to nil by the first cancel call
+	err      error             // set to non-nil by the first cancel call
+}
+
+func (c *cancelCtx) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *cancelCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *cancelCtx) String() string {
+	return fmt.Sprintf("%v.WithCancel", c.Context)
+}
+
+// cancel closes c.done, cancels each of c's children, and, if
+// removeFromParent is true, removes c from its parent's children.
+func (c *cancelCtx) cancel(removeFromParent bool, err error) {
+	if err == nil {
+		panic("context: internal error: missing cancel error")
+	}
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	for child := range c.children {
+		// NOTE: acquiring the child's lock while holding parent's lock.
+		child.cancel(false, err)
+	}
+	c.children = nil
+	c.mu.Unlock()
+
+	if removeFromParent {
+		removeChild(c.Context, c)
+	}
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d.  If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent.  The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return WithCancel(parent)
+	}
+	c := &timerCtx{
+		cancelCtx: newCancelCtx(parent),
+		deadline:  deadline,
+	}
+	propagateCancel(parent, c)
+	d := deadline.Sub(time.Now())
+	if d <= 0 {
+		c.cancel(true, DeadlineExceeded) // deadline has already passed
+		return c, func() { c.cancel(true, Canceled) }
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err == nil {
+		c.timer = time.AfterFunc(d, func() {
+			c.cancel(true, DeadlineExceeded)
+		})
+	}
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// A timerCtx carries a timer and a deadline.  It embeds a cancelCtx to
+// implement Done and Err.  It implements cancel by stopping its timer then
+// delegating to cancelCtx.cancel.
+type timerCtx struct {
+	*cancelCtx
+	timer *time.Timer // Under cancelCtx.mu.
+
+	deadline time.Time
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) {
+	return c.deadline, true
+}
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("%v.WithDeadline(%s [%s])", c.cancelCtx.Context, c.deadline, c.deadline.Sub(time.Now()))
+}
+
+func (c *timerCtx) cancel(removeFromParent bool, err error) {
+	c.cancelCtx.cancel(false, err)
+	if removeFromParent {
+		// Remove this timerCtx from its parent cancelCtx's children.
+		removeChild(c.cancelCtx.Context, c)
+	}
+	c.mu.Lock()
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.mu.Unlock()
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return &valueCtx{parent, key, val}
+}
+
+// A valueCtx carries a key-value pair.  It implements Value for that key and
+// delegates all other calls to the embedded Context.
+type valueCtx struct {
+	Context
+	key, val interface{}
+}
+
+func (c *valueCtx) String() string {
+	return fmt.Sprintf("%v.WithValue(%#v, %#v)", c.Context, c.key, c.val)
+}
+
+func (c *valueCtx) Value(key interface{}) interface{} {
+	if c.key == key {
+		return c.val
+	}
+	return c.Context.Value(key)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -59,6 +59,54 @@
 			"revisionTime": "2016-02-25T15:03:13Z"
 		},
 		{
+			"checksumSHA1": "T9J7FOCeCaD5q8T2v+72WtRq2ds=",
+			"path": "github.com/zenazn/goji/bind",
+			"revision": "64eb34159fe53473206c2b3e70fe396a639452f2",
+			"revisionTime": "2016-05-07T20:19:45Z"
+		},
+		{
+			"checksumSHA1": "VlmqBl1j3cULPU18lMBXNf+IHY8=",
+			"path": "github.com/zenazn/goji/graceful",
+			"revision": "64eb34159fe53473206c2b3e70fe396a639452f2",
+			"revisionTime": "2016-05-07T20:19:45Z"
+		},
+		{
+			"checksumSHA1": "caN0mgXEzfd0w9rhUsppkUUUCns=",
+			"path": "github.com/zenazn/goji/graceful/listener",
+			"revision": "64eb34159fe53473206c2b3e70fe396a639452f2",
+			"revisionTime": "2016-05-07T20:19:45Z"
+		},
+		{
+			"checksumSHA1": "mOUDsWfYLlh8f6ekwyIUo3+4xJI=",
+			"path": "goji.io",
+			"revision": "e355964ac565b94cf0fc7f218346626529125086",
+			"revisionTime": "2016-05-07T21:13:57Z"
+		},
+		{
+			"checksumSHA1": "Jf3C/refSMB2wVYGp1pssKXVNcI=",
+			"path": "goji.io/internal",
+			"revision": "e355964ac565b94cf0fc7f218346626529125086",
+			"revisionTime": "2016-05-07T21:13:57Z"
+		},
+		{
+			"checksumSHA1": "gHp/Mv7vgZWs7iq/F0YHnWgEotQ=",
+			"path": "goji.io/pat",
+			"revision": "e355964ac565b94cf0fc7f218346626529125086",
+			"revisionTime": "2016-05-07T21:13:57Z"
+		},
+		{
+			"checksumSHA1": "z2zVlHamw4ufyuSaf49reuusrmg=",
+			"path": "goji.io/pattern",
+			"revision": "e355964ac565b94cf0fc7f218346626529125086",
+			"revisionTime": "2016-05-07T21:13:57Z"
+		},
+		{
+			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
+			"path": "golang.org/x/net/context",
+			"revision": "8e573f4005aa312856df2ea97c32b9beac70dd89",
+			"revisionTime": "2016-06-29T18:55:36Z"
+		},
+		{
 			"checksumSHA1": "oBKY8LJtCoSvmYA4ADFDY02A8NY=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03",


### PR DESCRIPTION
We're probably going to be doing more things over http in this service, so we have to start by adding einhorn support to it. I only added a `/healthcheck` route since that's the trivial part. The route I actually want to implement will come later, but this is a fairly high-friction change to rollout so I wanted to minimize the up-front code impact.

cc @antifuchs @zenazn in case you have any stylistic opinions on how this should or should not be done.