### PR TITLE
Ignore empty packets

### DIFF
--- a/server.go
+++ b/server.go
@@ -117,6 +117,12 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 }
 
 func (s *Server) HandlePacket(packet []byte) {
+	if len(packet) == 0 {
+		// a lot of clients send packets that accidentally have a trailing
+		// newline, it's easier to just let them be
+		return
+	}
+
 	if bytes.HasPrefix(packet, []byte{'_', 'e', '{'}) {
 		event, err := ParseEvent(packet)
 		if err != nil {


### PR DESCRIPTION
#### Summary

Skip empty packets, don't raise a parser error on them.

#### Motivation

A lot of things send packets with trailing newlines (eg anyone using `echo | nc` without the `-n` flag). Although these are technically wrong, they're also the hardest to track down, and we don't get much out of fixing them. Let's just leave them alone.

#### Test plan

meh

#### Rollout/monitoring/revert plan

We'll puppet this out since it mostly affects local instances.