### PR TITLE
Load AWS region and bucket from config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	Tags                []string      `yaml:"tags"`
 	SentryDSN           string        `yaml:"sentry_dsn"`
 	FlushLimit          int           `yaml:"flush_max_per_body"`
+	AWSAccessKeyId      string        `yaml:"aws_access_key_id"`
+	AWSSecretAccessKey  string        `yaml:"aws_secret_access_key"`
+	AWSRegion           string        `yaml:"aws_region"`
+	AWSBucket           string        `yaml:"aws_s3_bucket"`
 }
 
 // ReadConfig unmarshals the config file and slurps in it's data.

--- a/example.yaml
+++ b/example.yaml
@@ -22,3 +22,9 @@ http_address: "localhost:8127"
 forward_address: "http://veneur.example.com"
 # Defaults to the os.Hostname()!
 # hostname: foobar
+
+## Add these if you want to archive data to S3
+#aws_access_key_id: "foo"
+#aws_secret_access_key: "bar"
+#aws_region: "us-west-2"
+#aws_s3_bucket: "stripe-veneur"

--- a/flusher.go
+++ b/flusher.go
@@ -228,7 +228,7 @@ func (s *Server) flushS3(finalMetrics []DDMetric) {
 		return
 	}
 
-	err = s3Post(s.Hostname, csv)
+	err = s3Post(s.Hostname, csv, tsvFt)
 	if err != nil {
 		s.logger.WithFields(logrus.Fields{
 			logrus.ErrorKey: err,

--- a/s3.go
+++ b/s3.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
-const S3Bucket = "stripe-veneur"
+const S3Bucket = "stripe-test-veneur"
 
 // TODO(aditya) config-ify this
 const DefaultAWSRegion = "us-west-2"

--- a/s3.go
+++ b/s3.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"errors"
 	"io"
+	"log"
 	"path"
 	"strconv"
 	"time"
@@ -27,14 +28,14 @@ var S3ClientUninitializedError = errors.New("s3 client has not been initialized"
 // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 
 func init() {
-	sess := session.New(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(DefaultAWSRegion),
 	})
-
-	_, err := sess.Config.Credentials.Get()
-	if err == nil {
-		svc = s3.New(sess)
+	if err != nil {
+		log.Printf("error getting AWS session: %s", err)
+		return
 	}
+	svc = s3.New(sess)
 }
 
 func s3Post(hostname string, data io.ReadSeeker) error {

--- a/s3.go
+++ b/s3.go
@@ -3,48 +3,36 @@ package veneur
 import (
 	"errors"
 	"io"
-	"log"
 	"path"
 	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
-const S3Bucket = "stripe-test-veneur"
+type filetype string
 
-// TODO(aditya) config-ify this
-const DefaultAWSRegion = "us-west-2"
-const AwsProfile = "veneur-s3-test"
+const (
+	jsonFt filetype = "json"
+	csvFt  filetype = "csv"
+	tsvFt  filetype = "tsv"
+)
+
+var S3Bucket = "stripe-veneur"
 
 var svc s3iface.S3API
 
 var S3ClientUninitializedError = errors.New("s3 client has not been initialized")
 
-// credentials will be pull from environment variables
-// AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-
-func init() {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(DefaultAWSRegion),
-	})
-	if err != nil {
-		log.Printf("error getting AWS session: %s", err)
-		return
-	}
-	svc = s3.New(sess)
-}
-
-func s3Post(hostname string, data io.ReadSeeker) error {
+func s3Post(hostname string, data io.ReadSeeker, ft filetype) error {
 	if svc == nil {
 		return S3ClientUninitializedError
 	}
 	params := &s3.PutObjectInput{
 		Bucket: aws.String(S3Bucket),
-		Key:    s3Path(hostname),
+		Key:    s3Path(hostname, ft),
 		Body:   data,
 	}
 
@@ -52,8 +40,8 @@ func s3Post(hostname string, data io.ReadSeeker) error {
 	return err
 }
 
-func s3Path(hostname string) *string {
+func s3Path(hostname string, ft filetype) *string {
 	t := time.Now()
-	filename := strconv.FormatInt(t.Unix(), 10) + ".json"
+	filename := strconv.FormatInt(t.Unix(), 10) + "." + string(ft)
 	return aws.String(path.Join(t.Format("2006/01/02"), hostname, filename))
 }

--- a/s3_test.go
+++ b/s3_test.go
@@ -68,7 +68,7 @@ func TestS3Post(t *testing.T) {
 
 	svc = client
 
-	err = s3Post("testbox", f)
+	err = s3Post("testbox", f, tsvFt)
 	assert.NoError(t, err)
 }
 
@@ -77,7 +77,7 @@ func TestS3Path(t *testing.T) {
 
 	start := time.Now()
 
-	path := s3Path(hostname)
+	path := s3Path(hostname, jsonFt)
 
 	end := time.Now()
 
@@ -123,6 +123,6 @@ func TestS3PostNoCredentials(t *testing.T) {
 	defer f.Close()
 
 	// this should not panic
-	err = s3Post("testbox", f)
+	err = s3Post("testbox", f, jsonFt)
 	assert.Equal(t, S3ClientUninitializedError, err)
 }

--- a/server.go
+++ b/server.go
@@ -119,6 +119,11 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	conf.Key = "REDACTED"
 	conf.SentryDSN = "REDACTED"
 	ret.logger.WithField("config", conf).Debug("Initialized server")
+	if svc == nil {
+		ret.logger.Info("AWS credentials not found. S3 archives are disabled")
+	} else {
+		ret.logger.Info("AWS credentials found. S3 archives are enabled")
+	}
 
 	return
 }


### PR DESCRIPTION
#### Summary

Load the AWS region and bucket from the config file. Also, use `.tsv` as the extension for the S3 archives.

At this point, it looks like we should store the s3 client on the server, but that involves a slightly bigger yakshave (some test refactoring). Since this is working and running in QA, I'd rather get this merged to master to keep that data collection going and bump that to the next PR, vs. hold off.


#### Motivation

Along with the coterminous puppet config, this means we're actually archiving our data now!

#### Test plan

Existing tests. Also, tested on QA.


#### Rollout/monitoring/revert plan


r? @tummychow 
