### PR TITLE
Forward some metrics instead of flushing immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 
 * `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client.
 * `veneur.flush.post_metrics_total` - The total number of time-series points that will be submitted to Datadog via POST. Datadog's rate limiting is roughly proportional to this number.
-* `veneur.flush.content_length_bytes.*` - The number of bytes in a single POST body. Remember that Veneur POSTs large sets of metrics in multiple separate bodies in parallel. Uses a histogram, so there are multiple metrics generated depending on your local DogStatsD config.
-* `veneur.flush.part_duration_ns` - Time taken for the POST transaction to the Datadog API. Tagged by `part` for each sub-part `marshal` (assembling the request body) and `post` (blocking on an HTTP response from Datadog).
-* `veneur.flush.total_duration_ns` - Total time spent POSTing to Datadog, across all parallel requests. Under most circumstances, this should be roughly equal to the total `veneur.flush.part_duration_ns`. If it's not, then some of the POSTs are happening in sequence, which suggests some kind of goroutine scheduling issue.
-* `veneur.flush.error_total` - Number of metrics dropped from errors attempting to POST to Datadog. If you're getting errors POSTing, this metric tells you how much damage those errors are causing to your metrics pipeline.
+* `veneur.forward.post_metrics_total` - Indicates how many metrics are being forwarded in a given POST request. A "metric", in this context, refers to a unique combination of name, tags and metric type.
+* `veneur.*.content_length_bytes.*` - The number of bytes in a single POST body. Remember that Veneur POSTs large sets of metrics in multiple separate bodies in parallel. Uses a histogram, so there are multiple metrics generated depending on your local DogStatsD config.
+* `veneur.flush.duration_ns` - Time taken for a single POST transaction to the Datadog API. Tagged by `part` for each sub-part `marshal` (assembling the request body) and `post` (blocking on an HTTP response).
+* `veneur.forward.duration_ns` - Same as `flush.duration_ns`, but for forwarding requests.
+* `veneur.flush.total_duration_ns` - Total time spent POSTing to Datadog, across all parallel requests. Under most circumstances, this should be roughly equal to the total `veneur.flush.duration_ns`. If it's not, then some of the POSTs are happening in sequence, which suggests some kind of goroutine scheduling issue.
+* `veneur.flush.error_total` - Number of errors received POSTing to Datadog.
+* `veneur.forward.error_total` - Number of errors received POSTing to an upstream Veneur. See also `import.request_error_total` below.
 * `veneur.flush.worker_duration_ns` - Per-worker timing — tagged by `worker` - for flush. This is important as it is the time in which the worker holds a lock and is unavailable for other work.
 * `veneur.worker.metrics_processed_total` - Total number of metric packets processed between flushes by workers, tagged by `worker`. This helps you find hot spots where a single worker is handling a lot of metrics. The sum across all workers should be approximately proportional to the number of packets received.
 * `veneur.worker.metrics_flushed_total` - Total number of metrics flushed at each flush time, tagged by `metric_type`. A "metric", in this context, refers to a unique combination of name, tags and metric type. You can use this metric to detect when your clients are introducing new instrumentation, or when you acquire new clients.
@@ -38,8 +41,9 @@ Veneur assumes you have a running DogStatsD on the localhost and emits metrics t
 Veneur is currently a work in progress and thus should not yet be relied on for production traffic.
 
 # Usage
+
 ```
