### PR TITLE
Add documentation for worker.go

### DIFF
--- a/http.go
+++ b/http.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Handler returns the Handler responsible for routing request processing.
 func (s *Server) Handler() http.Handler {
 	mux := goji.NewMux()
 
@@ -30,7 +31,7 @@ func (s *Server) Handler() http.Handler {
 			jsonMetrics []JSONMetric
 			body        io.ReadCloser
 			err         error
-			encoding    string = r.Header.Get("Content-Encoding")
+			encoding    = r.Header.Get("Content-Encoding")
 		)
 		switch encLogger := innerLogger.WithField("encoding", encoding); encoding {
 		case "":
@@ -73,7 +74,7 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-// feed a slice of json metrics to the server's workers
+// ImportMetrics feeds a slice of json metrics to the server's workers
 func (s *Server) ImportMetrics(jsonMetrics []JSONMetric) {
 	start := time.Now()
 

--- a/parser.go
+++ b/parser.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Metric is a representation of the sample provided by a client. The tag list
+// UDPMetric is a representation of the sample provided by a client. The tag list
 // should be deterministically ordered.
 type UDPMetric struct {
 	MetricKey
@@ -22,8 +22,7 @@ type UDPMetric struct {
 	LocalOnly  bool
 }
 
-// a struct used to key the metrics into the worker's map - must only contain
-// comparable types
+// MetricKey is a struct used to key the metrics into the worker's map. All fields must be comparable types.
 type MetricKey struct {
 	Name       string `json:"name"`
 	Type       string `json:"type"`
@@ -150,7 +149,7 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 	return ret, nil
 }
 
-// the json keys of this structure match datadog's undocumented /intake endpoint
+// UDPEvent represents the structure of datadog's undocumented /intake endpoint
 type UDPEvent struct {
 	Title       string   `json:"msg_title"`
 	Text        string   `json:"msg_text"`
@@ -163,6 +162,7 @@ type UDPEvent struct {
 	Tags        []string `json:"tags,omitempty"`
 }
 
+// ParseEvent parses a packet that represents a UDPEvent.
 func ParseEvent(packet []byte) (*UDPEvent, error) {
 	ret := &UDPEvent{
 		Timestamp:  time.Now().Unix(),
@@ -297,6 +297,7 @@ func ParseEvent(packet []byte) (*UDPEvent, error) {
 	return ret, nil
 }
 
+// UDPServiceCheck is a representation of the service check.
 type UDPServiceCheck struct {
 	Name      string   `json:"check"`
 	Status    int      `json:"status"`
@@ -306,6 +307,7 @@ type UDPServiceCheck struct {
 	Message   string   `json:"message,omitempty"`
 }
 
+// ParseServiceCheck parses a packet that represents a UDPServiceCheck.
 func ParseServiceCheck(packet []byte) (*UDPServiceCheck, error) {
 	ret := &UDPServiceCheck{
 		Timestamp: time.Now().Unix(),

--- a/samplers.go
+++ b/samplers.go
@@ -131,6 +131,7 @@ func (s *Set) Flush() []DDMetric {
 	}}
 }
 
+// Export converts a Set into a JSONMetric which reports the tags in the set.
 func (s *Set) Export() (JSONMetric, error) {
 	val, err := s.hll.GobEncode()
 	if err != nil {
@@ -147,6 +148,7 @@ func (s *Set) Export() (JSONMetric, error) {
 	}, nil
 }
 
+// Combine merges the values seen with another set (marshalled as a byte slice)
 func (s *Set) Combine(other []byte) error {
 	otherHLL, _ := hyperloglog.NewPlus(18)
 	if err := otherHLL.GobDecode(other); err != nil {
@@ -199,7 +201,7 @@ func NewHist(name string, tags []string) *Histo {
 	}
 }
 
-// this is the maximum number of DDMetrics that a histogram can flush if
+// HistogramLocalLength is the maximum number of DDMetrics that a histogram can flush if
 // len(percentiles)==0
 // specifically the count, min and max
 const HistogramLocalLength = 3
@@ -267,6 +269,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric 
 	return metrics
 }
 
+// Export converts a Histogram into a JSONMetric
 func (h *Histo) Export() (JSONMetric, error) {
 	val, err := h.value.GobEncode()
 	if err != nil {
@@ -283,6 +286,8 @@ func (h *Histo) Export() (JSONMetric, error) {
 	}, nil
 }
 
+// Combine merges the values of a histogram with another histogram
+// (marshalled as a byte slice)
 func (h *Histo) Combine(other []byte) error {
 	otherHistogram := tdigest.NewMerging(100, false)
 	if err := otherHistogram.GobDecode(other); err != nil {

--- a/sentry.go
+++ b/sentry.go
@@ -7,11 +7,9 @@ import (
 	"github.com/getsentry/raven-go"
 )
 
-// call inside deferred recover, eg
-// defer func() {
-// 	ConsumePanic(recover())
-// }
-// will report panic to sentry, print stack and then repanic (to ensure your program terminates)
+// ConsumePanic is intended to be called inside a deferred function when recovering
+// from a panic. It accepts the value of recover() as its only argument,
+// and reports the panic to Sentry, prints the stack,  and then repanics (to ensure your program terminates)
 func (s *Server) ConsumePanic(err interface{}) {
 	if err == nil {
 		return
@@ -101,7 +99,6 @@ func (s sentryHook) Fire(e *logrus.Entry) error {
 	if e.Level == logrus.PanicLevel || e.Level == logrus.FatalLevel {
 		// we don't want the program to terminate before reporting to sentry
 		return <-ch
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/server.go
+++ b/server.go
@@ -126,6 +126,10 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 // HandlePacket processes each packet that is sent to the server, and sends to an
 // appropriate worker (EventWorker or Worker).
 func (s *Server) HandlePacket(packet []byte) {
+  // This is a very performance-sensitive function
+  // and packets may be dropped if it gets slowed down.
+  // Keep that in mind when modifying!
+
 	if len(packet) == 0 {
 		// a lot of clients send packets that accidentally have a trailing
 		// newline, it's easier to just let them be

--- a/server.go
+++ b/server.go
@@ -14,9 +14,11 @@ import (
 	"github.com/zenazn/goji/graceful"
 )
 
-// must be a var so it can be set at link time
+// VERSION stores the current veneur version.
+// It must be a var so it can be set at link time.
 var VERSION = "dirty"
 
+// A Server is the actual veneur instance that will be run.
 type Server struct {
 	Workers     []*Worker
 	EventWorker *EventWorker
@@ -40,6 +42,7 @@ type Server struct {
 	HistogramPercentiles []float64
 }
 
+// NewFromConfig creates a new veneur server from a configuration specification.
 func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.Hostname = conf.Hostname
 	ret.Tags = conf.Tags
@@ -120,6 +123,8 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	return
 }
 
+// HandlePacket processes each packet that is sent to the server, and sends to an
+// appropriate worker (EventWorker or Worker).
 func (s *Server) HandlePacket(packet []byte) {
 	if len(packet) == 0 {
 		// a lot of clients send packets that accidentally have a trailing
@@ -163,6 +168,7 @@ func (s *Server) HandlePacket(packet []byte) {
 	}
 }
 
+// ReadSocket listens for available packets to handle.
 func (s *Server) ReadSocket(packetPool *sync.Pool, reuseport bool) {
 	// each goroutine gets its own socket
 	// if the sockets support SO_REUSEPORT, then this will cause the
@@ -204,6 +210,8 @@ func (s *Server) ReadSocket(packetPool *sync.Pool, reuseport bool) {
 	}
 }
 
+
+// HTTPServe starts the HTTP server and listens perpetually until it encounters an unrecoverable error.
 func (s *Server) HTTPServe() {
 	httpSocket := bind.Socket(s.HTTPAddr)
 	graceful.Timeout(10 * time.Second)
@@ -238,6 +246,7 @@ type SplitBytes struct {
 	lastChunk    bool
 }
 
+// NewSplitBytes initializes a SplitBytes struct with the provided buffer and delimiter.
 func NewSplitBytes(buf []byte, delim byte) *SplitBytes {
 	return &SplitBytes{
 		buf:   buf,

--- a/socket.go
+++ b/socket.go
@@ -6,6 +6,7 @@ import (
 	"net"
 )
 
+// NewSocket creates a socket which is intended for use by a single goroutine.
 func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, error) {
 	if reuseport {
 		panic("SO_REUSEPORT not supported on this platform")

--- a/worker.go
+++ b/worker.go
@@ -54,7 +54,8 @@ func NewWorkerMetrics() WorkerMetrics {
 	}
 }
 
-// Upsert creates an entry on the WorkerMetrics struct for the given metrickey, if it does not already exist.
+// Upsert creates an entry on the WorkerMetrics struct for the given metrickey (if one does not already exist)
+// and updates the existing entry (if one already exists).
 // Returns true if the metric entry was created and false otherwise.
 func (wm WorkerMetrics) Upsert(mk MetricKey, localOnly bool, tags []string) bool {
 	present := false

--- a/worker.go
+++ b/worker.go
@@ -23,7 +23,7 @@ type Worker struct {
 	wm         WorkerMetrics
 }
 
-// just a plain struct bundling together the flushed contents of a worker
+// WorkerMetrics is just a plain struct bundling together the flushed contents of a worker
 type WorkerMetrics struct {
 	// we do not want to key on the metric's Digest here, because those could
 	// collide, and then we'd have to implement a hashtable on top of go maps,
@@ -40,6 +40,7 @@ type WorkerMetrics struct {
 	localTimers     map[MetricKey]*Histo
 }
 
+// NewWorkerMetrics initializes a WorkerMetrics struct
 func NewWorkerMetrics() WorkerMetrics {
 	return WorkerMetrics{
 		counters:        make(map[MetricKey]*Counter),
@@ -53,7 +54,7 @@ func NewWorkerMetrics() WorkerMetrics {
 	}
 }
 
-// Create an entry in wm for the given metrickey, if it does not already exist.
+// Upsert creates an entry on the WorkerMetrics struct for the given metrickey, if it does not already exist.
 // Returns true if the metric entry was created and false otherwise.
 func (wm WorkerMetrics) Upsert(mk MetricKey, localOnly bool, tags []string) bool {
 	present := false
@@ -118,6 +119,8 @@ func NewWorker(id int, stats *statsd.Client, logger *logrus.Logger) *Worker {
 	}
 }
 
+// Work will start the worker listening for metrics to process or import.
+// It will not return until the worker is sent a message to terminate using Stop()
 func (w *Worker) Work() {
 	for {
 		select {
@@ -173,6 +176,7 @@ func (w *Worker) ProcessMetric(m *UDPMetric) {
 	}
 }
 
+// ImportMetric receives a metric from another veneur instance
 func (w *Worker) ImportMetric(other JSONMetric) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
@@ -237,7 +241,7 @@ func (w *Worker) Stop() {
 	close(w.QuitChan)
 }
 
-// A Worker that collects events and service checks instead of metrics.
+// EventWorker is similar to a Worker but it collects events and service checks instead of metrics.
 type EventWorker struct {
 	EventChan        chan UDPEvent
 	ServiceCheckChan chan UDPServiceCheck
@@ -247,6 +251,8 @@ type EventWorker struct {
 	stats            *statsd.Client
 }
 
+
+// NewEventWorker creates an EventWorker ready to collect events and service checks.
 func NewEventWorker(stats *statsd.Client) *EventWorker {
 	return &EventWorker{
 		EventChan:        make(chan UDPEvent),
@@ -256,6 +262,8 @@ func NewEventWorker(stats *statsd.Client) *EventWorker {
 	}
 }
 
+// Work will start the EventWorker listening for events and service checks.
+// This function will never return.
 func (ew *EventWorker) Work() {
 	for {
 		select {
@@ -271,6 +279,9 @@ func (ew *EventWorker) Work() {
 	}
 }
 
+
+// Flush returns the EventWorker's stored events and service checks and
+// resets the stored contents.
 func (ew *EventWorker) Flush() ([]UDPEvent, []UDPServiceCheck) {
 	start := time.Now()
 	ew.mutex.Lock()

--- a/worker.go
+++ b/worker.go
@@ -251,7 +251,6 @@ type EventWorker struct {
 	stats            *statsd.Client
 }
 
-
 // NewEventWorker creates an EventWorker ready to collect events and service checks.
 func NewEventWorker(stats *statsd.Client) *EventWorker {
 	return &EventWorker{
@@ -278,7 +277,6 @@ func (ew *EventWorker) Work() {
 		}
 	}
 }
-
 
 // Flush returns the EventWorker's stored events and service checks and
 // resets the stored contents.


### PR DESCRIPTION
#### Summary

As a way to start mapping the codebase for myself, I'm going through and fixing linting errors throughout veneur. Most of these are functions/structs which have no documentation string (or whose documentation does not start with the name of the function/struct).


Please take a look at the documentation I've added to verify that it is indeed correct!


r? @tummychow 
