### PR TITLE
Honor magic tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ With respect to the `tags` configuration option, the tags that will be added are
 
 If you want a metric to be strictly host-local, you can tell Veneur not to forward it by including a `veneurlocalonly` tag in the metric packet, eg `foo:1|h|#veneurlocalonly`. This tag will not actually appear in DataDog; Veneur removes it.
 
+Veneur also honors the same "magic" tags as the dogstatsd include in the agent. The tag `host` will override `Hostname` in the metric and `device` will override `DeviceName`.
+
 # Configuration
 
 Veneur expects to have a config file supplied via `-f PATH`. The include `example.yaml` outlines the options:

--- a/flusher.go
+++ b/flusher.go
@@ -109,7 +109,7 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 		}
 	}
 
-	finalMetrics = finalizeMetrics(s.Hostname, s.Tags, finalMetrics)
+finalizeMetrics(s.Hostname, s.Tags, finalMetrics)
 
 	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(combineStart).Nanoseconds()), []string{"part:combine"}, 1.0)
 
@@ -166,7 +166,7 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 	s.logger.WithField("metrics", len(finalMetrics)).Info("Completed flush to Datadog")
 }
 
-func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []DDMetric {
+func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) {
 	for i := range finalMetrics {
 		// Let's look for "magic tags" that override metric fields host and device.
 		for j, tag := range finalMetrics[i].Tags {
@@ -189,7 +189,6 @@ func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []
 
 		finalMetrics[i].Tags = append(finalMetrics[i].Tags, tags...)
 	}
-	return finalMetrics
 }
 
 func (s *Server) flushPart(metricSlice []DDMetric, wg *sync.WaitGroup) {

--- a/flusher.go
+++ b/flusher.go
@@ -177,9 +177,8 @@ func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []
 				// Override the hostname with the tag, trimming off the prefix
 				finalMetrics[i].Hostname = string(tag[5:len(tag)])
 			} else if strings.HasPrefix(tag, "device:") {
-				// delete the tag from the list
+				// Same as above, but device this time
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
-				// Override the hostname with the tag, trimming off the prefix
 				finalMetrics[i].DeviceName = string(tag[7:len(tag)])
 			}
 		}

--- a/flusher.go
+++ b/flusher.go
@@ -175,11 +175,11 @@ func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []
 				// delete the tag from the list
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
 				// Override the hostname with the tag, trimming off the prefix
-				finalMetrics[i].Hostname = string(tag[5:len(tag)])
+				finalMetrics[i].Hostname = string(tag[5:])
 			} else if strings.HasPrefix(tag, "device:") {
 				// Same as above, but device this time
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
-				finalMetrics[i].DeviceName = string(tag[7:len(tag)])
+				finalMetrics[i].DeviceName = string(tag[7:])
 			}
 		}
 		if finalMetrics[i].Hostname == "" {

--- a/flusher.go
+++ b/flusher.go
@@ -175,11 +175,11 @@ func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []
 				// delete the tag from the list
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
 				// Override the hostname with the tag, trimming off the prefix
-				finalMetrics[i].Hostname = string(tag[5:])
+				finalMetrics[i].Hostname = tag[5:]
 			} else if strings.HasPrefix(tag, "device:") {
 				// Same as above, but device this time
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
-				finalMetrics[i].DeviceName = string(tag[7:])
+				finalMetrics[i].DeviceName = tag[7:]
 			}
 		}
 		if finalMetrics[i].Hostname == "" {

--- a/flusher.go
+++ b/flusher.go
@@ -174,8 +174,13 @@ func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) []
 			if strings.HasPrefix(tag, "host:") {
 				// delete the tag from the list
 				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
-				// Override the hostname with the tag
+				// Override the hostname with the tag, trimming off the prefix
 				finalMetrics[i].Hostname = string(tag[5:len(tag)])
+			} else if strings.HasPrefix(tag, "device:") {
+				// delete the tag from the list
+				finalMetrics[i].Tags = append(finalMetrics[i].Tags[:j], finalMetrics[i].Tags[j+1:]...)
+				// Override the hostname with the tag, trimming off the prefix
+				finalMetrics[i].DeviceName = string(tag[7:len(tag)])
 			}
 		}
 		if finalMetrics[i].Hostname == "" {

--- a/flusher.go
+++ b/flusher.go
@@ -109,7 +109,7 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 		}
 	}
 
-finalizeMetrics(s.Hostname, s.Tags, finalMetrics)
+	finalizeMetrics(s.Hostname, s.Tags, finalMetrics)
 
 	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(combineStart).Nanoseconds()), []string{"part:combine"}, 1.0)
 

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -16,7 +16,7 @@ func TestServerTags(t *testing.T) {
 		Interval:   10,
 	}}
 