-venuer -f example.yaml
+veneur -f example.yaml
 ```
 
 See example.yaml for a sample config. Be sure and set your Datadog API `key`!
@@ -58,6 +62,7 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
 * `http_address` - The address to serve HTTP healthchecks and other endpoints. This can be a simple ip:port combination like `127.0.0.1:8127`. If you're under einhorn, you probably want `einhorn@0`.
+* `forward_address` - The address of an upstream Veneur to forward metrics to. See below.
 * `num_workers` - The number of worker goroutines to start.
 * `num_readers` - The number of reader goroutines to start. Veneur supports SO_REUSEPORT on Linux to scale to multiple readers. On other platforms, this should always be 1; other values will probably cause errors at startup. See below.
 * `read_buffer_size_bytes` - The size of the receive buffer for the UDP socket. Defaults to 2MB, as having a lot of buffer prevents packet drops during flush!
@@ -92,7 +97,7 @@ Veneur expires all metrics on each flush. If a metric is no longer being sent (o
 
 # Setup
 
-He're well document some explanations of setup choices you may make when using Veneur.
+Here we'll document some explanations of setup choices you may make when using Veneur.
 
 ## Einhorn Usage
 
@@ -105,6 +110,18 @@ You'll need to consult Einhorn's documentation for installation, setup and usage
 But once you've done that you can tell Veneur to use Einhorn by setting `http_address`
 to `einhorn@0`. This informs [goji/bind](https://github.com/zenazn/goji/tree/master/bind) to use it's
 Einhorn handling code to bind to the file descriptor for HTTP.
+
+## Forwarding
+
+Veneur instances can be configured to forward their global metrics to another Veneur instance. You can use this feature to get the best of both worlds: metrics that benefit from global aggregation can be passed up to a single global Veneur, but other metrics can be published locally with host-scoped information.
+
+To configure this feature, you need one Veneur, which we'll call the _global_ instance, and one or more other Veneurs, which we'll call _local_ instances. The local instances should have their `forward_address` configured to the global instance's `http_address`. The global instance should have an empty `forward_address` (ie just don't set it). You can then report metrics to any Veneur's `udp_address` as usual.
+
+If a local instance receives a histogram or set, it will publish the local parts of that metric (the count, min and max) directly to DataDog, but instead of publishing percentiles, it will package the entire histogram and send it to the global instance. The global instance will aggregate all the histograms together and publish their percentiles to DataDog.
+
+Note that the global instance can also receive metrics over UDP. It will publish a count, min and max for the samples that were sent directly to it, but not counting any samples from other Veneurs (this ensures that things don't get double-counted). You can even chain multiple levels of forwarding together if you want. This might be useful if, for example, your global Veneur is under too much load. The root of the tree will be the Veneur instance that has an empty `forward_address`. (Do not tell a Veneur instance to forward metrics to itself. We don't support that and it doesn't really make sense in the first place.)
+
+With respect to the `tags` configuration option, the tags that will be added are those of the Veneur that actually publishes to DataDog. If a local instance forwards its histograms and sets to a global instance, the local instance's tags will not be attached to the forwarded structures. It will still use its own tags for the other metrics it publishes, but the percentiles will get extra tags only from the global instance.
 
 # Performance
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Note that the global instance can also receive metrics over UDP. It will publish
 
 With respect to the `tags` configuration option, the tags that will be added are those of the Veneur that actually publishes to DataDog. If a local instance forwards its histograms and sets to a global instance, the local instance's tags will not be attached to the forwarded structures. It will still use its own tags for the other metrics it publishes, but the percentiles will get extra tags only from the global instance.
 
+If you want a metric to be strictly host-local, you can tell Veneur not to forward it by including a `veneurlocalonly` tag in the metric packet, eg `foo:1|h|#veneurlocalonly`. This tag will not actually appear in DataDog; Veneur removes it.
+
 # Performance
 
 Processing packets quickly is the name of the game.

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ReadBufferSizeBytes int           `yaml:"read_buffer_size_bytes"`
 	UDPAddr             string        `yaml:"udp_address"`
 	HTTPAddr            string        `yaml:"http_address"`
