### PR TITLE
Reporting statsd metrics from plugins

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -21,7 +20,6 @@ var _ plugin = &S3Plugin{}
 
 type S3Plugin struct {
 	logger   *logrus.Logger
-	statsd   *statsd.Client
 	svc      s3iface.S3API
 	s3Bucket string
 	hostname string
@@ -31,7 +29,6 @@ func (p *S3Plugin) Flush(metrics []DDMetric, hostname string) error {
 	const Delimiter = '\t'
 	const IncludeHeaders = false
 
-	start := time.Now()
 	csv, err := encodeDDMetricsCSV(metrics, Delimiter, IncludeHeaders, p.hostname)
 	if err != nil {
 		p.logger.WithFields(logrus.Fields{
@@ -50,19 +47,12 @@ func (p *S3Plugin) Flush(metrics []DDMetric, hostname string) error {
 		return err
 	}
 
-	p.statsd.TimeInMilliseconds("flush.plugins.s3.total_duration_ns", float64(time.Now().Sub(start).Nanoseconds()), []string{"part:post"}, 1.0)
 	log.WithField("metrics", len(metrics)).Debug("Completed flush to s3")
-	p.statsd.Gauge("flush.plugins.s3.post_metrics_total", float64(len(metrics)), nil, 1.0)
 	return nil
 }
 
 func (p *S3Plugin) Name() string {
 	return "s3"
-}
-
-func (p *S3Plugin) Initialize(statsd *statsd.Client, logger *logrus.Logger) {
-	p.statsd = statsd
-	p.logger = logger
 }
 
 type filetype string

--- a/s3.go
+++ b/s3.go
@@ -50,9 +50,19 @@ func (p *S3Plugin) Flush(metrics []DDMetric, hostname string) error {
 		return err
 	}
 
-	p.statsd.TimeInMilliseconds("flush.s3.total_duration_ns", float64(time.Now().Sub(start).Nanoseconds()), []string{"part:post"}, 1.0)
-	p.logger.WithField("metrics", len(metrics)).Debug("Completed flush to s3")
+	p.statsd.TimeInMilliseconds("flush.plugins.s3.total_duration_ns", float64(time.Now().Sub(start).Nanoseconds()), []string{"part:post"}, 1.0)
+	log.WithField("metrics", len(metrics)).Debug("Completed flush to s3")
+	p.statsd.Gauge("flush.plugins.s3.post_metrics_total", float64(len(metrics)), nil, 1.0)
 	return nil
+}
+
+func (p *S3Plugin) Name() string {
+	return "s3"
+}
+
+func (p *S3Plugin) Initialize(statsd *statsd.Client, logger *logrus.Logger) {
+	p.statsd = statsd
+	p.logger = logger
 }
 
 type filetype string

--- a/server.go
+++ b/server.go
@@ -162,7 +162,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 
 			plugin := &S3Plugin{
 				logger:   log,
-				statsd:   ret.statsd,
 				svc:      svc,
 				s3Bucket: conf.AWSBucket,
 				hostname: ret.Hostname,

--- a/server_test.go
+++ b/server_test.go
@@ -515,6 +515,10 @@ func (dp *dummyPlugin) Flush(metrics []DDMetric, hostname string) error {
 	return dp.flush(metrics, hostname)
 }
 
+func (dp *dummyPlugin) Name() string {
+	return "dummy_plugin"
+}
+
 // TestGlobalServerPluginFlush tests that we are able to
 // register a dummy plugin on the server, and that when we do,
 // flushing on the server causes the plugin to flush

--- a/server_test.go
+++ b/server_test.go
@@ -218,8 +218,6 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 	config.APIHostname = remoteServer.URL
 
 	server := setupVeneurServer(t, config)
-	s3p := stubS3()
-	s3p.statsd = server.statsd
 	defer server.Shutdown()
 
 	for _, value := range metricValues {
@@ -634,7 +632,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		return &s3.PutObjectOutput{ETag: aws.String("912ec803b2ce49e4a541068d495ab570")}, nil
 	}
 
-	s3p := &S3Plugin{logger: log, statsd: server.statsd, svc: client}
+	s3p := &S3Plugin{logger: log, svc: client}
 
 	server.registerPlugin(s3p)
 


### PR DESCRIPTION
#### Summary

Report statsd metrics (flush times, number of errors, and number of metrics flushed) for all plugins automatically. We do this by requiring a `Name()` method for the plugin to satisfy the interface, and that is used to define the metric name within the `veneur.flush.plugins` namespace.

#### Motivation

Better reporting and monitoring for plugins

#### Test plan

N/A

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @tummychow 
