### PR TITLE
fix a TSV test that incorrectly uses local time

### DIFF
--- a/samplers_test.go
+++ b/samplers_test.go
@@ -253,7 +253,7 @@ type CSVTestCase struct {
 
 func CSVTestCases() []CSVTestCase {
 
-	partition := time.Now().Format("20060102")
+	partition := time.Now().UTC().Format("20060102")
 
 	return []CSVTestCase{
 		{


### PR DESCRIPTION
#### Summary
This test fails if run after UTC midnight, but before local midnight. This commit updates the code to use UTC time in both cases (here, in this test, and at https://github.com/stripe/veneur/blob/master/samplers.go#L116)

#### Motivation
Flappy tests are bad.


#### Test plan
Ran the tests at 12:41AM UTC and 17:41PM local.


#### Rollout/monitoring/revert plan
n/a

r? @tummychow 