### PR TITLE
Add shutdown function for server

### DIFF
--- a/server.go
+++ b/server.go
@@ -228,7 +228,14 @@ func (s *Server) HTTPServe() {
 	if err := graceful.Serve(httpSocket, s.Handler()); err != nil {
 		s.logger.WithError(err).Error("HTTP server shut down due to error")
 	}
-	graceful.Wait()
+
+	graceful.Shutdown()
+}
+
+// Shutdown signals the server to shut down after closing all
+// current connections.
+func (s *Server) Shutdown() {
+	graceful.Shutdown()
 }
 
 // SplitBytes iterates over a byte buffer, returning chunks split by a given

--- a/server.go
+++ b/server.go
@@ -235,6 +235,7 @@ func (s *Server) HTTPServe() {
 // Shutdown signals the server to shut down after closing all
 // current connections.
 func (s *Server) Shutdown() {
+	// TODO(aditya) shut down workers and socket readers
 	s.logger.Info("Shutting down server gracefully")
 	graceful.Shutdown()
 }

--- a/server.go
+++ b/server.go
@@ -235,6 +235,7 @@ func (s *Server) HTTPServe() {
 // Shutdown signals the server to shut down after closing all
 // current connections.
 func (s *Server) Shutdown() {
+	s.logger.Info("Shutting down server gracefully")
 	graceful.Shutdown()
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -138,6 +138,7 @@ func TestLocalServer(t *testing.T) {
 	config.APIHostname = globalServer.URL
 
 	server := setupLocalServer(t, config)
+	defer server.Shutdown()
 
 	metricValues := []float64{1.0, 2.0, 7.0, 8.0, 100.0}
 


### PR DESCRIPTION
#### Summary

Add a shutdown function to the server. This allows us to write tests without leaving dangling servers.

#### Motivation

tests++
dangling_servers--

#### Test plan

```sh
$ go test -run TestLocalServer
INFO[0000] Starting server                               version=dirty
INFO[0000] Starting workers                              number=96
INFO[0000] HTTP server listening                         address=localhost:8127
INFO[0000] Completed flush to Datadog                    metrics=6
INFO[0000] Shutting down server gracefully
INFO[0000] Terminating HTTP listener
PASS
```

#### Rollout/monitoring/revert plan

N/A


r? @tummychow 

