### PR TITLE
Implement plugin system for flushing

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -34,8 +34,6 @@ type plugin interface {
 }
 
 func (s *Server) FlushGlobal(interval time.Duration, metricLimit int) {
-	//NewS3Plugin(c)
-
 	go s.flushEventsChecks() // we can do all of this separately
 
 	percentiles := s.HistogramPercentiles

--- a/handlers_global.go
+++ b/handlers_global.go
@@ -26,7 +26,7 @@ func (ch contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // metrics to the global veneur instance.
 func handleImport(s *Server) http.Handler {
 	return contextHandler(func(c context.Context, w http.ResponseWriter, r *http.Request) {
-		innerLogger := s.logger.WithField("client", r.RemoteAddr)
+		innerLogger := log.WithField("client", r.RemoteAddr)
 		start := time.Now()
 
 		var (

--- a/s3.go
+++ b/s3.go
@@ -1,33 +1,78 @@
 package veneur
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/csv"
 	"errors"
 	"io"
 	"path"
 	"strconv"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
+var _ plugin = &S3Plugin{}
+
+type S3Plugin struct {
+	logger *logrus.Logger
+	statsd *statsd.Client
+	svc    s3iface.S3API
+}
+
+func (p *S3Plugin) Flush(metrics []DDMetric, hostname string) error {
+	const Delimiter = '\t'
+	const IncludeHeaders = false
+
+	start := time.Now()
+	csv, err := encodeDDMetricsCSV(metrics, Delimiter, IncludeHeaders)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"metrics":       len(metrics),
+		}).Error("Could not marshal metrics before posting to s3")
+		return err
+	}
+
+	err = p.s3Post(hostname, csv, tsvGzFt)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"metrics":       len(metrics),
+		}).Error("Error posting to s3")
+		return err
+	}
+
+	p.statsd.TimeInMilliseconds("flush.s3.total_duration_ns", float64(time.Now().Sub(start).Nanoseconds()), []string{"part:post"}, 1.0)
+	log.WithField("metrics", len(metrics)).Debug("Completed flush to s3")
+	return nil
+}
+
+func (p *S3Plugin) Initialize(statsd *statsd.Client, logger *logrus.Logger) {
+	p.statsd = statsd
+	p.logger = logger
+}
+
 type filetype string
 
 const (
-	jsonFt filetype = "json"
-	csvFt  filetype = "csv"
-	tsvFt  filetype = "tsv"
+	jsonFt  filetype = "json"
+	csvFt            = "csv"
+	tsvFt            = "tsv"
+	tsvGzFt          = "tsv.gz"
 )
 
 var S3Bucket = "stripe-veneur"
 
-var svc s3iface.S3API
-
 var S3ClientUninitializedError = errors.New("s3 client has not been initialized")
 
