### PR TITLE
Add tags to service checks and events.

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -290,11 +290,13 @@ func (s *Server) flushEventsChecks() {
 		if events[i].Hostname == "" {
 			events[i].Hostname = s.Hostname
 		}
+		events[i].Tags = append(events[i].Tags, s.Tags...)
 	}
 	for i := range checks {
 		if checks[i].Hostname == "" {
 			checks[i].Hostname = s.Hostname
 		}
+		checks[i].Tags = append(checks[i].Tags, s.Tags...)
 	}
 
 	if len(events) != 0 {


### PR DESCRIPTION
#### Summary
Appends "global" server tags to service checks and events.

#### Motivation
I was investigating a `No Data` alert this morning and noticed that the service check in question did not have a `host_env`. After investigating I realized that events and service checks no longer have their global tags applied. This fixes that.

This is [in a single commit](https://github.com/stripe/veneur/pull/54/commits/61fc244a7537c64b8a38596fec7def1a10ae4dcd) and can be pulled out if you disagree!

#### Test plan
We don't seem to have any way to test this phase of the flusher. Perhaps we should pluck out the parts of `flusher.go` that "prepare" the data and make them testable?

#### Rollout/monitoring/revert plan
* Merge
* Update SHA in puppet-land
* Puppet the fleet

r? @tummychow 