-	metrics = finalizeMetrics("somehostname", []string{"a:b", "c:d"}, metrics)
+	finalizeMetrics("somehostname", []string{"a:b", "c:d"}, metrics)
 	assert.Equal(t, "somehostname", metrics[0].Hostname, "Metric hostname uses argument")
 	assert.Contains(t, metrics[0].Tags, "a:b", "Tags should contain server tags")
 }
@@ -30,7 +30,7 @@ func TestHostMagicTag(t *testing.T) {
 		Interval:   10,
 	}}
 
-	metrics = finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
+	finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
 	assert.Equal(t, "abc123", metrics[0].Hostname, "Metric hostname should be from tag")
 	assert.NotContains(t, metrics[0].Tags, "host:abc123", "Host tag should be removed")
 	assert.Contains(t, metrics[0].Tags, "x:e", "Last tag is still around")
@@ -45,7 +45,7 @@ func TestDeviceMagicTag(t *testing.T) {
 		Interval:   10,
 	}}
 
-	metrics = finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
+	finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
 	assert.Equal(t, "abc123", metrics[0].DeviceName, "Metric devicename should be from tag")
 	assert.NotContains(t, metrics[0].Tags, "device:abc123", "Host tag should be removed")
 	assert.Contains(t, metrics[0].Tags, "x:e", "Last tag is still around")

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -1,0 +1,36 @@
+package veneur
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerTags(t *testing.T) {
+	metrics := []DDMetric{{
+		Name:       "foo.bar.baz",
+		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(1.0)}},
+		Tags:       []string{"gorch:frobble", "x:e"},
+		MetricType: "rate",
+		Interval:   10,
+	}}
+
+	metrics = finalizeMetrics("somehostname", []string{"a:b", "c:d"}, metrics)
+	assert.Contains(t, metrics[0].Tags, "a:b", "Tags should contain server tags")
+}
+
+func TestHostMagicTag(t *testing.T) {
+	metrics := []DDMetric{{
+		Name:       "foo.bar.baz",
+		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(1.0)}},
+		Tags:       []string{"gorch:frobble", "host:abc123", "x:e"},
+		MetricType: "rate",
+		Interval:   10,
+	}}
+
+	metrics = finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
+	assert.Equal(t, "abc123", metrics[0].Hostname, "Metric hostname should be from tag")
+	assert.NotContains(t, metrics[0].Tags, "host:abc123", "Host tag should be removed")
+	assert.Contains(t, metrics[0].Tags, "x:e", "Last tag is still around")
+}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -17,6 +17,7 @@ func TestServerTags(t *testing.T) {
 	}}
 
 	metrics = finalizeMetrics("somehostname", []string{"a:b", "c:d"}, metrics)
+	assert.Equal(t, "somehostname", metrics[0].Hostname, "Metric hostname uses argument")
 	assert.Contains(t, metrics[0].Tags, "a:b", "Tags should contain server tags")
 }
 

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -34,3 +34,18 @@ func TestHostMagicTag(t *testing.T) {
 	assert.NotContains(t, metrics[0].Tags, "host:abc123", "Host tag should be removed")
 	assert.Contains(t, metrics[0].Tags, "x:e", "Last tag is still around")
 }
+
+func TestDeviceMagicTag(t *testing.T) {
+	metrics := []DDMetric{{
+		Name:       "foo.bar.baz",
+		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(1.0)}},
+		Tags:       []string{"gorch:frobble", "device:abc123", "x:e"},
+		MetricType: "rate",
+		Interval:   10,
+	}}
+
+	metrics = finalizeMetrics("badhostname", []string{"a:b", "c:d"}, metrics)
+	assert.Equal(t, "abc123", metrics[0].DeviceName, "Metric devicename should be from tag")
+	assert.NotContains(t, metrics[0].Tags, "device:abc123", "Host tag should be removed")
+	assert.Contains(t, metrics[0].Tags, "x:e", "Last tag is still around")
+}

--- a/samplers.go
+++ b/samplers.go
@@ -19,6 +19,7 @@ type DDMetric struct {
 	Tags       []string      `json:"tags,omitempty"`
 	MetricType string        `json:"type"`
 	Hostname   string        `json:"host"`
+	DeviceName string        `json:"device_name"`
 	Interval   int32         `json:"interval,omitempty"`
 }
 


### PR DESCRIPTION
#### Summary
Honor the "magic" tags as used in the official DogStatsD agent for overriding the host and device.


#### Motivation
The official DogStatsD server allows a metric to include a `host` tag that overrides the Metric's hostname and a `device` tags that overrides DeviceName. Initially we didn't need this, but now we'd like to override the host some metrics to cut down on cardinality.

#### Test plan
New tests!

r? @tummychow 
cc @ChimeraCoder 

