### PR TITLE
Prevent veneurs from forwarding their own metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ ENV GOPATH=/go
 RUN go get -u -v github.com/kardianos/govendor
 WORKDIR /go/src/github.com/stripe/veneur
 ADD . /go/src/github.com/stripe/veneur
-CMD cp -r henson /build/ && govendor test -v -timeout 10s +local && go build -a -v -o /build/veneur ./cmd/veneur
+CMD cp -r henson /build/ && govendor test -v -timeout 10s +local && go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur ./cmd/veneur

--- a/flusher.go
+++ b/flusher.go
@@ -212,6 +212,8 @@ func (s *Server) flushForward(wms []WorkerMetrics) {
 				}).Error("Could not export metric")
 				continue
 			}
+			// the exporter doesn't know that these two are "different"
+			jm.Type = "timer"
 			jsonMetrics = append(jsonMetrics, jm)
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -14,6 +14,9 @@ import (
 	"github.com/zenazn/goji/graceful"
 )
 
+// must be a var so it can be set at link time
+var VERSION = "dirty"
+
 type Server struct {
 	Workers     []*Worker
 	EventWorker *EventWorker
@@ -79,6 +82,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			logrus.PanicLevel,
 		},
 	})
+	ret.logger.WithField("version", VERSION).Info("Starting server")
 
 	ret.logger.WithField("number", conf.NumWorkers).Info("Starting workers")
 	ret.Workers = make([]*Worker, conf.NumWorkers)

--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		return
 	}
 	ret.statsd.Namespace = "veneur."
-	ret.statsd.Tags = ret.Tags
+	ret.statsd.Tags = append(ret.Tags, "veneurlocalonly")
 
 	// nil is a valid sentry client that noops all methods, if there is no DSN
 	// we can just leave it as nil

--- a/worker.go
+++ b/worker.go
@@ -191,6 +191,10 @@ func (w *Worker) ImportMetric(other JSONMetric) {
 		if err := w.wm.histograms[other.MetricKey].Combine(other.Value); err != nil {
 			w.logger.WithError(err).Error("Could not merge histograms")
 		}
+	case "timer":
+		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
+			w.logger.WithError(err).Error("Could not merge timers")
+		}
 	default:
 		w.logger.WithField("type", other.Type).Error("Unknown metric type for importing")
 	}


### PR DESCRIPTION
#### Summary

Attach the magic `veneurlocalonly` escape tag to all metrics that veneur itself generates.

#### Motivation

Normally, when a service reports metrics, its `host_type` and other such things are attached by veneur itself (or whoever else is responsible for aggregating the metrics). However, veneur's statsd client attaches those in the packet that it sends. (Debatable whether that's still the correct behavior now that we have veneur talking to itself. Feel free to share thoughts. The most correct behavior might be to have `veneurlocalonly` as the only tag our client sends to itself.)

What ends up happening as a result is veneur receives a packet that already has its own tags. If it forwards that metric to a global veneur, that veneur will attach its _own_ tags on top of the ones that were already sent. You end up with tags that are duplicated, eg two `host_type`s for a single timeseries.

We could try to deduplicate tags (eg when we flush, we don't add tags that the metric already has), but that's kind of annoying, and we have to do it for _every single unique name/tags/type tuple_ we have. I'm not convinced that it will be cheap. The easier, cop-out solution is to give up global aggregation for veneur's own metrics and make them all host-specific. That's what I decided to do here.

tl;dr host-local tags get weird when the concept of host-locality goes away, so we decided to make the most finicky ones host-local again

#### Test plan

We puppeted it out everywhere and it did what we expected.

#### Rollout/monitoring/revert plan

puppet it

I will cc @gphat , but he's out so I'm assigning to @asf instead. Ping me if you need more context on the issue. This one was insidious.