### PR TITLE
Remove bogus config option.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -15,7 +15,6 @@ func TestReadConfig(t *testing.T) {
 api_hostname: https://app.datadoghq.com
 metric_max_length: 4096
 flush_max_per_body: 25000
-publish_histogram_counters: true
 debug: true
 interval: "10s"
 key: "farts"

--- a/example.yaml
+++ b/example.yaml
@@ -2,7 +2,6 @@
 api_hostname: https://app.datadoghq.com
 metric_max_length: 4096
 flush_max_per_body: 25000
-publish_histogram_counters: true
 debug: true
 interval: "10s"
 key: "farts"


### PR DESCRIPTION
#### Summary
Remove unused and confusing config option.


#### Motivation
It's confusing and because @ross was nice enough to report it. :)


#### Test plan
Didn't. It's unused and tests will catch me if I'm wrong.


#### Rollout/monitoring/revert plan
* Merge
* ???
* Profit!

r? @chimeracoder || @tummychow


