### PR TITLE
Enable plugins on local veneur (fleet) instances

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -94,6 +94,12 @@ func (s *Server) FlushLocal(interval time.Duration, metricLimit int) {
 	// since not everything in tempMetrics is safe for sharing
 	go s.flushForward(tempMetrics)
 
+	go func() {
+		for _, p := range s.getPlugins() {
+			go p.Flush(finalMetrics, s.Hostname)
+		}
+	}()
+
 	s.flushRemote(finalMetrics, metricLimit)
 }
 

--- a/flusher.go
+++ b/flusher.go
@@ -96,7 +96,14 @@ func (s *Server) FlushLocal(interval time.Duration, metricLimit int) {
 
 	go func() {
 		for _, p := range s.getPlugins() {
-			go p.Flush(finalMetrics, s.Hostname)
+			start := time.Now()
+			err := p.Flush(finalMetrics, s.Hostname)
+			s.statsd.TimeInMilliseconds(fmt.Sprintf("flush.plugins.%s.total_duration_ns", p.Name()), float64(time.Now().Sub(start).Nanoseconds()), []string{"part:post"}, 1.0)
+			if err != nil {
+				countName := fmt.Sprintf("flush.plugins.%s.error_total", p.Name())
+				s.statsd.Count(countName, 1, []string{}, 1.0)
+			}
+			s.statsd.Gauge(fmt.Sprintf("flush.plugins.%s.post_metrics_total", p.Name()), float64(len(finalMetrics)), nil, 1.0)
 		}
 	}()
 


### PR DESCRIPTION
#### Summary

Now that we're collecting the data from globalstats and everything seems to be going well, we can start looking at rolling it out to fleet as well.

#### Motivation

Collect data from entire veneur fleet

#### Test plan

Tested with one box on QA, monitored graphs

#### Rollout/monitoring/revert plan

This won't actually do anything until we puppet the changes, which we can roll out slowly.



r? @tummychow 