### PR TITLE
Disable keep-alive on POST

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -364,6 +364,8 @@ func (s *Server) postHelper(endpoint string, bodyObject interface{}, action stri
 	if compress {
 		req.Header.Set("Content-Encoding", "deflate")
 	}
+	// we only make http requests at flush time, so keepalive is not a big win
+	req.Close = true
 
 	requestStart := time.Now()
 	resp, err := s.HTTPClient.Do(req)


### PR DESCRIPTION
#### Summary

Our HTTP requests now ask the transport to close the connection after they're finished, preventing tcp keepalive.

#### Motivation

We're seeing EOFs coming out of the `Do` method. This usually indicates that the client had a connection that it was keeping alive, but the server terminated it unexpectedly. Some of the connections are on the forwarding path (and we could investigate those on the server side of veneur), but others are along the way to other services, and I don't want to be in the business of diagnosing them.

We only POST a (constant) number of requests each flush interval and those are 10s apart. We can probably afford to just turn keepalive off.

#### Test plan

Been stewing in QA for a few hours and the EOFs have abated.

#### Rollout/monitoring/revert plan

This is mostly a local-side change so we'll puppet this one.