### PR TITLE
Remove publish_histogram_counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `interval` - How often to flush. Something like 10s seems good.
 * `key` - Your Datadog API key
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s
-* `publish_histogram_counters` - Veneur can publish a counter, `$name.count`, for how many samples a histogram has received. Note that this counter, like every other metric passing through veneur, will be attached to Veneur's own host.
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
 * `http_address` - The address to serve HTTP healthchecks and other endpoints. If you're under einhorn, you probably want `einhorn@0`.
 * `num_workers` - The number of worker goroutines to start.

--- a/config.go
+++ b/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	StatsAddr           string        `yaml:"stats_address"`
 	Tags                []string      `yaml:"tags"`
 	SentryDSN           string        `yaml:"sentry_dsn"`
-	HistCounters        bool          `yaml:"publish_histogram_counters"`
 	FlushLimit          int           `yaml:"flush_max_per_body"`
 }
 

--- a/flusher.go
+++ b/flusher.go
@@ -17,10 +17,7 @@ import (
 // for posting to Datadog.
 func (s *Server) Flush(interval time.Duration, metricLimit int) {
 	// number of ddmetrics generated when a histogram flushes
-	histogramSize := 2 + len(s.HistogramPercentiles)
-	if s.HistogramCounter {
-		histogramSize++
-	}
+	histogramSize := 3 + len(s.HistogramPercentiles)
 
 	// allocating this long array to count up the sizes is cheaper than appending
 	// the []DDMetrics together one at a time
@@ -42,13 +39,13 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 			finalMetrics = append(finalMetrics, g.Flush()...)
 		}
 		for _, h := range wm.histograms {
-			finalMetrics = append(finalMetrics, h.Flush(interval, s.HistogramPercentiles, s.HistogramCounter)...)
+			finalMetrics = append(finalMetrics, h.Flush(interval, s.HistogramPercentiles)...)
 		}
 		for _, s := range wm.sets {
 			finalMetrics = append(finalMetrics, s.Flush()...)
 		}
 		for _, t := range wm.timers {
-			finalMetrics = append(finalMetrics, t.Flush(interval, s.HistogramPercentiles, s.HistogramCounter)...)
+			finalMetrics = append(finalMetrics, t.Flush(interval, s.HistogramPercentiles)...)
 		}
 	}
 	for i := range finalMetrics {

--- a/samplers.go
+++ b/samplers.go
@@ -192,10 +192,9 @@ func NewHist(name string, tags []string) *Histo {
 	}
 }
 
-// Flush generates DDMetrics for the current state of the Histo. counter indicates
-// whether to include the histogram's built-in counter, and percentiles indicates
-// what percentiles should be exported from the histogram.
-func (h *Histo) Flush(interval time.Duration, percentiles []float64, counter bool) []DDMetric {
+// Flush generates DDMetrics for the current state of the Histo. percentiles
+// indicates what percentiles should be exported from the histogram.
+func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric {
 	now := float64(time.Now().Unix())
 	rate := float64(h.count) / interval.Seconds()
 	metrics := make([]DDMetric, 0, 3+len(percentiles))
@@ -213,16 +212,14 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, counter boo
 			Tags:       h.tags,
 			MetricType: "gauge",
 		},
-	)
-	if counter {
-		metrics = append(metrics, DDMetric{
+		DDMetric{
 			Name:       fmt.Sprintf("%s.count", h.name),
 			Value:      [1][2]float64{{now, rate}},
 			Tags:       h.tags,
 			MetricType: "rate",
 			Interval:   int32(interval.Seconds()),
-		})
-	}
+		},
+	)
 
 	for _, p := range percentiles {
 		metrics = append(

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -136,7 +136,7 @@ func TestHisto(t *testing.T) {
 	h.Sample(20, 1.0)
 	h.Sample(25, 1.0)
 
-	metrics := h.Flush(10*time.Second, []float64{0.50}, true)
+	metrics := h.Flush(10*time.Second, []float64{0.50})
 	// We get lots of metrics back for histograms!
 	assert.Len(t, metrics, 4, "Flushed metrics length")
 
@@ -181,19 +181,6 @@ func TestHisto(t *testing.T) {
 	assert.Equal(t, float64(15), m4.Value[0][1], "Value")
 }
 
-func TestHistoWithoutCount(t *testing.T) {
-	h := NewHist("a.b.c", []string{"a:b"})
-
-	h.Sample(5, 0.5)
-	h.Sample(10, 0.5)
-	h.Sample(15, 0.5)
-	h.Sample(20, 0.5)
-	h.Sample(25, 0.5)
-
-	metrics := h.Flush(10*time.Second, []float64{0.50}, false)
-	assert.Len(t, metrics, 3, "Metrics flush length")
-}
-
 func TestHistoSampleRate(t *testing.T) {
 
 	h := NewHist("a.b.c", []string{"a:b"})
@@ -208,7 +195,7 @@ func TestHistoSampleRate(t *testing.T) {
 	h.Sample(20, 0.5)
 	h.Sample(25, 0.5)
 
-	metrics := h.Flush(10*time.Second, []float64{0.50}, true)
+	metrics := h.Flush(10*time.Second, []float64{0.50})
 	assert.Len(t, metrics, 4, "Metrics flush length")
 
 	// First the max

--- a/server.go
+++ b/server.go
@@ -32,7 +32,6 @@ type Server struct {
 	RcvbufBytes int
 
 	HistogramPercentiles []float64
-	HistogramCounter     bool
 }
 
 func NewFromConfig(conf Config) (ret Server, err error) {
@@ -40,7 +39,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.Tags = conf.Tags
 	ret.DDHostname = conf.APIHostname
 	ret.DDAPIKey = conf.Key
-	ret.HistogramCounter = conf.HistCounters
 	ret.HistogramPercentiles = conf.Percentiles
 
 	ret.HTTPClient = &http.Client{


### PR DESCRIPTION
We never ended up using this path and we're probably not about to. I'd like to kill it before I start mucking with this code in more detail.