### PR TITLE
Add event and service check support

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Metric is a representation of the sample provided by a client. The tag list
@@ -148,6 +149,250 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 	}
 
 	ret.Digest = h.Sum32()
+
+	return ret, nil
+}
+
+// the json keys of this structure match datadog's undocumented /intake endpoint
+type UDPEvent struct {
+	Title       string   `json:"msg_title"`
+	Text        string   `json:"msg_text"`
+	Timestamp   int64    `json:"timestamp,omitempty"` // represented as a unix epoch
+	Hostname    string   `json:"host,omitempty"`
+	Aggregation string   `json:"aggregation_key,omitempty"`
+	Priority    string   `json:"priority,omitempty"`
+	Source      string   `json:"source_type_name,omitempty"`
+	AlertLevel  string   `json:"alert_type,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+func ParseEvent(packet []byte) (*UDPEvent, error) {
+	ret := &UDPEvent{
+		Timestamp:  time.Now().Unix(),
+		Priority:   "normal",
+		AlertLevel: "info",
+	}
+
+	pipeSplitter := NewSplitBytes(packet, '|')
+	pipeSplitter.Next()
+
+	startingColon := bytes.IndexByte(pipeSplitter.Chunk(), ':')
+	if startingColon == -1 {
+		return nil, errors.New("Invalid event packet, need at least 1 colon")
+	}
+
+	lengthsChunk := pipeSplitter.Chunk()[:startingColon]
+	// the second half of the condition will never panic, because the first half
+	// guarantees that it has a nonzero length
+	if !bytes.HasPrefix(lengthsChunk, []byte{'_', 'e', '{'}) || lengthsChunk[len(lengthsChunk)-1] != '}' {
+		return nil, errors.New("Invalid event packet, must have _e{} wrapper around length section")
+	}
+	// discard the _e{} wrapper
+	lengthsChunk = lengthsChunk[3 : len(lengthsChunk)-1]
+
+	lengthComma := bytes.IndexByte(lengthsChunk, ',')
+	if lengthComma == -1 {
+		return nil, errors.New("Invalid event packet, length section requires comma divider")
+	}
+
+	titleExpectedLength, err := strconv.Atoi(string(lengthsChunk[:lengthComma]))
+	if err != nil {
+		return nil, fmt.Errorf("Invalid event packet, title length is not an integer: %s", err)
+	}
+	if titleExpectedLength <= 0 {
+		return nil, errors.New("Invalid event packet, title length must be positive")
+	}
+
+	textExpectedLength, err := strconv.Atoi(string(lengthsChunk[lengthComma+1:]))
+	if err != nil {
+		return nil, fmt.Errorf("Invalid event packet, text length is not an integer: %s", err)
+	}
+	if textExpectedLength <= 0 {
+		return nil, errors.New("Invalid event packet, text length must be positive")
+	}
+
+	titleChunk := pipeSplitter.Chunk()[startingColon+1:]
+	if len(titleChunk) != titleExpectedLength {
+		return nil, errors.New("Invalid event packet, actual title length did not match encoded length")
+	}
+	ret.Title = string(titleChunk)
+
+	if !pipeSplitter.Next() {
+		return nil, errors.New("Invalid event packet, must have at least 1 pipe for text")
+	}
+	textChunk := pipeSplitter.Chunk()
+	if len(textChunk) != textExpectedLength {
+		return nil, errors.New("Invalid event packet, actual text length did not match encoded length")
+	}
+	ret.Text = string(textChunk)
+
+	var (
+		foundTimestamp   bool
+		foundHostname    bool
+		foundAggregation bool
+		foundPriority    bool
+		foundSource      bool
+		foundAlert       bool
+	)
+	for pipeSplitter.Next() {
+		if len(pipeSplitter.Chunk()) == 0 {
+			return nil, errors.New("Invalid event packet, empty string after/between pipes")
+		}
+
+		switch {
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'d', ':'}):
+			if foundTimestamp {
+				return nil, errors.New("Invalid event packet, multiple date sections")
+			}
+			unixTimestamp, err := strconv.ParseInt(string(pipeSplitter.Chunk()[2:]), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid event packet, could not parse date as unix timestamp: %s", err)
+			}
+			ret.Timestamp = unixTimestamp
+			foundTimestamp = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'h', ':'}):
+			if foundHostname {
+				return nil, errors.New("Invalid event packet, multiple hostname sections")
+			}
+			ret.Hostname = string(pipeSplitter.Chunk()[2:])
+			foundHostname = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'k', ':'}):
+			if foundAggregation == true {
+				return nil, errors.New("Invalid event packet, multiple aggregation key sections")
+			}
+			ret.Aggregation = string(pipeSplitter.Chunk()[2:])
+			foundAggregation = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'p', ':'}):
+			if foundPriority == true {
+				return nil, errors.New("Invalid event packet, multiple priority sections")
+			}
+			ret.Priority = string(pipeSplitter.Chunk()[2:])
+			if ret.Priority != "normal" && ret.Priority != "low" {
+				return nil, errors.New("Invalid event packet, priority must be normal or low")
+			}
+			foundPriority = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'s', ':'}):
+			if foundSource == true {
+				return nil, errors.New("Invalid event packet, multiple source sections")
+			}
+			ret.Source = string(pipeSplitter.Chunk()[2:])
+			foundSource = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'t', ':'}):
+			if foundAlert == true {
+				return nil, errors.New("Invalid event packet, multiple alert sections")
+			}
+			ret.AlertLevel = string(pipeSplitter.Chunk()[2:])
+			if ret.AlertLevel != "error" && ret.AlertLevel != "warning" && ret.AlertLevel != "info" && ret.AlertLevel != "success" {
+				return nil, errors.New("Invalid event packet, alert level must be error, warning, info or success")
+			}
+			foundAlert = true
+		case pipeSplitter.Chunk()[0] == '#':
+			if ret.Tags != nil {
+				return nil, errors.New("Invalid event packet, multiple tag sections")
+			}
+			tags := strings.Split(string(pipeSplitter.Chunk()[1:]), ",")
+			ret.Tags = tags // no need to sort, we don't aggregate on this
+		default:
+			return nil, errors.New("Invalid event packet, unrecognized metadata section")
+		}
+	}
+
+	return ret, nil
+}
+
+type UDPServiceCheck struct {
+	Name      string   `json:"check"`
+	Status    int      `json:"status"`
+	Hostname  string   `json:"host_name"`
+	Timestamp int64    `json:"timestamp,omitempty"` // represented as a unix epoch
+	Tags      []string `json:"tags,omitempty"`
+	Message   string   `json:"message,omitempty"`
+}
+
+func ParseServiceCheck(packet []byte) (*UDPServiceCheck, error) {
+	ret := &UDPServiceCheck{
+		Timestamp: time.Now().Unix(),
+	}
+
+	pipeSplitter := NewSplitBytes(packet, '|')
+	pipeSplitter.Next()
+
+	if !bytes.Equal(pipeSplitter.Chunk(), []byte{'_', 's', 'c'}) {
+		return nil, errors.New("Invalid service check packet, no _sc prefix")
+	}
+
+	if !pipeSplitter.Next() {
+		return nil, errors.New("Invalid service check packet, need name section")
+	}
+	if len(pipeSplitter.Chunk()) == 0 {
+		return nil, errors.New("Invalid service check packet, empty name")
+	}
+	ret.Name = string(pipeSplitter.Chunk())
+
+	if !pipeSplitter.Next() {
+		return nil, errors.New("Invalid service check packet, need status section")
+	}
+	switch {
+	case bytes.Equal(pipeSplitter.Chunk(), []byte{'0'}):
+		ret.Status = 0
+	case bytes.Equal(pipeSplitter.Chunk(), []byte{'1'}):
+		ret.Status = 1
+	case bytes.Equal(pipeSplitter.Chunk(), []byte{'2'}):
+		ret.Status = 2
+	case bytes.Equal(pipeSplitter.Chunk(), []byte{'3'}):
+		ret.Status = 3
+	default:
+		return nil, errors.New("Invalid service check packet, must have status of 0, 1, 2, or 3")
+	}
+
+	var (
+		foundTimestamp bool
+		foundHostname  bool
+		foundMessage   bool
+	)
+	for pipeSplitter.Next() {
+		if len(pipeSplitter.Chunk()) == 0 {
+			return nil, errors.New("Invalid service packet packet, empty string after/between pipes")
+		}
+		if foundMessage {
+			return nil, errors.New("Invalid service check packet, message must be the last metadata section")
+		}
+
+		switch {
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'d', ':'}):
+			if foundTimestamp || foundMessage {
+				return nil, errors.New("Invalid service check packet, multiple date sections")
+			}
+			unixTimestamp, err := strconv.ParseInt(string(pipeSplitter.Chunk()[2:]), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid service check packet, could not parse date as unix timestamp: %s", err)
+			}
+			ret.Timestamp = unixTimestamp
+			foundTimestamp = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'h', ':'}):
+			if foundHostname || foundMessage {
+				return nil, errors.New("Invalid service check packet, multiple hostname sections")
+			}
+			ret.Hostname = string(pipeSplitter.Chunk()[2:])
+			foundHostname = true
+		case bytes.HasPrefix(pipeSplitter.Chunk(), []byte{'m', ':'}):
+			// this section must come last, so its flag also gets checked by
+			// the other cases
+			if foundMessage {
+				return nil, errors.New("Invalid service check packet, multiple message sections")
+			}
+			ret.Message = string(pipeSplitter.Chunk()[2:])
+			foundMessage = true
+		case pipeSplitter.Chunk()[0] == '#':
+			if ret.Tags != nil || foundMessage {
+				return nil, errors.New("Invalid service check packet, multiple tag sections")
+			}
+			tags := strings.Split(string(pipeSplitter.Chunk()[1:]), ",")
+			ret.Tags = tags // no need to sort, we don't aggregate on this
+		default:
+			return nil, errors.New("Invalid service check packet, unrecognized metadata section")
+		}
+	}
 
 	return ret, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -107,7 +107,7 @@ func TestInvalidPackets(t *testing.T) {
 
 	for packet, errContent := range table {
 		_, err := ParseMetric([]byte(packet))
-		assert.NotNil(t, err, "Should have gotten error parsing: ", packet)
+		assert.NotNil(t, err, "Should have gotten error parsing %q", packet)
 		assert.Contains(t, err.Error(), errContent, "Error should have contained text")
 	}
 }


### PR DESCRIPTION
#### Summary

Add support for events and service checks over UDP.

#### Motivation

We're looking to replace dogstatsd with veneur, and there are a few services that report events/checks through dogstatsd, so we need to support those. Unfortunately the endpoints we need for these are not great, but we have to use what we've got.

#### Test plan

I have it running on some QA boxes that are actually generating these things.

#### Rollout/monitoring/revert plan

as usual