### PR TITLE
Fix some slice aliasing bugs

### DIFF
--- a/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
@@ -114,7 +114,11 @@ func (c *Client) format(name, value string, tags []string, rate float64) string 
 		buf.WriteString(strconv.FormatFloat(rate, 'f', -1, 64))
 	}
 
-	tags = append(c.Tags, tags...)
+	// do not append to c.Tags directly, because it's shared
+	// across all invocations of this function
+	tagCopy := make([]string, len(c.Tags), len(c.Tags)+len(tags))
+	copy(tagCopy, c.Tags)
+	tags = append(tagCopy, tags...)
 	if len(tags) > 0 {
 		buf.WriteString("|#")
 		buf.WriteString(tags[0])

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "JhyS/zIicgtrSasHSZ6WtXGWJVk=",
+			"checksumSHA1": "Xv2p37sE7x+W7UMevRA9ad9lAV4=",
 			"path": "github.com/DataDog/datadog-go/statsd",
-			"revision": "cc2f4770f4d61871e19bfee967bc767fe730b0d9",
-			"revisionTime": "2016-03-29T13:52:53Z"
+			"revision": "94b37b603fe4425010c27ee250fed81a00ae583b",
+			"revisionTime": "2016-08-10T17:59:41Z"
 		},
 		{
 			"checksumSHA1": "htjvdG/znrHmFYRQBqA2vHrJsF4=",


### PR DESCRIPTION
#### Summary

Update datadog-go for https://github.com/DataDog/datadog-go/pull/16

#### Motivation

As detailed on that PR, we were seeing some spurious tags because of shared slice shenanigans. I'm also eliminating some slice sharing in veneur which is not currently causing a bug, but imo is good hygiene.

#### Test plan

It's been on globalstats boxen for the last ~16hr and no spurious `part` tags have appeared.

#### Rollout/monitoring/revert plan

I will probably henson + puppet this.