### PR TITLE
Tweaks for localhost

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -44,7 +44,7 @@ func main() {
 			defer func() {
 				server.ConsumePanic(recover())
 			}()
-			server.ReadSocket(packetPool)
+			server.ReadSocket(packetPool, conf.NumReaders != 1)
 		}()
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -111,9 +111,6 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Invalid float for sample rate: %s", sr)
 			}
-			if ret.Type == "gauge" || ret.Type == "set" {
-				return nil, fmt.Errorf("Invalid metric packet, %s cannot have a sample rate", ret.Type)
-			}
 			if sampleRate <= 0 || sampleRate > 1 {
 				return nil, fmt.Errorf("Sample rate %f must be >0 and <=1", sampleRate)
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -72,8 +72,7 @@ func TestParserWithSampleRate(t *testing.T) {
 	assert.Contains(t, valueError.Error(), "Invalid number", "Invalid number error missing")
 
 	_, valueError = ParseMetric([]byte("a.b.c:1|g|@0.1"))
-	assert.NotNil(t, valueError, "No errors when parsing")
-	assert.Contains(t, valueError.Error(), "sample rate", "Sample rate error missing")
+	assert.NoError(t, valueError, "Got errors when parsing")
 }
 
 func TestParserWithSampleRateAndTags(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -153,13 +153,12 @@ func (s *Server) HandlePacket(packet []byte) {
 	}
 }
 
-func (s *Server) ReadSocket(packetPool *sync.Pool) {
+func (s *Server) ReadSocket(packetPool *sync.Pool, reuseport bool) {
 	// each goroutine gets its own socket
 	// if the sockets support SO_REUSEPORT, then this will cause the
 	// kernel to distribute datagrams across them, for better read
 	// performance
-	s.logger.WithField("address", s.UDPAddr).Info("UDP server listening")
-	serverConn, err := NewSocket(s.UDPAddr, s.RcvbufBytes)
+	serverConn, err := NewSocket(s.UDPAddr, s.RcvbufBytes, reuseport)
 	if err != nil {
 		// if any goroutine fails to create the socket, we can't really
 		// recover, so we just blow up
@@ -167,6 +166,7 @@ func (s *Server) ReadSocket(packetPool *sync.Pool) {
 		// SO_REUSEPORT support
 		s.logger.WithError(err).Fatal("Error listening for UDP")
 	}
+	s.logger.WithField("address", s.UDPAddr).Info("UDP server listening")
 
 	for {
 		buf := packetPool.Get().([]byte)

--- a/socket.go
+++ b/socket.go
@@ -6,7 +6,10 @@ import (
 	"net"
 )
 
-func NewSocket(addr *net.UDPAddr, recvBuf int) (net.PacketConn, error) {
+func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, error) {
+	if reuseport {
+		panic("SO_REUSEPORT not supported on this platform")
+	}
 	serverConn, err := net.ListenUDP("udp", addr)
 	if err != nil {
 		return nil, err

--- a/socket_test.go
+++ b/socket_test.go
@@ -11,7 +11,7 @@ func TestSocket(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:8200")
 	assert.NoError(t, err, "should have constructed udp address correctly")
 
-	sock, err := NewSocket(addr, 2*1024*1024)
+	sock, err := NewSocket(addr, 2*1024*1024, false)
 	assert.NoError(t, err, "should have constructed socket correctly")
 
 	client, err := net.DialUDP("udp", nil, addr)


### PR DESCRIPTION
#### Summary

- allow gauges and sets to have a sample rate (that we ignore)
- do not set SO_REUSEPORT for a single UDP reader

#### Motivation

- some clients do actually sample their gauges on the client side. There's no mathematically meaningful action we can take in response to that, but we should still consume the packet.
- some of our boxes are still on precise, which has linux 3.2, and SO_REUSEPORT was introduced in 3.9. So we need a way to opt out of it. I'd rather not mess with SO_REUSEADDR, so we'll just turn off SO_REUSEPORT if there's only one reader.

#### Test plan

Tested on boxes that exhibit the described behavior

#### Rollout/monitoring/revert plan

As usual