### PR TITLE
Add test for parsing config file

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,57 @@
+package veneur
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadConfig(t *testing.T) {
+
+	// It's better not to require read access on the filesystem
+	// in tests if we can avoid it
+	const exampleConfig = `---
+api_hostname: https://app.datadoghq.com
+metric_max_length: 4096
+flush_max_per_body: 25000
+publish_histogram_counters: true
+debug: true
+interval: "10s"
+key: "farts"
+num_workers: 96
+num_readers: 4
+percentiles:
+  - 0.5
+  - 0.75
+  - 0.99
+read_buffer_size_bytes: 2097152
+stats_address: "localhost:8125"
+tags:
+ - "foo:bar"
+#  - "baz:gorch"
+udp_address: "localhost:8126"
+#http_address: "einhorn@0"
+http_address: "localhost:8127"
+forward_address: "http://veneur.example.com"
+# Defaults to the os.Hostname()!
+# hostname: foobar`
+
+	r := strings.NewReader(exampleConfig)
+	c, err := readConfig(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "https://app.datadoghq.com", c.APIHostname)
+	assert.Equal(t, 96, c.NumWorkers)
+}
+
+func TestReadBadConfig(t *testing.T) {
+	const exampleConfig = `--- api_hostname: :bad`
+	r := strings.NewReader(exampleConfig)
+	c, err := readConfig(r)
+
+	assert.NotNil(t, err, "Should have encountered parsing error when reading invalid config file")
+	assert.Equal(t, c, Config{}, "Parsing invalid config file should return zero struct")
+}


### PR DESCRIPTION
#### Summary

This takes us from 0% coverage of `config.go` to 56% coverage.

Unfortunately the YAML package we use doesn't support reader inputs. There's a PR on that upstream, but it's blocked on a contributor agreement at the moment (https://github.com/go-yaml/yaml/pull/163).


#### Motivation

Better test coverage

#### Test plan

Added test

#### Rollout/monitoring/revert plan

N/A


r? @gphat || @tummychow 

