### PR TITLE
Delay attaching custom tags until flush time

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -53,6 +53,7 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 	}
 	for i := range finalMetrics {
 		finalMetrics[i].Hostname = s.Hostname
+		finalMetrics[i].Tags = append(finalMetrics[i].Tags, s.Tags...)
 	}
 
 	s.statsd.Gauge("flush.post_metrics_total", float64(len(finalMetrics)), nil, 1.0)

--- a/server.go
+++ b/server.go
@@ -117,10 +117,6 @@ func (s *Server) HandlePacket(packet []byte) {
 		return
 	}
 
-	if len(s.Tags) > 0 {
-		metric.Tags = append(metric.Tags, s.Tags...)
-	}
-
 	s.Workers[metric.Digest%uint32(len(s.Workers))].WorkChan <- *metric
 }
 


### PR DESCRIPTION
see commit message

Concrete example: I have a metric named `foo` with a tag `bar`, being produced by hosts A and B. I have a local veneur running on host A, and a global veneur running on host B. Both veneurs are configured to add a tag `soupdog`.

The local veneur has a metric structure stored for the metric; the `MetricKey` for this structure has the name `foo` and the tag `bar`. However the sampler associated with that `MetricKey` has the name `foo` and two tags `bar`, `soupdog`.

Now I marshal the sampler structure and forward it to the global veneur. The global veneur has also received some copies of this metric, so it has its own sampler under the `foo`/`bar` `MetricKey`. However, the structure that it just received has a different `MetricKey` with the name `foo` and the tags `bar`, `soupdog`. So these two structures, even though they correspond to the same metric, would mistakenly be separated.

My solution is to not attach any bonus tags until the last possible moment, which is when the metric leaves veneur's control and gets sent to DataDog. If we forward to another veneur, then we won't attach any of our tags, and we'll let the global veneur decide what to do there. This is also, I think, the most intuitive behavior to explain (the winner is the last veneur to touch it, and until then the only tags attached are the ones that the client originally sent).