### PR TITLE
Improve flush handling

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -124,7 +124,7 @@ func (s *Server) flushPart(metricSlice []DDMetric, wg *sync.WaitGroup) {
 	req.Header.Set("Content-Encoding", "deflate")
 
 	fstart := time.Now()
-	resp, err := http.DefaultClient.Do(req) // TODO: add configurable http client to server struct
+	resp, err := s.HTTPClient.Do(req)
 	if err != nil {
 		s.statsd.Count("flush.error_total", int64(len(metricSlice)), []string{"cause:io"}, 1.0)
 		s.logger.WithError(err).Error("Error writing POST request")

--- a/flusher.go
+++ b/flusher.go
@@ -83,7 +83,7 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 	wg.Wait()
 	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(flushStart).Nanoseconds()), nil, 1.0)
 
-	s.statsd.Count("flush.error_total", 0, nil, 0.1) // make sure this metric is not sparse
+	s.statsd.Count("flush.error_total", 0, nil, 1.0) // make sure this metric is not sparse
 	s.logger.WithField("metrics", len(finalMetrics)).Info("Completed flush to Datadog")
 }
 


### PR DESCRIPTION
- always report the 0 error_total, do not sample it
- use our own HTTP client with a timeout on it