### PR TITLE
Support merging sets

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -23,9 +23,9 @@ type UDPMetric struct {
 // a struct used to key the metrics into the worker's map - must only contain
 // comparable types
 type MetricKey struct {
-	Name       string
-	Type       string
-	JoinedTags string // tags in deterministic order, joined with commas
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	JoinedTags string `json:"tagstring"` // tags in deterministic order, joined with commas
 }
 
 // ParseMetric converts the incoming packet from Datadog DogStatsD

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -1,6 +1,8 @@
 package veneur
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -101,6 +103,23 @@ func TestSet(t *testing.T) {
 	assert.Len(t, m1.Tags, 1, "Tag count")
 	assert.Equal(t, "a:b", m1.Tags[0], "First tag")
 	assert.Equal(t, float64(4), m1.Value[0][1], "Value")
+}
+
+func TestSetMerge(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	s := NewSet("a.b.c", []string{"a:b"})
+	for i := 0; i < 100; i++ {
+		s.Sample(strconv.Itoa(rand.Int()), 1.0)
+	}
+	assert.Equal(t, uint64(100), s.hll.Count(), "counts did not match")
+
+	jm, err := s.Export()
+	assert.NoError(t, err, "should have exported successfully")
+
+	s2 := NewSet("a.b.c", []string{"a:b"})
+	assert.NoError(t, s2.Combine(jm.Value), "should have combined successfully")
+	assert.Equal(t, s.hll.Count(), s2.hll.Count(), "counts did not match after merging")
 }
 
 func TestHisto(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -27,3 +27,18 @@ func TestWorker(t *testing.T) {
 	nometrics := w.Flush()
 	assert.Len(t, nometrics.counters, 0, "Should flush no metrics")
 }
+
+func TestWorkerImportSet(t *testing.T) {
+	w := NewWorker(1, nil, logrus.New())
+	testset := NewSet("a.b.c", nil)
+	testset.Sample("foo", 1.0)
+	testset.Sample("bar", 1.0)
+
+	jsonMetric, err := testset.Export()
+	assert.NoError(t, err, "should have exported successfully")
+
+	w.ImportMetric(jsonMetric)
+
+	wm := w.Flush()
+	assert.Len(t, wm.sets, 1, "number of flushed sets")
+}


### PR DESCRIPTION
This adds the code to export a set into a JSON structure that can then be consumed by a worker and merged into its existing metrics. The code to actually feed things to the ImportMetric function will be added later, but it's basically going to be an extra channel in the worker's main select loop. cc @antifuchs @rhwlo in case you have opinions