### PR TITLE
Add tests for reporting to both global and remote

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -28,8 +28,21 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// On the CI server, we can't be guaranteed that the port will be
+// released immediately after the server is shut down. Instead, use
+// a unique port for each test. As long as we don't have an insane number
+// of integration tests, we should be fine.
+var HttpAddrPort = 8127
+
+var localHandler http.Handler
+
+
+
 // set up a boilerplate local config for later use
 func localConfig() Config {
+  port := HttpAddrPort
+  HttpAddrPort++
+
 	return Config{
 		APIHostname: "http://localhost",
 		Debug:       DebugMode,
@@ -42,7 +55,7 @@ func localConfig() Config {
 		Percentiles:         []float64{.5, .75, .99},
 		ReadBufferSizeBytes: 2097152,
 		UDPAddr:             "localhost:8126",
-		HTTPAddr:            "localhost:8127",
+		HTTPAddr:            fmt.Sprintf("localhost:%d", port),
 		ForwardAddr:         "http://localhost",
 		NumWorkers:          96,
 


### PR DESCRIPTION
#### Summary

Add a test for a client that reports to both a global veneur instance and a remote API. I also added copious comments to explain the components.


Since this involves asynchronous communication with the global server, we have to ensure that the test itself always runs (see comment to this effect). I did the same thing (more or less) for the remote server as well - even though that communication is synchronous, we may not always have that guarantee, and I'd rather make sure that our tests are always testing for correct behavior if we decide to change that in the future. (Besides, an extra `defer`/`assert` combo is pretty cheap).


As with the other PRs, we could possibly make this a bit cleaner, but I'd rather save the refactoring all for once, since right now we're just adding tests for existing functionality incrementally.


#### Motivation

Moar tests

#### Test plan

I heard you like tests, so I added test, and then added a test that our test is actually testing.

#### Rollout/monitoring/revert plan

N/A


r? @tummychow 
