### PR TITLE
Add test coverage for local server flushing

### DIFF
--- a/server.go
+++ b/server.go
@@ -126,9 +126,9 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 // HandlePacket processes each packet that is sent to the server, and sends to an
 // appropriate worker (EventWorker or Worker).
 func (s *Server) HandlePacket(packet []byte) {
-  // This is a very performance-sensitive function
-  // and packets may be dropped if it gets slowed down.
-  // Keep that in mind when modifying!
+	// This is a very performance-sensitive function
+	// and packets may be dropped if it gets slowed down.
+	// Keep that in mind when modifying!
 
 	if len(packet) == 0 {
 		// a lot of clients send packets that accidentally have a trailing
@@ -213,7 +213,6 @@ func (s *Server) ReadSocket(packetPool *sync.Pool, reuseport bool) {
 		packetPool.Put(buf)
 	}
 }
-
 
 // HTTPServe starts the HTTP server and listens perpetually until it encounters an unrecoverable error.
 func (s *Server) HTTPServe() {

--- a/server_test.go
+++ b/server_test.go
@@ -37,6 +37,15 @@ func localConfig() Config {
 	}
 }
 
+// assertMetrics checks that all expected metrics are present
+// and have the correct value
+func assertMetrics(t *testing.T, metrics DDMetricsRequest, expectedMetrics map[string]float64) {
+	// it doesn't count as accidentally quadratic if it's intentional
+	for metricName, expectedValue := range expectedMetrics {
+		assertMetric(t, metrics, metricName, expectedValue)
+	}
+}
+
 func assertMetric(t *testing.T, metrics DDMetricsRequest, metricName string, value float64) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -52,15 +61,10 @@ func assertMetric(t *testing.T, metrics DDMetricsRequest, metricName string, val
 	assert.FailNow(t, "did not find expected metric", metricName)
 }
 
-func assertMetrics(t *testing.T, metrics DDMetricsRequest, expectedMetrics map[string]float64) {
-	// it doesn't count as accidentally quadratic if it's intentional
-	for metricName, expectedValue := range expectedMetrics {
-		assertMetric(t, metrics, metricName, expectedValue)
-	}
-}
 
+// setupLocalServer creates a local server from the specified config
+// and starts listening for requests. It returns the server for inspection.
 func setupLocalServer(t *testing.T, config Config) Server {
-
 	server, err := NewFromConfig(config)
 	if err != nil {
 		t.Fatal(err)
@@ -95,6 +99,9 @@ func setupLocalServer(t *testing.T, config Config) Server {
 	return server
 }
 
+
+// DDMetricsRequest represents the body of the POST request
+// for sending metrics data to Datadog
 type DDMetricsRequest struct {
 	Series []DDMetric
 }

--- a/server_test.go
+++ b/server_test.go
@@ -36,6 +36,9 @@ func localConfig() Config {
 		// on platforms which do not support SO_REUSEPORT
 		NumReaders: 1,
 
+		// Currently this points nowhere, which is intentional.
+		// We don't need internal metrics for the tests, and they make testing
+		// more complicated.
 		StatsAddr:  "localhost:8125",
 		Tags:       []string{},
 		SentryDSN:  "",

--- a/server_test.go
+++ b/server_test.go
@@ -136,65 +136,19 @@ func TestLocalServer(t *testing.T) {
 
 	server := setupLocalServer(t, config)
 
-	metrics := []UDPMetric{
-		{
+	metricValues := []float64{1.0, 2.0, 7.0, 8.0, 100.0}
+
+	for _, value := range metricValues {
+		server.Workers[0].ProcessMetric(&UDPMetric{
 			MetricKey: MetricKey{
 				Name: "a.b.c",
 				Type: "histogram",
 			},
-			Value:      1.0,
+			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
 			LocalOnly:  true,
-		},
-		{
-
-			MetricKey: MetricKey{
-				Name: "a.b.c",
-				Type: "histogram",
-			},
-			Value:      2.0,
-			Digest:     12345,
-			SampleRate: 1.0,
-			LocalOnly:  true,
-		},
-		{
-
-			MetricKey: MetricKey{
-				Name: "a.b.c",
-				Type: "histogram",
-			},
-			Value:      7.0,
-			Digest:     12345,
-			SampleRate: 1.0,
-			LocalOnly:  true,
-		},
-		{
-
-			MetricKey: MetricKey{
-				Name: "a.b.c",
-				Type: "histogram",
-			},
-			Value:      8.0,
-			Digest:     12345,
-			SampleRate: 1.0,
-			LocalOnly:  true,
-		},
-		{
-
-			MetricKey: MetricKey{
-				Name: "a.b.c",
-				Type: "histogram",
-			},
-			Value:      100.0,
-			Digest:     12345,
-			SampleRate: 1.0,
-			LocalOnly:  true,
-		},
-	}
-
-	for _, metric := range metrics {
-		server.Workers[0].ProcessMetric(&metric)
+		})
 	}
 	server.Flush(config.Interval, config.FlushLimit)
 }

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -1,385 +1,346 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package assert
 
 import (
-
 	http "net/http"
 	url "net/url"
 	time "time"
 )
-
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 	return Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	return False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // InEpsilonSlice is the same as InEpsilon, except it compares two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	return Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	return Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	return NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	return True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {


### PR DESCRIPTION
#### Summary

Increase test coverage of `flusher.go` from 5.2% to 60%!


![screenshot 2016-09-22 09 45 55](https://cloud.githubusercontent.com/assets/376414/18757602/6bf097ea-80a9-11e6-9f0a-8be14da46019.png)

![screenshot 2016-09-22 09 45 26](https://cloud.githubusercontent.com/assets/376414/18757603/6c014c70-80a9-11e6-8c4e-32a7e76a9122.png)




#### Motivation

Adding pluggable backends will require some nontrivial refactoring of this function (and some related functions). Since the current version works, we should make sure that it's well-tested before we modify it.

#### Test plan


Added tests!

#### Rollout/monitoring/revert plan

None needed


r? @tummychow 