### PR TITLE
Separate flushing globally from flushing locally

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -184,7 +184,7 @@ func (s *Server) generateDDMetrics(interval time.Duration, percentiles []float64
 
 // reportMetricsFlushCounts reports the counts of
 // Counters, Gauges, LocalHistograms, LocalSets, and LocalTimers
-// to Datadog. These are shared by both global and local flush operations.
+// as metrics. These are shared by both global and local flush operations.
 // It does *not* report the totalHistograms, totalSets, or totalTimers
 // because those are only performed by the global veneur instance.
 // It also does not report the total metrics posted, because on the local veneur,

--- a/flusher.go
+++ b/flusher.go
@@ -19,6 +19,9 @@ import (
 // Flush takes the slices of metrics, combines then and marshals them to json
 // for posting to Datadog.
 func (s *Server) Flush(interval time.Duration, metricLimit int) {
+	// right now we have only one destination plugin
+	// but eventually, this is where we would loop over our supported
+	// destinations
 	if s.IsLocal() {
 		s.FlushLocal(interval, metricLimit)
 	} else {

--- a/flusher.go
+++ b/flusher.go
@@ -18,7 +18,7 @@ import (
 
 // Flush takes the slices of metrics, combines then and marshals them to json
 // for posting to Datadog.
-func (s *Server) Flush(interval time.Duration, metricLimit int) {
+func (s *Server) FlushGlobal(interval time.Duration, metricLimit int) {
 	go s.flushEventsChecks() // we can do all of this separately
 
 	percentiles := s.HistogramPercentiles
@@ -165,6 +165,164 @@ func (s *Server) Flush(interval time.Duration, metricLimit int) {
 
 	s.logger.WithField("metrics", len(finalMetrics)).Info("Completed flush to Datadog")
 }
+
+
+
+
+// Flush takes the slices of metrics, combines then and marshals them to json
+// for posting to Datadog.
+func (s *Server) FlushLocal(interval time.Duration, metricLimit int) {
+	go s.flushEventsChecks() // we can do all of this separately
+
+	percentiles := s.HistogramPercentiles
+	if s.ForwardAddr != "" {
+		// don't publish percentiles if we're a local veneur; that's the global
+		// veneur's job
+		percentiles = nil
+	}
+
+	// allocating this long array to count up the sizes is cheaper than appending
+	// the []DDMetrics together one at a time
+	tempMetrics := make([]WorkerMetrics, 0, len(s.Workers))
+	var (
+		totalCounters   int
+		totalGauges     int
+		totalHistograms int
+		totalSets       int
+		totalTimers     int
+
+		totalLocalHistograms int
+		totalLocalSets       int
+		totalLocalTimers     int
+	)
+	gatherStart := time.Now()
+	for i, w := range s.Workers {
+		s.logger.WithField("worker", i).Debug("Flushing")
+		wm := w.Flush()
+		tempMetrics = append(tempMetrics, wm)
+
+		totalCounters += len(wm.counters)
+		totalGauges += len(wm.gauges)
+		totalHistograms += len(wm.histograms)
+		totalSets += len(wm.sets)
+		totalTimers += len(wm.timers)
+
+		totalLocalHistograms += len(wm.localHistograms)
+		totalLocalSets += len(wm.localSets)
+		totalLocalTimers += len(wm.localTimers)
+	}
+	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(gatherStart).Nanoseconds()), []string{"part:gather"}, 1.0)
+
+	totalLength := totalCounters + totalGauges + (totalTimers+totalHistograms)*(HistogramLocalLength+len(percentiles)) +
+		// local-only histograms will be flushed with percentiles, so we intentionally
+		// use the original percentile list here
+		totalLocalSets + (totalLocalTimers+totalLocalHistograms)*(HistogramLocalLength+len(s.HistogramPercentiles))
+	if s.ForwardAddr == "" {
+		totalLength += totalSets
+	}
+
+	combineStart := time.Now()
+	finalMetrics := make([]DDMetric, 0, totalLength)
+	for _, wm := range tempMetrics {
+		for _, c := range wm.counters {
+			finalMetrics = append(finalMetrics, c.Flush(interval)...)
+		}
+		for _, g := range wm.gauges {
+			finalMetrics = append(finalMetrics, g.Flush()...)
+		}
+		// if we're a local veneur, then percentiles=nil, and only the local
+		// parts (count, min, max) will be flushed
+		for _, h := range wm.histograms {
+			finalMetrics = append(finalMetrics, h.Flush(interval, percentiles)...)
+		}
+		for _, t := range wm.timers {
+			finalMetrics = append(finalMetrics, t.Flush(interval, percentiles)...)
+		}
+
+		// local-only samplers should be flushed in their entirety, since they
+		// will not be forwarded
+		// we still want percentiles for these, even if we're a local veneur, so
+		// we use the original percentile list when flushing them
+		for _, h := range wm.localHistograms {
+			finalMetrics = append(finalMetrics, h.Flush(interval, s.HistogramPercentiles)...)
+		}
+		for _, s := range wm.localSets {
+			finalMetrics = append(finalMetrics, s.Flush()...)
+		}
+		for _, t := range wm.localTimers {
+			finalMetrics = append(finalMetrics, t.Flush(interval, s.HistogramPercentiles)...)
+		}
+
+		if s.ForwardAddr == "" {
+			// sets have no local parts, so if we're a local veneur, there's
+			// nothing to flush at all
+			for _, s := range wm.sets {
+				finalMetrics = append(finalMetrics, s.Flush()...)
+			}
+		}
+	}
+
+	finalizeMetrics(s.Hostname, s.Tags, finalMetrics)
+
+	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(combineStart).Nanoseconds()), []string{"part:combine"}, 1.0)
+
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalCounters), []string{"metric_type:counter"}, 1.0)
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalGauges), []string{"metric_type:gauge"}, 1.0)
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalLocalHistograms), []string{"metric_type:local_histogram"}, 1.0)
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalLocalSets), []string{"metric_type:local_set"}, 1.0)
+	s.statsd.Count("worker.metrics_flushed_total", int64(totalLocalTimers), []string{"metric_type:local_timer"}, 1.0)
+	if s.ForwardAddr == "" {
+		// only report these lengths if we're the global veneur instance
+		// responsible for flushing them
+		// this avoids double-counting problems where a local veneur reports
+		// histograms that it received, and then a global veneur reports them
+		// again
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalHistograms), []string{"metric_type:histogram"}, 1.0)
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalSets), []string{"metric_type:set"}, 1.0)
+		s.statsd.Count("worker.metrics_flushed_total", int64(totalTimers), []string{"metric_type:timer"}, 1.0)
+	}
+
+	if s.ForwardAddr != "" {
+		// we cannot do this until we're done using tempMetrics here, since
+		// not everything in tempMetrics is safe for sharing
+		go s.flushForward(tempMetrics)
+	}
+
+	s.statsd.Gauge("flush.post_metrics_total", float64(len(finalMetrics)), nil, 1.0)
+	// Check to see if we have anything to do
+	if len(finalMetrics) == 0 {
+		s.logger.Info("Nothing to flush, skipping.")
+		return
+	}
+
+	// break the metrics into chunks of approximately equal size, such that
+	// each chunk is less than the limit
+	// we compute the chunks using rounding-up integer division
+	workers := ((len(finalMetrics) - 1) / metricLimit) + 1
+	chunkSize := ((len(finalMetrics) - 1) / workers) + 1
+	s.logger.WithField("workers", workers).Debug("Worker count chosen")
+	s.logger.WithField("chunkSize", chunkSize).Debug("Chunk size chosen")
+	var wg sync.WaitGroup
+	flushStart := time.Now()
+	for i := 0; i < workers; i++ {
+		chunk := finalMetrics[i*chunkSize:]
+		if i < workers-1 {
+			// trim to chunk size unless this is the last one
+			chunk = chunk[:chunkSize]
+		}
+		wg.Add(1)
+		go s.flushPart(chunk, &wg)
+	}
+	wg.Wait()
+	s.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Now().Sub(flushStart).Nanoseconds()), []string{"part:post"}, 1.0)
+
+	s.logger.WithField("metrics", len(finalMetrics)).Info("Completed flush to Datadog")
+}
+
+
+
+
+
 
 func finalizeMetrics(hostname string, tags []string, finalMetrics []DDMetric) {
 	for i := range finalMetrics {

--- a/http_test.go
+++ b/http_test.go
@@ -102,7 +102,7 @@ func testServerImport(t *testing.T, filename string, contentEncoding string) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupLocalServer(t, config)
+	s := setupVeneurServer(t, config)
 	defer s.Shutdown()
 
 	handler := handleImport(&s)

--- a/server.go
+++ b/server.go
@@ -240,7 +240,7 @@ func (s *Server) Shutdown() {
 	graceful.Shutdown()
 }
 
-// IsGlobal indicates whether veneur is running as a local instance
+// IsLocal indicates whether veneur is running as a local instance
 // (forwarding non-local data to a global veneur instance) or is running as a global
 // instance (sending all data directly to the final destination).
 func (s *Server) IsLocal() bool {

--- a/server.go
+++ b/server.go
@@ -240,6 +240,13 @@ func (s *Server) Shutdown() {
 	graceful.Shutdown()
 }
 
+// IsGlobal indicates whether veneur is running as a local instance
+// (forwarding non-local data to a global veneur instance) or is running as a global
+// instance (sending all data directly to the final destination).
+func (s *Server) IsLocal() bool {
+	return s.ForwardAddr != ""
+}
+
 // SplitBytes iterates over a byte buffer, returning chunks split by a given
 // delimiter byte. It does not perform any allocations, and does not modify the
 // buffer it is given. It is not safe for use by concurrent goroutines.


### PR DESCRIPTION
#### Summary

Split server flushing into two components (`FlushLocal` and `FlushGlobal`). Also, add a basic for global server flushing, which we did not previously have.

This is a revised version of https://github.com/stripe/veneur/pull/74. Unlike #74, this PR regroups the common parts of local and global flushing. These common components can now be tested individually (though I have not written those individual tests yet).

This diff is a little wonky to read, unfortunately. Git doesn't quite understand what to do when extracting pieces of long functions like this one.

#### Motivation

From pairing with @antifuchs two weeks ago on getting pluggable destination support, this was the logical first step. Fundamentally, flushing locally and flushing globally are different operations - it's much easier if we allow a plugin to specify different actions when flushing locally vs. globally, and simply taking in the `ForwardAddr` as a parameter and switching on that is a bit awkward.

#### Test plan

Added test for global server flushing. We are now at 73% coverage for this file.

#### Rollout/monitoring/revert plan

Deploy on globalstats canary first, then roll out there. Then, canary with an observability service, repeat.


r? @gphat || @tummychow 
