### PR TITLE
Post metrics to S3 as TSV instead of JSON

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -222,7 +222,7 @@ func (s *Server) flushS3(finalMetrics []DDMetric) {
 	if err != nil {
 		s.logger.WithFields(logrus.Fields{
 			"metrics": len(finalMetrics),
-		}).Error("Could not marshal finalMetrics before posting to s3")
+		}).Error("Could not marshal finalMetrics before posting to s3: ", err)
 		return
 	}
 
@@ -232,7 +232,7 @@ func (s *Server) flushS3(finalMetrics []DDMetric) {
 	if err != nil {
 		s.logger.WithFields(logrus.Fields{
 			"metrics": len(finalMetrics),
-		}).Error("Could not unfurl csv before posting to s3")
+		}).Error("Could not unfurl csv before posting to s3: ", err)
 		return
 	}
 	seekableData := bytes.NewReader(bts)
@@ -241,7 +241,7 @@ func (s *Server) flushS3(finalMetrics []DDMetric) {
 	if err != nil {
 		s.logger.WithFields(logrus.Fields{
 			"metrics": len(finalMetrics),
-		}).Error("Error posting to s3")
+		}).Error("Error posting to s3: ", err)
 		return
 	}
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -26,6 +26,17 @@ func (m *mockS3Client) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput,
 	return m.putObject(input)
 }
 
+// stubS3 sets svc to a mockS3Client that will return 200 for all responses
+// useful for avoiding erroneous error log lines when testing things that aren't
+// related to s3.
+func stubS3() {
+	client := &mockS3Client{}
+	client.putObject = func(*s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+		return &s3.PutObjectOutput{ETag: aws.String("912ec803b2ce49e4a541068d495ab570")}, nil
+	}
+	svc = client
+}
+
 // TestS3Post tests that we can correctly post a sequence of
 // DDMetrics to S3
 func TestS3Post(t *testing.T) {

--- a/samplers.go
+++ b/samplers.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"encoding/csv"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -68,7 +69,9 @@ func init() {
 
 // encodeTSV generates a newline-terminated TSV row that describes
 // the data represented by the DDMetric
-func (d DDMetric) encodeTSV() string {
+func (d DDMetric) encodeTSV(w *csv.Writer) error {
+	w.Comma = '\t'
+
 	timestamp := d.Value[0][0]
 	value := strconv.FormatFloat(d.Value[0][1], 'f', -1, 64)
 	interval := strconv.Itoa(int(d.Interval))
@@ -99,7 +102,13 @@ func (d DDMetric) encodeTSV() string {
 		}
 	}
 
-	return strings.Join(fields[:], "\t") + "\n"
+	err := w.Write(fields[:])
+	if err != nil {
+		return err
+	}
+
+	w.Flush()
+	return w.Error()
 }
 
 // JSONMetric is used to represent a metric that can be remarshaled with its

--- a/samplers.go
+++ b/samplers.go
@@ -102,11 +102,7 @@ func (d DDMetric) encodeTSV(w *csv.Writer) error {
 		}
 	}
 
-	err := w.Write(fields[:])
-	if err != nil {
-		return err
-	}
-
+	w.Write(fields[:])
 	w.Flush()
 	return w.Error()
 }

--- a/samplers.go
+++ b/samplers.go
@@ -110,6 +110,22 @@ func encodeDDMetricsCSV(metrics []DDMetric, delimiter rune) (io.Reader, error) {
 	w := csv.NewWriter(b)
 	w.Comma = delimiter
 
+	// Write the headers first
+	headers := [...]string{
+		// the order here doesn't actually matter
+		// as long as the keys are right
+		tsvName:       tsvName.String(),
+		tsvTags:       tsvTags.String(),
+		tsvMetricType: tsvMetricType.String(),
+		tsvHostname:   tsvHostname.String(),
+		tsvDeviceName: tsvDeviceName.String(),
+		tsvInterval:   tsvInterval.String(),
+		tsvValue:      tsvValue.String(),
+		tsvTimestamp:  tsvTimestamp.String(),
+	}
+
+	w.Write(headers[:])
+
 	for _, metric := range metrics {
 		metric.encodeCSV(w)
 	}

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -265,7 +265,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "food",
 				Interval:   0,
 			},
-			Row: strings.NewReader("a.b.c.max\t[foo:bar,baz:quz]\tgauge\tglobalstats\tfood\t0\t1476119058\t100\n"),
+			Row: strings.NewReader("a.b.c.max\t{foo:bar,baz:quz}\tgauge\tglobalstats\tfood\t0\t1476119058\t100\n"),
 		},
 		{
 			// Test that we are able to handle a missing field (DeviceName)
@@ -281,7 +281,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "",
 				Interval:   10,
 			},
-			Row: strings.NewReader("a.b.c.max\t[foo:bar,baz:quz]\trate\tlocalhost\t\t10\t1476119058\t100\n"),
+			Row: strings.NewReader("a.b.c.max\t{foo:bar,baz:quz}\trate\tlocalhost\t\t10\t1476119058\t100\n"),
 		},
 		{
 			// Test that we are able to handle tags which have tab characters in them
@@ -299,7 +299,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "eniac",
 				Interval:   10,
 			},
-			Row: strings.NewReader("a.b.c.max\t\"[foo:b\tar,baz:quz]\"\trate\tlocalhost\teniac\t10\t1476119058\t100\n"),
+			Row: strings.NewReader("a.b.c.max\t\"{foo:b\tar,baz:quz}\"\trate\tlocalhost\teniac\t10\t1476119058\t100\n"),
 		},
 	}
 }
@@ -338,7 +338,7 @@ func TestEncodeDDMetricsCSV(t *testing.T) {
 		metrics[i] = tc.DDMetric
 	}
 
-	c, err := encodeDDMetricsCSV(metrics, Delimiter)
+	c, err := encodeDDMetricsCSV(metrics, Delimiter, true)
 	assert.NoError(t, err)
 	r := csv.NewReader(c)
 	r.FieldsPerRecord = 8

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"math/rand"
 	"strconv"
@@ -297,7 +296,6 @@ func TestEncodeTSV(t *testing.T) {
 			err := tc.DDMetric.encodeTSV(w)
 			assert.NoError(t, err)
 
-			log.Printf("asdf %s", b.String())
 			assertReadersEqual(t, tc.Row, b)
 		})
 	}
@@ -314,7 +312,6 @@ func assertReadersEqual(t *testing.T, expected io.Reader, actual io.Reader) {
 	}
 
 	// do the lazy thing for now
-
 	bts, err := ioutil.ReadAll(expected)
 	if err != nil {
 		t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -168,6 +168,8 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 		}
 	}()
 
+	stubS3()
+
 	metricValues := []float64{1.0, 2.0, 7.0, 8.0, 100.0}
 
 	expectedMetrics := map[string]float64{


### PR DESCRIPTION
#### Summary

Post S3 archives as TSV instead of JSON.

#### Motivation

TSV has a number of advantages. For us, it fits in better with our Redshift pipeline. It also allows for streamed input, though since each file represents one flush chunk, that's less of a pain point.

#### Test plan

Added tests for two examples (with one common edge case). We'll want to flesh these out a bit more.

#### Rollout/monitoring/revert plan


Deploy to canary on QA, enable for (at least) a few minutes, check S3.


r? @tummychow 
