### PR TITLE
Add Go 1.7 and tip to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: go
 go:
   - 1.6
+  - 1.7
+  - tip


### PR DESCRIPTION
#### Summary

Currently, we're only testing against 1.6, which is no longer the most recent stable release of Go.

This PR adds the most recent stable release (1.6) and also tip. Tip is stable enough that any failures here represent things we should already be future-proofing against (rather than upstream problems). That way, we can be sure veneur will work with each stable release of Go even before it lands.

One admitted disadvantage is that `tip` tests take longer than stable releases - for example, on the build for this PR, the tests for 1.6 and 1.7 completed in 33 seconds, but the tip release took 2 minutes. I think that's fine for our purposes - our tests themselves are fast enough that we don't expect build times to increase substantially beyond this, and the only practical implication is that the yellow 'pending' icon shows up for a bit longer. (Clicking through that will almost always display the outcome of the stable release tests, because it usually takes more than 33 seconds after pushing a branch to write a PR in the first place!)


#### Motivation

Better testing, future-proofing.

#### Test plan

See CI build

#### Rollout/monitoring/revert plan

N/A


r? @tummychow  || @gphat (stephen is AFK right now)