-func s3Post(hostname string, data io.ReadSeeker, ft filetype) error {
-	if svc == nil {
+func (p *S3Plugin) s3Post(hostname string, data io.ReadSeeker, ft filetype) error {
+	if p.svc == nil {
 		return S3ClientUninitializedError
 	}
 	params := &s3.PutObjectInput{
@@ -36,7 +81,7 @@ func s3Post(hostname string, data io.ReadSeeker, ft filetype) error {
 		Body:   data,
 	}
 
-	_, err := svc.PutObject(params)
+	_, err := p.svc.PutObject(params)
 	return err
 }
 
@@ -44,4 +89,40 @@ func s3Path(hostname string, ft filetype) *string {
 	t := time.Now()
 	filename := strconv.FormatInt(t.Unix(), 10) + "." + string(ft)
 	return aws.String(path.Join(t.Format("2006/01/02"), hostname, filename))
+}
+
+// encodeDDMetricsCSV returns a reader containing the gzipped CSV representation of the
+// DDMetrics data, one row per DDMetric.
+// the AWS sdk requires seekable input, so we return a ReadSeeker here
+func encodeDDMetricsCSV(metrics []DDMetric, delimiter rune, includeHeaders bool) (io.ReadSeeker, error) {
+	b := &bytes.Buffer{}
+	gzw := gzip.NewWriter(b)
+	w := csv.NewWriter(gzw)
+	w.Comma = delimiter
+
+	if includeHeaders {
+		// Write the headers first
+		headers := [...]string{
+			// the order here doesn't actually matter
+			// as long as the keys are right
+			tsvName:       tsvName.String(),
+			tsvTags:       tsvTags.String(),
+			tsvMetricType: tsvMetricType.String(),
+			tsvHostname:   tsvHostname.String(),
+			tsvDeviceName: tsvDeviceName.String(),
+			tsvInterval:   tsvInterval.String(),
+			tsvValue:      tsvValue.String(),
+			tsvTimestamp:  tsvTimestamp.String(),
+		}
+
+		w.Write(headers[:])
+	}
+
+	for _, metric := range metrics {
+		metric.encodeCSV(w)
+	}
+
+	w.Flush()
+	gzw.Close()
+	return bytes.NewReader(b.Bytes()), w.Error()
 }

--- a/samplers.go
+++ b/samplers.go
@@ -1,12 +1,9 @@
 package veneur
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/csv"
 	"fmt"
 	"hash/fnv"
-	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -102,42 +99,6 @@ func (d DDMetric) encodeCSV(w *csv.Writer) error {
 
 	w.Write(fields[:])
 	return w.Error()
-}
-
-// encodeDDMetricsCSV returns a reader containing the gzipped CSV representation of the
-// DDMetrics data, one row per DDMetric.
-// the AWS sdk requires seekable input, so we return a ReadSeeker here
-func encodeDDMetricsCSV(metrics []DDMetric, delimiter rune, includeHeaders bool) (io.ReadSeeker, error) {
-	b := &bytes.Buffer{}
-	gzw := gzip.NewWriter(b)
-	w := csv.NewWriter(gzw)
-	w.Comma = delimiter
-
-	if includeHeaders {
-		// Write the headers first
-		headers := [...]string{
-			// the order here doesn't actually matter
-			// as long as the keys are right
-			tsvName:       tsvName.String(),
-			tsvTags:       tsvTags.String(),
-			tsvMetricType: tsvMetricType.String(),
-			tsvHostname:   tsvHostname.String(),
-			tsvDeviceName: tsvDeviceName.String(),
-			tsvInterval:   tsvInterval.String(),
-			tsvValue:      tsvValue.String(),
-			tsvTimestamp:  tsvTimestamp.String(),
-		}
-
-		w.Write(headers[:])
-	}
-
-	for _, metric := range metrics {
-		metric.encodeCSV(w)
-	}
-
-	w.Flush()
-	gzw.Close()
-	return bytes.NewReader(b.Bytes()), w.Error()
 }
 
 // JSONMetric is used to represent a metric that can be remarshaled with its

--- a/server_test.go
+++ b/server_test.go
@@ -624,7 +624,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 
 		assert.Equal(t, len(expectedRecords), len(records))
 
-		assertCSVFieldsMatch(t, expectedRecords, records, []int{0,1,2,3,4,5,7})
+		assertCSVFieldsMatch(t, expectedRecords, records, []int{0, 1, 2, 3, 4, 5, 7})
 		//assert.Equal(t, expectedRecords, records)
 
 		RemoteResponseChan <- struct{}{}

--- a/worker.go
+++ b/worker.go
@@ -133,7 +133,7 @@ func (w *Worker) Work() {
 			}
 		case <-w.QuitChan:
 			// We have been asked to stop.
-			w.logger.WithField("worker", w.id).Error("Stopping")
+			log.WithField("worker", w.id).Error("Stopping")
 			return
 		}
 	}
@@ -173,7 +173,7 @@ func (w *Worker) ProcessMetric(m *UDPMetric) {
 			w.wm.timers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		}
 	default:
-		w.logger.WithField("type", m.Type).Error("Unknown metric type for processing")
+		log.WithField("type", m.Type).Error("Unknown metric type for processing")
 	}
 }
 
@@ -190,18 +190,18 @@ func (w *Worker) ImportMetric(other JSONMetric) {
 	switch other.Type {
 	case "set":
 		if err := w.wm.sets[other.MetricKey].Combine(other.Value); err != nil {
-			w.logger.WithError(err).Error("Could not merge sets")
+			log.WithError(err).Error("Could not merge sets")
 		}
 	case "histogram":
 		if err := w.wm.histograms[other.MetricKey].Combine(other.Value); err != nil {
-			w.logger.WithError(err).Error("Could not merge histograms")
+			log.WithError(err).Error("Could not merge histograms")
 		}
 	case "timer":
 		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
-			w.logger.WithError(err).Error("Could not merge timers")
+			log.WithError(err).Error("Could not merge timers")
 		}
 	default:
-		w.logger.WithField("type", other.Type).Error("Unknown metric type for importing")
+		log.WithField("type", other.Type).Error("Unknown metric type for importing")
 	}
 }
 


### PR DESCRIPTION
#### Summary

Implement a plugin system for flushing, and port the S3 archival to the new plugin system.

#### Motivation

Allow third-party plugins (ie, plugins that are not written as part of the `veneur` package itself).

Doing this required splitting the logger from the server (and I plan on doing the same to the `statsd` field as well). I paired with @rhwlo the other day on sketching out what the plugin system should look like, and this was one of the outcomes from that.

The main argument for defining the logger at the package-level is that - well, it essentially already *is*. We currently have one server per veneur process, we have no plans on changing that, and I think it would be a very bad idea for us to do so. The only reason the logger is encapsulated inside the server is that we're setting the loglevel based on the configuration, but that's easy for us to split out.

The alternative would be to force all plugins to take the veneur server as a value, and that feels much dirtier (plugins should have no need to talk to the veneur server at all).

I've made `plugin` a private interface for now because I think we'll want to tweak it a bit more, but the plan is to put the S3 archival in a separate package altogether (the same way the t-digest parts are in a separate package) 



#### Test plan

Added tests. Test coverage is pretty good - the only untested parts in `s3.go` are the obscure error handlers.

<img width="337" alt="screenshot 2016-10-13 15 46 53" src="https://cloud.githubusercontent.com/assets/376414/19364479/58d2f644-915c-11e6-86b5-8e82b15cc2a0.png">

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @tummychow 
