### PR TITLE
Full aggregates support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `interval` - How often to flush. Something like 10s seems good. **Note: If you change this, it breaks all kinds of things on Datadog's side. You'll have to change all your metric's metadata.**
 * `key` - Your Datadog API key
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s
+* `aggregates` - The aggregates to generate from our timers and histograms. Specified as array of strings, choices: min, max, median, avg, count, sum. Default: min, max, count
 * `udp_address` - The address on which to listen for metrics. Probably `:8126` so as not to interfere with normal DogStatsD.
 * `http_address` - The address to serve HTTP healthchecks and other endpoints. This can be a simple ip:port combination like `127.0.0.1:8127`. If you're under einhorn, you probably want `einhorn@0`.
 * `forward_address` - The address of an upstream Veneur to forward metrics to. See below.

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package veneur
 
 type Config struct {
+	Aggregates          []string  `yaml:"aggregates"`
 	APIHostname         string    `yaml:"api_hostname"`
 	AwsAccessKeyID      string    `yaml:"aws_access_key_id"`
 	AwsRegion           string    `yaml:"aws_region"`

--- a/example.yaml
+++ b/example.yaml
@@ -12,6 +12,10 @@ percentiles:
   - 0.5
   - 0.75
   - 0.99
+#aggregates:
+#  - "min"
+#  - "max"
+#  - "count"
 read_buffer_size_bytes: 2097152
 stats_address: "localhost:8125"
 tags:

--- a/samplers.go
+++ b/samplers.go
@@ -342,7 +342,6 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:      [1][2]float64{{now, h.localSum}},
 			Tags:       tags,
 			MetricType: "gauge",
-			Interval:   int32(interval.Seconds()),
 		})
 		if (aggregates.Value&AggregateAverage) == AggregateAverage && h.localWeight != 0 {
 			// we need both a rate and a non-zero sum before it will make sense
@@ -352,7 +351,6 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 				Value:      [1][2]float64{{now, h.localSum / h.localWeight}},
 				Tags:       tags,
 				MetricType: "gauge",
-				Interval:   int32(interval.Seconds()),
 			})
 		}
 	}

--- a/samplers.go
+++ b/samplers.go
@@ -274,6 +274,7 @@ type Histo struct {
 	localWeight float64
 	localMin    float64
 	localMax    float64
+	localSum    float64
 }
 
 // Sample adds the supplied value to the histogram.
@@ -284,6 +285,7 @@ func (h *Histo) Sample(sample float64, sampleRate float32) {
 	h.localWeight += weight
 	h.localMin = math.Min(h.localMin, sample)
 	h.localMax = math.Max(h.localMax, sample)
+	h.localSum += sample * weight
 }
 
 // NewHist generates a new Histo and returns it.
@@ -295,25 +297,23 @@ func NewHist(name string, tags []string) *Histo {
 		value:    tdigest.NewMerging(100, false),
 		localMin: math.Inf(+1),
 		localMax: math.Inf(-1),
+		localSum: 0,
 	}
 }
 
-// HistogramLocalLength is the maximum number of DDMetrics that a histogram can flush if
-// len(percentiles)==0
-// specifically the count, min and max
-const HistogramLocalLength = 3
-
 // Flush generates DDMetrics for the current state of the Histo. percentiles
 // indicates what percentiles should be exported from the histogram.
