### PR TITLE
Enable multi-metric packets

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,45 @@
+package veneur
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitBytes(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	buf := make([]byte, 1000)
+
+	for i := 0; i < 1000; i++ {
+		// we construct a string of random length which is approximately 1/3rd A
+		// and the other 2/3rds B
+		buf = buf[:rand.Intn(cap(buf))]
+		for i := range buf {
+			if rand.Intn(3) == 0 {
+				buf[i] = 'A'
+			} else {
+				buf[i] = 'B'
+			}
+		}
+		checkBufferSplit(t, buf)
+		buf = buf[:cap(buf)]
+	}
+
+	// also test pathological cases that the fuzz is unlikely to find
+	checkBufferSplit(t, nil)
+	checkBufferSplit(t, []byte{})
+}
+
+func checkBufferSplit(t *testing.T, buf []byte) {
+	var testSplit [][]byte
+	sb := NewSplitBytes(buf, 'A')
+	for sb.Next() {
+		testSplit = append(testSplit, sb.Chunk())
+	}
+
+	// now compare our split to the "real" implementation of split
+	assert.EqualValues(t, bytes.Split(buf, []byte{'A'}), testSplit, "should have split %s correctly", buf)
+}


### PR DESCRIPTION
I tried pointing Veneur at itself, but we use a buffered datadog client and we ourselves don't support buffering. We could just turn buffering off (to my knowledge we don't have anything else that uses it) but I figure we might as well support this too?