### PR TITLE
Update Redshift timestamp format

### DIFF
--- a/samplers.go
+++ b/samplers.go
@@ -14,7 +14,7 @@ import (
 )
 
 const PartitionDateFormat = "20060102"
-const RedshiftDateFormat = "01.02.2006 03:04:05"
+const RedshiftDateFormat = "2006-01-02 03:04:05"
 
 // DDMetric is a data structure that represents the JSON that Datadog
 // wants when posting to the API

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -269,7 +269,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "food",
 				Interval:   0,
 			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\tgauge\tglobalstats\ttestbox-c3eac9\tfood\t0\t10.10.2016 05:04:18\t100\t%s\n", partition)),
+			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\tgauge\tglobalstats\ttestbox-c3eac9\tfood\t0\t2016-10-10 05:04:18\t100\t%s\n", partition)),
 		},
 		{
 			// Test that we are able to handle a missing field (DeviceName)
@@ -285,7 +285,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "",
 				Interval:   10,
 			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\trate\tlocalhost\ttestbox-c3eac9\t\t10\t10.10.2016 05:04:18\t100\t%s\n", partition)),
+			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\trate\tlocalhost\ttestbox-c3eac9\t\t10\t2016-10-10 05:04:18\t100\t%s\n", partition)),
 		},
 		{
 			// Test that we are able to handle tags which have tab characters in them
@@ -303,7 +303,7 @@ func CSVTestCases() []CSVTestCase {
 				DeviceName: "eniac",
 				Interval:   10,
 			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t\"{foo:b\tar,baz:quz}\"\trate\tlocalhost\ttestbox-c3eac9\teniac\t10\t10.10.2016 05:04:18\t100\t%s\n", partition)),
+			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t\"{foo:b\tar,baz:quz}\"\trate\tlocalhost\ttestbox-c3eac9\teniac\t10\t2016-10-10 05:04:18\t100\t%s\n", partition)),
 		},
 	}
 }


### PR DESCRIPTION
#### Summary

Use the default Redshift timestamp format (http://docs.aws.amazon.com/redshift/latest/dg/r_DATEFORMAT_and_TIMEFORMAT_strings.html )


#### Motivation

Redshift import

#### Test plan

Updated tests, ran in QA.


r? @tummychow  || @gphat 

