### PR TITLE
Update Dockerfile to use Go 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build


### PR DESCRIPTION
#### Summary

Use Go 1.7 as the base docker image. Namely, this will update our Jenkins builds to use Go 1.7, which has some new stdlib helper functions we care about.

#### Motivation

This is a prerequisite for https://github.com/stripe/veneur/pull/68. Submitting as a separate PR since it's distinct enough.

#### Test plan

Existing tests

#### Rollout/monitoring/revert plan

At the moment, we just need this for our tests. But we should probably deploy veneur shortly after merging this anyway, so we can monitor for any other unexpected issues (e.g. performance implications).


r? @gphat || @tummychow 

