### PR TITLE
Some doc updates.

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -18,7 +18,8 @@ tags:
  - "foo:bar"
 #  - "baz:gorch"
 udp_address: "localhost:8126"
-http_address: "einhorn@0"
+#http_address: "einhorn@0"
+http_address: "localhost:8127"
 forward_address: "http://veneur.example.com"
 # Defaults to the os.Hostname()!
 # hostname: foobar


### PR DESCRIPTION
#### Summary
Adds some small doc and config updates for convenience.


#### Motivation
* We weren't documenting the Sentry integration.
* The `example.yaml` didn't work because it defaulted to Einhorn
* There was some header fuckery that I cleaned up

r? @tummychow 