### PR TITLE
Disable CI tests for Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 go:
-  - 1.6
   - 1.7
   - tip

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Veneur (venn-urr) is a server implementation of the [DogStatsD protocol](http://
 
 Veneur is currently handling all metrics for Stripe and is considered production ready. It is, however, still in heavy development and may change!
 
+Building veneur requires Go 1.7 or later.
+
 # Motivation
 
 We wanted percentiles, histograms and sets to be global. Veneur helps us do that!


### PR DESCRIPTION
#### Summary

Disable CI tests for Go 1.6 (ie, make Veneur 1.7+ only)

#### Motivation


After https://github.com/stripe/veneur/pull/70 lands, Veneur will run on Go 1.7 (but tests will still run on 1.6 as well). Before  https://github.com/stripe/veneur/pull/68 can land, we need to make 1.7+ is required.

#### Test plan

Anti-test!

#### Rollout/monitoring/revert plan

N/A


r? @gphat || @tummychow 
