### PR TITLE
Add error handling for empty data posted to /import

### DIFF
--- a/handlers_global.go
+++ b/handlers_global.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"time"
 
 	"golang.org/x/net/context"
@@ -58,6 +59,29 @@ func handleImport(s *Server) http.Handler {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			innerLogger.WithError(err).Error("Could not decode /import request")
 			s.statsd.Count("import.request_error_total", 1, []string{"cause:json"}, 1.0)
+			return
+		}
+
+		if len(jsonMetrics) == 0 {
+			const msg = "Received empty /import request"
+			http.Error(w, msg, http.StatusBadRequest)
+			innerLogger.WithError(err).Error(msg)
+			return
+		}
+
+		var nonEmpty bool
+		sentinel := JSONMetric{}
+		for _, metric := range jsonMetrics {
+			if !reflect.DeepEqual(sentinel, metric) {
+				nonEmpty = true
+				break
+			}
+		}
+
+		if !nonEmpty {
+			const msg = "Received empty or improperly-formed metrics"
+			http.Error(w, msg, http.StatusBadRequest)
+			innerLogger.Error(msg)
 			return
 		}
 

--- a/handlers_global.go
+++ b/handlers_global.go
@@ -69,10 +69,15 @@ func handleImport(s *Server) http.Handler {
 			return
 		}
 
+		// We want to make sure we have at least one entry
+		// that is not empty (ie, all fields are the zero value)
+		// because that is usually the sign that we are unmarshalling
+		// into the wrong struct type
 		var nonEmpty bool
 		sentinel := JSONMetric{}
 		for _, metric := range jsonMetrics {
 			if !reflect.DeepEqual(sentinel, metric) {
+				// we have found at least one entry that is properly formed
 				nonEmpty = true
 				break
 			}

--- a/http_test.go
+++ b/http_test.go
@@ -258,7 +258,7 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupLocalServer(t, config)
+	s := setupVeneurServer(t, config)
 	defer s.Shutdown()
 
 	handler := handleImport(&s)


### PR DESCRIPTION
#### Summary

While it's still fresh-in-mind, here are two more tests for edge cases that we want to look out for. 

The first checks for an empty list (and tests that the server properly handles an empty list). This is unlikely to happen, since we explicitly check for empty data before posting to `/import` in the flusher, but this adds an extra check. If we end up in this situation, it's likely that we're dropping data we shouldn't be.


The second checks that the unmarshalled data is non-empty. This is a subtler edge case - we'd run into it if we changed the schema of the data on the client without changing it on the server. This is also unlikely to happen, but if it does, we don't want the error to happen silently.

Now, this approach does use reflection, for simplicity. I'd be interested in profiling this on Monday to see the exact impact, but since this isn't our critical code path, I doubt it'll be prohibitive.


#### Motivation

Don't silently drop data. Well, no more than we have to. #thanksUDP

#### Test plan

Added tests for the additional checks

#### Rollout/monitoring/revert plan

Profile, deploy, monitor flush times.


r? @tummychow 