-func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric {
+func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates HistogramAggregates) []DDMetric {
 	now := float64(time.Now().Unix())
 	// we only want to flush the number of samples we received locally, since
 	// any other samples have already been flushed by a local veneur instance
 	// before this was forwarded to us
 	rate := h.localWeight / interval.Seconds()
-	metrics := make([]DDMetric, 0, 3+len(percentiles))
+	metrics := make([]DDMetric, 0, aggregates.Count+len(percentiles))
 
-	if !math.IsInf(h.localMax, 0) {
+	if (aggregates.Value&AggregateMax) == AggregateMax && !math.IsInf(h.localMax, 0) {
+		// XXX: why is this recreating tags mutliple times, granted they won't always be used, but it seems preferable to
+		// generate them once anyway
 		tags := make([]string, len(h.tags))
 		copy(tags, h.tags)
 		metrics = append(metrics, DDMetric{
@@ -323,7 +323,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric 
 			MetricType: "gauge",
 		})
 	}
-	if !math.IsInf(h.localMin, 0) {
+	if (aggregates.Value&AggregateMin) == AggregateMin && !math.IsInf(h.localMin, 0) {
 		tags := make([]string, len(h.tags))
 		copy(tags, h.tags)
 		metrics = append(metrics, DDMetric{
@@ -333,7 +333,31 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric 
 			MetricType: "gauge",
 		})
 	}
-	if rate != 0 {
+
+	if (aggregates.Value&AggregateSum) == AggregateSum && h.localSum != 0 {
+		tags := make([]string, len(h.tags))
+		copy(tags, h.tags)
+		metrics = append(metrics, DDMetric{
+			Name:       fmt.Sprintf("%s.sum", h.name),
+			Value:      [1][2]float64{{now, h.localSum}},
+			Tags:       tags,
+			MetricType: "gauge",
+			Interval:   int32(interval.Seconds()),
+		})
+		if (aggregates.Value&AggregateAverage) == AggregateAverage && h.localWeight != 0 {
+			// we need both a rate and a non-zero sum before it will make sense
+			// to submit an average
+			metrics = append(metrics, DDMetric{
+				Name:       fmt.Sprintf("%s.avg", h.name),
+				Value:      [1][2]float64{{now, h.localSum / h.localWeight}},
+				Tags:       tags,
+				MetricType: "gauge",
+				Interval:   int32(interval.Seconds()),
+			})
+		}
+	}
+
+	if (aggregates.Value&AggregateCount) == AggregateCount && rate != 0 {
 		// if we haven't received any local samples, then leave this sparse,
 		// otherwise it can lead to some misleading zeroes in between the
 		// flushes of downstream instances
@@ -346,6 +370,20 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64) []DDMetric 
 			MetricType: "rate",
 			Interval:   int32(interval.Seconds()),
 		})
+	}
+
+	if (aggregates.Value & AggregateMedian) == AggregateMedian {
+		tags := make([]string, len(h.tags))
+		copy(tags, h.tags)
+		metrics = append(
+			metrics,
+			DDMetric{
+				Name:       fmt.Sprintf("%s.median", h.name),
+				Value:      [1][2]float64{{now, h.value.Quantile(0.5)}},
+				Tags:       tags,
+				MetricType: "gauge",
+			},
+		)
 	}
 
 	for _, p := range percentiles {

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -137,6 +137,8 @@ func TestSetMerge(t *testing.T) {
 
 func TestHisto(t *testing.T) {
 
+	aggregates := HistogramAggregates{AggregateMin + AggregateMax + AggregateCount, 3}
+
 	h := NewHist("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", h.name, "Name")
@@ -149,7 +151,7 @@ func TestHisto(t *testing.T) {
 	h.Sample(20, 1.0)
 	h.Sample(25, 1.0)
 
-	metrics := h.Flush(10*time.Second, []float64{0.50})
+	metrics := h.Flush(10*time.Second, []float64{0.50}, aggregates)
 	// We get lots of metrics back for histograms!
 	assert.Len(t, metrics, 4, "Flushed metrics length")
 
@@ -196,6 +198,8 @@ func TestHisto(t *testing.T) {
 
 func TestHistoSampleRate(t *testing.T) {
 
+	aggregates := HistogramAggregates{AggregateMin + AggregateMax + AggregateCount, 3}
+
 	h := NewHist("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", h.name, "Name")
@@ -208,7 +212,7 @@ func TestHistoSampleRate(t *testing.T) {
 	h.Sample(20, 0.5)
 	h.Sample(25, 0.5)
 
-	metrics := h.Flush(10*time.Second, []float64{0.50})
+	metrics := h.Flush(10*time.Second, []float64{0.50}, aggregates)
 	assert.Len(t, metrics, 4, "Metrics flush length")
 
 	// First the max

--- a/server.go
+++ b/server.go
@@ -32,6 +32,40 @@ var log = logrus.New()
 
 //go:generate gojson -input example.yaml -o config.go -fmt yaml -pkg veneur -name Config
 
+type Aggregate int
+
+const (
+	AggregateMin     Aggregate = 1 << iota
+	AggregateMax               = 1 << iota
+	AggregateMedian            = 1 << iota
+	AggregateAverage           = 1 << iota
+	AggregateCount             = 1 << iota
+	AggregateSum               = 1 << iota
+)
+
+var aggregatesLookup = map[string]Aggregate{
+	"min":    AggregateMin,
+	"max":    AggregateMax,
+	"median": AggregateMedian,
+	"avg":    AggregateAverage,
+	"count":  AggregateCount,
+	"sum":    AggregateSum,
+}
+
+type HistogramAggregates struct {
+	Value Aggregate
+	Count int
+}
+
+var aggregates = [...]string{
+	AggregateMin:     "min",
+	AggregateMax:     "max",
+	AggregateMedian:  "median",
+	AggregateAverage: "avg",
+	AggregateCount:   "count",
+	AggregateSum:     "sum",
+}
+
 // A Server is the actual veneur instance that will be run.
 type Server struct {
 	Workers     []*Worker
@@ -58,6 +92,8 @@ type Server struct {
 	pluginMtx sync.Mutex
 
 	enableProfiling bool
+
+	HistogramAggregates HistogramAggregates
 }
 
 // NewFromConfig creates a new veneur server from a configuration specification.
@@ -67,6 +103,16 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.DDHostname = conf.APIHostname
 	ret.DDAPIKey = conf.Key
 	ret.HistogramPercentiles = conf.Percentiles
+	if len(conf.Aggregates) == 0 {
+		ret.HistogramAggregates.Value = AggregateMin + AggregateMax + AggregateCount
+		ret.HistogramAggregates.Count = 3
+	} else {
+		ret.HistogramAggregates.Value = 0
+		for _, agg := range conf.Aggregates {
+			ret.HistogramAggregates.Value += aggregatesLookup[agg]
+		}
+		ret.HistogramAggregates.Count = len(conf.Aggregates)
+	}
 
 	interval, err := time.ParseDuration(conf.Interval)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -35,12 +35,12 @@ var log = logrus.New()
 type Aggregate int
 
 const (
-	AggregateMin     Aggregate = 1 << iota
-	AggregateMax               = 1 << iota
-	AggregateMedian            = 1 << iota
-	AggregateAverage           = 1 << iota
-	AggregateCount             = 1 << iota
-	AggregateSum               = 1 << iota
+	AggregateMin Aggregate = 1 << iota
+	AggregateMax
+	AggregateMedian
+	AggregateAverage
+	AggregateCount
+	AggregateSum
 )
 
 var aggregatesLookup = map[string]Aggregate{

--- a/server_test.go
+++ b/server_test.go
@@ -72,6 +72,7 @@ func generateConfig(forwardAddr string) Config {
 		Key:                 "",
 		MetricMaxLength:     4096,
 		Percentiles:         []float64{.5, .75, .99},
+		Aggregates:          []string{"min", "max", "count"},
 		ReadBufferSizeBytes: 2097152,
 		UdpAddress:          "localhost:8126",
 		HTTPAddress:         fmt.Sprintf("localhost:%d", port),


### PR DESCRIPTION
#### Summary

Adds support for the full list of [histogram aggregates](https://github.com/DataDog/dd-agent/blob/7e0a805fa1fad154c0a1d785bb637cfb0e631c02/aggregator.py#L265-L270).

#### Motivation

The current configuration we run with has things other than min, max, and count enabled and I'd like to be able to match that so we can test drop-in replacement.

#### Test plan

Unit tests added.