+	ForwardAddr         string        `yaml:"forward_address"`
 	NumWorkers          int           `yaml:"num_workers"`
 	NumReaders          int           `yaml:"num_readers"`
 	StatsAddr           string        `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -19,5 +19,6 @@ tags:
 #  - "baz:gorch"
 udp_address: "localhost:8126"
 http_address: "einhorn@0"
+forward_address: "http://veneur.example.com"
 # Defaults to the os.Hostname()!
 # hostname: foobar

--- a/flusher.go
+++ b/flusher.go
@@ -17,20 +17,39 @@ import (
 // Flush takes the slices of metrics, combines then and marshals them to json
 // for posting to Datadog.
 func (s *Server) Flush(interval time.Duration, metricLimit int) {
-	// number of ddmetrics generated when a histogram flushes
-	histogramSize := 3 + len(s.HistogramPercentiles)
+	percentiles := s.HistogramPercentiles
+	if s.ForwardAddr != "" {
+		// don't publish percentiles if we're a local veneur; that's the global
+		// veneur's job
+		percentiles = nil
+	}
 
 	// allocating this long array to count up the sizes is cheaper than appending
 	// the []DDMetrics together one at a time
 	tempMetrics := make([]WorkerMetrics, 0, len(s.Workers))
-	totalLength := 0
+	var (
+		totalCounters   int
+		totalGauges     int
+		totalHistograms int
+		totalSets       int
+		totalTimers     int
+	)
 	for i, w := range s.Workers {
 		s.logger.WithField("worker", i).Debug("Flushing")
 		wm := w.Flush()
 		tempMetrics = append(tempMetrics, wm)
-		totalLength += len(wm.counters) + len(wm.gauges) + len(wm.sets) + ((len(wm.timers) + len(wm.histograms)) * histogramSize)
+
+		totalCounters += len(wm.counters)
+		totalGauges += len(wm.gauges)
+		totalHistograms += len(wm.histograms)
+		totalSets += len(wm.sets)
+		totalTimers += len(wm.timers)
 	}
 
+	totalLength := totalCounters + totalGauges + (totalTimers+totalHistograms)*(HistogramLocalLength+len(percentiles))
+	if s.ForwardAddr == "" {
+		totalLength += totalSets
+	}
 	finalMetrics := make([]DDMetric, 0, totalLength)
 	for _, wm := range tempMetrics {
 		for _, c := range wm.counters {
@@ -39,19 +58,44 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 		for _, g := range wm.gauges {
 			finalMetrics = append(finalMetrics, g.Flush()...)
 		}
+		// if we're a local veneur, then percentiles=nil, and only the local
+		// parts (count, min, max) will be flushed
 		for _, h := range wm.histograms {
-			finalMetrics = append(finalMetrics, h.Flush(interval, s.HistogramPercentiles)...)
-		}
-		for _, s := range wm.sets {
-			finalMetrics = append(finalMetrics, s.Flush()...)
+			finalMetrics = append(finalMetrics, h.Flush(interval, percentiles)...)
 		}
 		for _, t := range wm.timers {
-			finalMetrics = append(finalMetrics, t.Flush(interval, s.HistogramPercentiles)...)
+			finalMetrics = append(finalMetrics, t.Flush(interval, percentiles)...)
+		}
+		if s.ForwardAddr == "" {
+			// sets have no local parts, so if we're a local veneur, there's
+			// nothing to flush at all
+			for _, s := range wm.sets {
+				finalMetrics = append(finalMetrics, s.Flush()...)
+			}
 		}
 	}
 	for i := range finalMetrics {
 		finalMetrics[i].Hostname = s.Hostname
 		finalMetrics[i].Tags = append(finalMetrics[i].Tags, s.Tags...)
+	}
+
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalCounters), []string{"metric_type:counter"}, 1.0)
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalGauges), []string{"metric_type:gauge"}, 1.0)
+	if s.ForwardAddr == "" {
+		// only report these lengths if we're the global veneur instance
+		// responsible for flushing them
+		// this avoids double-counting problems where a local veneur reports
+		// histograms that it received, and then a global veneur reports them
+		// again
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalHistograms), []string{"metric_type:histogram"}, 1.0)
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalSets), []string{"metric_type:set"}, 1.0)
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalTimers), []string{"metric_type:timer"}, 1.0)
+	}
+
+	if s.ForwardAddr != "" {
+		// we cannot do this until we're done using tempMetrics here, since
+		// not everything in tempMetrics is safe for sharing
+		go s.flushForward(tempMetrics)
 	}
 
 	s.statsd.Gauge("flush.post_metrics_total", float64(len(finalMetrics)), nil, 1.0)
@@ -82,85 +126,152 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 	wg.Wait()
 	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(flushStart).Nanoseconds()), nil, 1.0)
 
-	s.statsd.Count("flush.error_total", 0, nil, 1.0) // make sure this metric is not sparse
 	s.logger.WithField("metrics", len(finalMetrics)).Info("Completed flush to Datadog")
 }
 
 func (s *Server) flushPart(metricSlice []DDMetric, wg *sync.WaitGroup) {
 	defer wg.Done()
-
-	cstart := time.Now()
-	var reqBody bytes.Buffer
-	compressor := zlib.NewWriter(&reqBody)
-	encoder := json.NewEncoder(compressor)
-	err := encoder.Encode(map[string][]DDMetric{
+	s.postHelper(fmt.Sprintf("%s/api/v1/series?api_key=%s", s.DDHostname, s.DDAPIKey), map[string][]DDMetric{
 		"series": metricSlice,
-	})
-	if err != nil {
-		s.statsd.Count("flush.error_total", 1, []string{"cause:json"}, 1.0)
-		s.logger.WithError(err).Error("Error rendering JSON request body")
+	}, "flush")
+}
+
+func (s *Server) flushForward(wms []WorkerMetrics) {
+	jmLength := 0
+	for _, wm := range wms {
+		jmLength += len(wm.histograms)
+		jmLength += len(wm.sets)
+		jmLength += len(wm.timers)
+	}
+
+	jsonMetrics := make([]JSONMetric, 0, jmLength)
+	for _, wm := range wms {
+		for _, histo := range wm.histograms {
+			jm, err := histo.Export()
+			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"type":          "histogram",
+					"name":          histo.name,
+				}).Error("Could not export metric")
+				continue
+			}
+			jsonMetrics = append(jsonMetrics, jm)
+		}
+		for _, set := range wm.sets {
+			jm, err := set.Export()
+			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"type":          "set",
+					"name":          set.name,
+				}).Error("Could not export metric")
+				continue
+			}
+			jsonMetrics = append(jsonMetrics, jm)
+		}
+		for _, timer := range wm.timers {
+			jm, err := timer.Export()
+			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"type":          "timer",
+					"name":          timer.name,
+				}).Error("Could not export metric")
+				continue
+			}
+			jsonMetrics = append(jsonMetrics, jm)
+		}
+	}
+
+	s.statsd.Gauge("forward.post_metrics_total", float64(len(jsonMetrics)), nil, 1.0)
+	if len(jsonMetrics) == 0 {
+		s.logger.Info("Nothing to forward, skipping.")
 		return
 	}
-	// make sure to flush remaining compressed bytes to the buffer
-	compressor.Close()
-	s.statsd.TimeInMilliseconds(
-		"flush.part_duration_ns",
-		float64(time.Now().Sub(cstart).Nanoseconds()),
-		[]string{"part:marshal"},
-		1.0,
-	)
-	// Len reports the unread length, so we have to record this before it's POSTed
-	bodyLength := reqBody.Len()
-	s.statsd.Histogram("flush.content_length_bytes", float64(bodyLength), nil, 1.0)
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", s.DDHostname, s.DDAPIKey), &reqBody)
+	if s.postHelper(fmt.Sprintf("%s/import", s.ForwardAddr), jsonMetrics, "forward") == nil {
+		s.logger.WithField("metrics", len(jsonMetrics)).Info("Completed forward to upstream Veneur")
+	}
+}
+
+// shared code for POSTing to an endpoint, that consumes JSON, that is zlib-
+// compressed, that returns 202 on success, that has a small response
+// action is a string used for statsd metric names and log messages emitted from
+// this function - probably a static string for each callsite
+func (s *Server) postHelper(endpoint string, bodyObject interface{}, action string) error {
+	// attach this field to all the logs we generate
+	innerLogger := s.logger.WithField("action", action)
+
+	marshalStart := time.Now()
+	var bodyBuffer bytes.Buffer
+	compressor := zlib.NewWriter(&bodyBuffer)
+	encoder := json.NewEncoder(compressor)
+	if err := encoder.Encode(bodyObject); err != nil {
+		s.statsd.Count(action+".error_total", 1, []string{"cause:json"}, 1.0)
+		innerLogger.WithError(err).Error("Could not render JSON")
+		return err
+	}
+	// don't forget to flush leftover compressed bytes to the buffer
+	if err := compressor.Close(); err != nil {
+		s.statsd.Count(action+".error_total", 1, []string{"cause:compress"}, 1.0)
+		innerLogger.WithError(err).Error("Could not finalize compression")
+		return err
+	}
+	s.statsd.TimeInMilliseconds(action+".duration_ns", float64(time.Now().Sub(marshalStart).Nanoseconds()), []string{"part:json"}, 1.0)
+
+	// Len reports the unread length, so we have to record this before the
+	// http client consumes it
+	bodyLength := bodyBuffer.Len()
+	s.statsd.Histogram(action+".content_length_bytes", float64(bodyLength), nil, 1.0)
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, &bodyBuffer)
 	if err != nil {
-		s.statsd.Count("flush.error_total", 1, []string{"cause:construct"}, 1.0)
-		s.logger.WithError(err).Error("Error constructing POST request")
-		return
+		s.statsd.Count(action+".error_total", 1, []string{"cause:construct"}, 1.0)
+		innerLogger.WithError(err).Error("Could not construct request")
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Encoding", "deflate")
 
-	fstart := time.Now()
+	requestStart := time.Now()
 	resp, err := s.HTTPClient.Do(req)
 	if err != nil {
 		if urlErr, ok := err.(*url.Error); ok {
-			// if the error has a URL in it, retrieve the inner error and
-			// discard the URL (it contains the api key, so we cannot log it)
+			// if the error has the url in it, then retrieve the inner error
+			// and ditch the url (which might contain secrets)
 			err = urlErr.Err
 		}
-		s.statsd.Count("flush.error_total", 1, []string{"cause:io"}, 1.0)
-		s.logger.WithError(err).Error("Error writing POST request")
-		return
+		s.statsd.Count(action+".error_total", 1, []string{"cause:io"}, 1.0)
+		innerLogger.WithError(err).Error("Could not execute request")
+		return err
 	}
-	s.statsd.TimeInMilliseconds(
-		"flush.part_duration_ns",
-		float64(time.Now().Sub(fstart).Nanoseconds()),
-		[]string{"part:post"},
-		1.0,
-	)
+	s.statsd.TimeInMilliseconds(action+".duration_ns", float64(time.Now().Sub(requestStart).Nanoseconds()), []string{"part:post"}, 1.0)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		// don't bail out if this errors, we'll just log the body as empty
-		s.logger.WithError(err).Error("Error reading response body")
+		// this error is not fatal, since we only need the body for reporting
+		// purposes
+		s.statsd.Count(action+".error_total", 1, []string{"cause:readresponse"}, 1.0)
+		innerLogger.WithError(err).Error("Could not read response body")
 	}
-	resultFields := logrus.Fields{
-		"status":           resp.Status,
-		"request_headers":  req.Header,
-		"response_headers": resp.Header,
+	resultLogger := innerLogger.WithFields(logrus.Fields{
 		"request_length":   bodyLength,
-		"response":         string(body),
-		"total_metrics":    len(metricSlice),
-	}
+		"request_headers":  req.Header,
+		"status":           resp.Status,
+		"response_headers": resp.Header,
+		"response":         string(responseBody),
+	})
 
 	if resp.StatusCode != http.StatusAccepted {
-		s.statsd.Count("flush.error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
-		s.logger.WithFields(resultFields).Error("Error POSTing")
-		return
+		s.statsd.Count(action+".error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
+		resultLogger.Error("Could not POST")
+		return err
 	}
 
-	s.logger.WithFields(resultFields).Debug("POSTing JSON")
+	// make sure the error metric isn't sparse
+	s.statsd.Count(action+".error_total", 0, nil, 1.0)
+	resultLogger.Debug("POSTed successfully")
+	return nil
 }

--- a/parser.go
+++ b/parser.go
@@ -18,6 +18,7 @@ type UDPMetric struct {
 	Value      interface{}
 	SampleRate float32
 	Tags       []string
+	LocalOnly  bool
 }
 
 // a struct used to key the metrics into the worker's map - must only contain
@@ -121,6 +122,16 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 			}
 			tags := strings.Split(string(data[i][1:]), ",")
 			sort.Strings(tags)
+			for i, tag := range tags {
+				// we use this tag as an escape hatch for metrics that always
+				// want to be host-local
+				if tag == "veneurlocalonly" {
+					// delete the tag from the list
+					tags = append(tags[:i], tags[i+1:]...)
+					ret.LocalOnly = true
+					break
+				}
+			}
 			ret.Tags = tags
 			// we specifically need the sorted version here so that hashing over
 			// tags behaves deterministically

--- a/parser_test.go
+++ b/parser_test.go
@@ -111,3 +111,12 @@ func TestInvalidPackets(t *testing.T) {
 		assert.Contains(t, err.Error(), errContent, "Error should have contained text")
 	}
 }
+
+func TestLocalOnlyEscape(t *testing.T) {
+	m, err := ParseMetric([]byte("a.b.c:1|h|#veneurlocalonly"))
+	assert.NoError(t, err, "should have no error parsing")
+	assert.True(t, m.LocalOnly, "should have gotten local only metric")
+	for _, thisTag := range m.Tags {
+		assert.NotEqual(t, "veneurlocalonly", thisTag, "veneurlocalonly should not actually be a tag")
+	}
+}

--- a/samplers.go
+++ b/samplers.go
@@ -192,6 +192,11 @@ func NewHist(name string, tags []string) *Histo {
 	}
 }
 
+// this is the maximum number of DDMetrics that a histogram can flush if
+// len(percentiles)==0
+// specifically the count, min and max
+const HistogramLocalLength = 3
+
 // Flush generates DDMetrics for the current state of the Histo. percentiles
 // indicates what percentiles should be exported from the histogram.
 func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric {

--- a/server.go
+++ b/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	HTTPClient *http.Client
 
 	HTTPAddr    string
+	ForwardAddr string
 	UDPAddr     *net.UDPAddr
 	RcvbufBytes int
 
@@ -97,6 +98,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	}
 	ret.RcvbufBytes = conf.ReadBufferSizeBytes
 	ret.HTTPAddr = conf.HTTPAddr
+	ret.ForwardAddr = conf.ForwardAddr
 
 	conf.Key = "REDACTED"
 	conf.SentryDSN = "REDACTED"

--- a/worker.go
+++ b/worker.go
@@ -185,12 +185,6 @@ func (w *Worker) Flush() WorkerMetrics {
 	w.stats.Count("worker.metrics_processed_total", processed, []string{fmt.Sprintf("worker:%d", w.id)}, 1.0)
 	w.stats.Count("worker.metrics_imported_total", imported, []string{fmt.Sprintf("worker:%d", w.id)}, 1.0)
 
-	w.stats.Count("worker.metrics_flushed_total", int64(len(ret.counters)), []string{"metric_type:counter"}, 1.0)
-	w.stats.Count("worker.metrics_flushed_total", int64(len(ret.gauges)), []string{"metric_type:gauge"}, 1.0)
-	w.stats.Count("worker.metrics_flushed_total", int64(len(ret.histograms)), []string{"metric_type:histogram"}, 1.0)
-	w.stats.Count("worker.metrics_flushed_total", int64(len(ret.sets)), []string{"metric_type:set"}, 1.0)
-	w.stats.Count("worker.metrics_flushed_total", int64(len(ret.timers)), []string{"metric_type:timer"}, 1.0)
-
 	return ret
 }
 

--- a/worker.go
+++ b/worker.go
@@ -33,21 +33,29 @@ type WorkerMetrics struct {
 	histograms map[MetricKey]*Histo
 	sets       map[MetricKey]*Set
 	timers     map[MetricKey]*Histo
+
+	// these are used for metrics that shouldn't be forwarded
+	localHistograms map[MetricKey]*Histo
+	localSets       map[MetricKey]*Set
+	localTimers     map[MetricKey]*Histo
 }
 
 func NewWorkerMetrics() WorkerMetrics {
 	return WorkerMetrics{
-		counters:   make(map[MetricKey]*Counter),
-		gauges:     make(map[MetricKey]*Gauge),
-		histograms: make(map[MetricKey]*Histo),
-		sets:       make(map[MetricKey]*Set),
-		timers:     make(map[MetricKey]*Histo),
+		counters:        make(map[MetricKey]*Counter),
+		gauges:          make(map[MetricKey]*Gauge),
+		histograms:      make(map[MetricKey]*Histo),
+		sets:            make(map[MetricKey]*Set),
+		timers:          make(map[MetricKey]*Histo),
+		localHistograms: make(map[MetricKey]*Histo),
+		localSets:       make(map[MetricKey]*Set),
+		localTimers:     make(map[MetricKey]*Histo),
 	}
 }
 
 // Create an entry in wm for the given metrickey, if it does not already exist.
 // Returns true if the metric entry was created and false otherwise.
-func (wm WorkerMetrics) Upsert(mk MetricKey, tags []string) bool {
+func (wm WorkerMetrics) Upsert(mk MetricKey, localOnly bool, tags []string) bool {
 	present := false
 	switch mk.Type {
 	case "counter":
@@ -59,16 +67,34 @@ func (wm WorkerMetrics) Upsert(mk MetricKey, tags []string) bool {
 			wm.gauges[mk] = NewGauge(mk.Name, tags)
 		}
 	case "histogram":
-		if _, present = wm.histograms[mk]; !present {
-			wm.histograms[mk] = NewHist(mk.Name, tags)
+		if localOnly {
+			if _, present = wm.localHistograms[mk]; !present {
+				wm.localHistograms[mk] = NewHist(mk.Name, tags)
+			}
+		} else {
+			if _, present = wm.histograms[mk]; !present {
+				wm.histograms[mk] = NewHist(mk.Name, tags)
+			}
 		}
 	case "set":
-		if _, present = wm.sets[mk]; !present {
-			wm.sets[mk] = NewSet(mk.Name, tags)
+		if localOnly {
+			if _, present = wm.localSets[mk]; !present {
+				wm.localSets[mk] = NewSet(mk.Name, tags)
+			}
+		} else {
+			if _, present = wm.sets[mk]; !present {
+				wm.sets[mk] = NewSet(mk.Name, tags)
+			}
 		}
 	case "timer":
-		if _, present = wm.timers[mk]; !present {
-			wm.timers[mk] = NewHist(mk.Name, tags)
+		if localOnly {
+			if _, present = wm.localTimers[mk]; !present {
+				wm.localTimers[mk] = NewHist(mk.Name, tags)
+			}
+		} else {
+			if _, present = wm.timers[mk]; !present {
+				wm.timers[mk] = NewHist(mk.Name, tags)
+			}
 		}
 		// no need to raise errors on unknown types
 		// the caller will probably end up doing that themselves
@@ -117,7 +143,7 @@ func (w *Worker) ProcessMetric(m *UDPMetric) {
 	defer w.mutex.Unlock()
 
 	w.processed++
-	w.wm.Upsert(m.MetricKey, m.Tags)
+	w.wm.Upsert(m.MetricKey, m.LocalOnly, m.Tags)
 
 	switch m.Type {
 	case "counter":
@@ -125,11 +151,23 @@ func (w *Worker) ProcessMetric(m *UDPMetric) {
 	case "gauge":
 		w.wm.gauges[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 	case "histogram":
-		w.wm.histograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		if m.LocalOnly {
+			w.wm.localHistograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		} else {
+			w.wm.histograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		}
 	case "set":
-		w.wm.sets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
+		if m.LocalOnly {
+			w.wm.localSets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
+		} else {
+			w.wm.sets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
+		}
 	case "timer":
-		w.wm.timers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		if m.LocalOnly {
+			w.wm.localTimers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		} else {
+			w.wm.timers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		}
 	default:
 		w.logger.WithField("type", m.Type).Error("Unknown metric type for processing")
 	}
@@ -142,7 +180,7 @@ func (w *Worker) ImportMetric(other JSONMetric) {
 	// we don't increment the processed metric counter here, it was already
 	// counted by the original veneur that sent this to us
 	w.imported++
-	w.wm.Upsert(other.MetricKey, other.Tags)
+	w.wm.Upsert(other.MetricKey, false, other.Tags)
 
 	switch other.Type {
 	case "set":

--- a/worker_test.go
+++ b/worker_test.go
@@ -28,6 +28,26 @@ func TestWorker(t *testing.T) {
 	assert.Len(t, nometrics.counters, 0, "Should flush no metrics")
 }
 
+func TestWorkerLocal(t *testing.T) {
+	w := NewWorker(1, nil, logrus.New())
+
+	m := UDPMetric{
+		MetricKey: MetricKey{
+			Name: "a.b.c",
+			Type: "histogram",
+		},
+		Value:      1.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		LocalOnly:  true,
+	}
+	w.ProcessMetric(&m)
+
+	wm := w.Flush()
+	assert.Len(t, wm.localHistograms, 1, "number of local histograms")
+	assert.Len(t, wm.histograms, 0, "number of global histograms")
+}
+
 func TestWorkerImportSet(t *testing.T) {
 	w := NewWorker(1, nil, logrus.New())
 	testset := NewSet("a.b.c", nil)


### PR DESCRIPTION
#### Summary

Enable one Veneur instance to forward metric structures to another instance instead of flushing them to DataDog.

#### Motivation

- spread load between Veneurs
- reduce reliance on the single Veneur global instance
- get host-local counters for histograms back without having to implement client-side changes
- bring Veneur's statsd performance to hosts that are overwhelming their local dogstatsd instances

I'm not 100% convinced this PR is ready to merge yet, but I would like to start review ahead of schedule. I have to implement event/service check support before we can replace dogstatsd, and those changes are almost guaranteed to conflict with these ones if I put them on a separate branch.

#### Test plan

I had two Veneurs running in QA configured to forward to the main QA instance and they were doing what I expected.

#### Rollout/monitoring/revert plan

Roll out to global instances as normal. We aren't ready to do a local rollout yet.