### PR TITLE
Perform t-digest merges in place

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -227,7 +227,7 @@ func (s *Server) flushForward(wms []WorkerMetrics) {
 
 	s.statsd.Gauge("forward.post_metrics_total", float64(len(jsonMetrics)), nil, 1.0)
 	if len(jsonMetrics) == 0 {
-		s.logger.Info("Nothing to forward, skipping.")
+		s.logger.Debug("Nothing to forward, skipping.")
 		return
 	}
 


### PR DESCRIPTION
#### Summary

Halve memory consumption of t-digests by rewriting the merge algorithm.

I also tacked on the change we talked about to halve logging volume on low-traffic local instances.

#### Motivation

Right now, t-digests require a main buffer of centroids with length `O(compression)`, and then another buffer of the same length to use for performing the main/temp merge. Removing that buffer allows us to approximately halve the memory that a t-digest consumes.

The way the new merge works is that we merge centroids directly into the main buffer. This could potentially overwrite unmerged centroids that are later in the buffer, so where do we put those? As we merge in centroids from the temporary buffer, the space at the start of that buffer is freed up, and we can swap centroids from main to temp before merging the next temp centroid in. Then instead of referring directly to the main buffer to find the next centroid to merge, we can use that empty space.

The other catch is that, if we take a centroid from the empty space and merge that into the main buffer, this could _also_ overwrite unmerged centroids! To avoid this, we copy the remaining elements of the empty space down, and attach the next centroid in the main buffer to the end of the empty space. This copy operation is probably the most expensive part of this change.

Ping me if you feel that explanation is inadequate. (Figuring out how to do this in-place makes for a really fun puzzle, if you want to try that before reading the code. I had to adjust my pseudocode solution 2 or 3 times.)

Performance wise, it breaks down like this:

- we're allocating half as much memory for histograms. That's good, because histograms are by far our most heavily used data structure, but in practice it's not that important because we're not memory contended. Histograms were already constant size before this change. Making them smaller is nice but doesn't really impact us.
- we're spending less time creating histograms. Each histogram now requires one "large" allocation (main buffer) and one "small" allocation (temp buffer), saving one "large" allocation that we had to do before. This doesn't impact GC time very much (a single large buffer is still only one object), but it does reduce time spent in `makeslice` considerably. The global veneur has to allocate a lot of t-digests because that's how it combines them together at import time, so this does actually matter here.
- the merge process is more expensive than before because of the additional slice shuffling. `MergingDigest.Add` went from about 800ns/op to 1200ns/op on my macbook. This indicates that the cost of merging, amortized across addition operations, is probably about 50% greater. This mainly affects local veneurs, since they're the ones that are invoking `Add`. Is it consequential? I don't really know, but since each local veneur is only pulling packets for its local host, I personally don't think so.

Some other things to note:

- fortunately we do not have to adjust the gob encoding of t-digests, since the merge buffer (which was removed in this commit) was never being encoded in the first place.
- when merging two t-digests together, we have to allocate a temporary slice of ints with `O(compression)` length, to shuffle the list of main centroids from the digest being merged in. (Before this change, we were using the merge buffer for this.) That extra allocation is not free, although based on profiling, it's faster to allocate this int slice than it was to allocate the merging buffer.

Overall I basically think the in-place merge is a structural improvement to the algorithm, and we can handle the slowdown on the writing end.

#### Test plan

The built-in automated tests for t-digests did a good job of finding bugs in this. If the merge algorithm breaks, it usually manifests as either a huge math error or an out of range panic. Also it was running in prod for a little while.

#### Rollout/monitoring/revert plan

I don't think deploying this is super important since there are no bugfixes or features in here. But we can puppet it if we want.

cc @antifuchs @rhwlo 