### PR TITLE
Use gojson to generate Config struct

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -48,13 +48,18 @@ func main() {
 		}()
 	}
 
+  interval, err := conf.ParseInterval()
+  if err != nil{
+    logrus.Fatalf("Error parsing configuration %s", err)
+  }
+
 	go func() {
 		defer func() {
 			server.ConsumePanic(recover())
 		}()
-		ticker := time.NewTicker(conf.Interval)
+		ticker := time.NewTicker(interval)
 		for range ticker.C {
-			server.Flush(conf.Interval, conf.FlushMaxPerBody)
+			server.Flush(interval, conf.FlushMaxPerBody)
 		}
 	}()
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -54,7 +54,7 @@ func main() {
 		}()
 		ticker := time.NewTicker(conf.Interval)
 		for range ticker.C {
-			server.Flush(conf.Interval, conf.FlushLimit)
+			server.Flush(conf.Interval, conf.FlushMaxPerBody)
 		}
 	}()
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -48,10 +48,10 @@ func main() {
 		}()
 	}
 
-  interval, err := conf.ParseInterval()
-  if err != nil{
-    logrus.Fatalf("Error parsing configuration %s", err)
-  }
+	interval, err := conf.ParseInterval()
+	if err != nil {
+		logrus.Fatalf("Error parsing configuration %s", err)
+	}
 
 	go func() {
 		defer func() {

--- a/config.go
+++ b/config.go
@@ -1,28 +1,26 @@
 package veneur
 
-import "time"
-
 type Config struct {
-	APIHostname         string        `yaml:"api_hostname"`
-	AwsAccessKeyID      string        `yaml:"aws_access_key_id"`
-	AwsRegion           string        `yaml:"aws_region"`
-	AwsS3Bucket         string        `yaml:"aws_s3_bucket"`
-	AwsSecretAccessKey  string        `yaml:"aws_secret_access_key"`
-	Debug               bool          `yaml:"debug"`
-	EnableProfiling     bool          `yaml:"enable_profiling"`
-	FlushMaxPerBody     int           `yaml:"flush_max_per_body"`
-	ForwardAddress      string        `yaml:"forward_address"`
-	Hostname            string        `yaml:"hostname"`
-	HTTPAddress         string        `yaml:"http_address"`
-	Key                 string        `yaml:"key"`
-	MetricMaxLength     int           `yaml:"metric_max_length"`
-	Interval            time.Duration `yaml:"interval"`
-	NumReaders          int           `yaml:"num_readers"`
-	NumWorkers          int           `yaml:"num_workers"`
-	Percentiles         []float64     `yaml:"percentiles"`
-	ReadBufferSizeBytes int           `yaml:"read_buffer_size_bytes"`
-	SentryDsn           string        `yaml:"sentry_dsn"`
-	StatsAddress        string        `yaml:"stats_address"`
-	Tags                []string      `yaml:"tags"`
-	UdpAddress          string        `yaml:"udp_address"`
+	APIHostname         string    `yaml:"api_hostname"`
+	AwsAccessKeyID      string    `yaml:"aws_access_key_id"`
+	AwsRegion           string    `yaml:"aws_region"`
+	AwsS3Bucket         string    `yaml:"aws_s3_bucket"`
+	AwsSecretAccessKey  string    `yaml:"aws_secret_access_key"`
+	Debug               bool      `yaml:"debug"`
+	EnableProfiling     bool      `yaml:"enable_profiling"`
+	FlushMaxPerBody     int       `yaml:"flush_max_per_body"`
+	ForwardAddress      string    `yaml:"forward_address"`
+	Hostname            string    `yaml:"hostname"`
+	HTTPAddress         string    `yaml:"http_address"`
+	Interval            string    `yaml:"interval"`
+	Key                 string    `yaml:"key"`
+	MetricMaxLength     int       `yaml:"metric_max_length"`
+	NumReaders          int       `yaml:"num_readers"`
+	NumWorkers          int       `yaml:"num_workers"`
+	Percentiles         []float64 `yaml:"percentiles"`
+	ReadBufferSizeBytes int       `yaml:"read_buffer_size_bytes"`
+	SentryDsn           string    `yaml:"sentry_dsn"`
+	StatsAddress        string    `yaml:"stats_address"`
+	Tags                []string  `yaml:"tags"`
+	UdpAddress          string    `yaml:"udp_address"`
 }

--- a/config.go
+++ b/config.go
@@ -1,71 +1,28 @@
 package veneur
 
-import (
-	"io"
-	"io/ioutil"
-	"os"
-	"time"
+import "time"
 
-	"gopkg.in/yaml.v2"
-)
-
-// Config is a collection of settings that control Veneur.
 type Config struct {
 	APIHostname         string        `yaml:"api_hostname"`
+	AwsAccessKeyID      string        `yaml:"aws_access_key_id"`
+	AwsRegion           string        `yaml:"aws_region"`
+	AwsS3Bucket         string        `yaml:"aws_s3_bucket"`
+	AwsSecretAccessKey  string        `yaml:"aws_secret_access_key"`
 	Debug               bool          `yaml:"debug"`
 	EnableProfiling     bool          `yaml:"enable_profiling"`
+	FlushMaxPerBody     int           `yaml:"flush_max_per_body"`
+	ForwardAddress      string        `yaml:"forward_address"`
 	Hostname            string        `yaml:"hostname"`
-	Interval            time.Duration `yaml:"interval"`
+	HTTPAddress         string        `yaml:"http_address"`
 	Key                 string        `yaml:"key"`
 	MetricMaxLength     int           `yaml:"metric_max_length"`
+	Interval            time.Duration `yaml:"interval"`
+	NumReaders          int           `yaml:"num_readers"`
+	NumWorkers          int           `yaml:"num_workers"`
 	Percentiles         []float64     `yaml:"percentiles"`
 	ReadBufferSizeBytes int           `yaml:"read_buffer_size_bytes"`
-	UDPAddr             string        `yaml:"udp_address"`
-	HTTPAddr            string        `yaml:"http_address"`
-	ForwardAddr         string        `yaml:"forward_address"`
-	NumWorkers          int           `yaml:"num_workers"`
-	NumReaders          int           `yaml:"num_readers"`
-	StatsAddr           string        `yaml:"stats_address"`
+	SentryDsn           string        `yaml:"sentry_dsn"`
+	StatsAddress        string        `yaml:"stats_address"`
 	Tags                []string      `yaml:"tags"`
-	SentryDSN           string        `yaml:"sentry_dsn"`
-	FlushLimit          int           `yaml:"flush_max_per_body"`
-	AWSAccessKeyId      string        `yaml:"aws_access_key_id"`
-	AWSSecretAccessKey  string        `yaml:"aws_secret_access_key"`
-	AWSRegion           string        `yaml:"aws_region"`
-	AWSBucket           string        `yaml:"aws_s3_bucket"`
-}
-
-// ReadConfig unmarshals the config file and slurps in it's data.
-func ReadConfig(path string) (c Config, err error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return c, err
-	}
-	defer f.Close()
-	return readConfig(f)
-}
-
-func readConfig(r io.Reader) (c Config, err error) {
-	// Unfortunately the YAML package does not
-	// support reader inputs
-	// TODO(aditya) convert this when the
-	// upstream PR lands
-	bts, err := ioutil.ReadAll(r)
-	if err != nil {
-		return
-	}
-	err = yaml.Unmarshal(bts, &c)
-	if err != nil {
-		return
-	}
-
-	if c.Hostname == "" {
-		c.Hostname, _ = os.Hostname()
-	}
-
-	if c.ReadBufferSizeBytes == 0 {
-		c.ReadBufferSizeBytes = 1048576 * 2 // 2 MB
-	}
-
-	return c, nil
+	UdpAddress          string        `yaml:"udp_address"`
 }

--- a/config_parse.go
+++ b/config_parse.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -41,4 +42,8 @@ func readConfig(r io.Reader) (c Config, err error) {
 	}
 
 	return c, nil
+}
+
+func (c Config) ParseInterval() (time.Duration, error) {
+	return time.ParseDuration(c.Interval)
 }

--- a/config_parse.go
+++ b/config_parse.go
@@ -1,0 +1,44 @@
+package veneur
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// ReadConfig unmarshals the config file and slurps in it's data.
+func ReadConfig(path string) (c Config, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return c, err
+	}
+	defer f.Close()
+	return readConfig(f)
+}
+
+func readConfig(r io.Reader) (c Config, err error) {
+	// Unfortunately the YAML package does not
+	// support reader inputs
+	// TODO(aditya) convert this when the
+	// upstream PR lands
+	bts, err := ioutil.ReadAll(r)
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(bts, &c)
+	if err != nil {
+		return
+	}
+
+	if c.Hostname == "" {
+		c.Hostname, _ = os.Hostname()
+	}
+
+	if c.ReadBufferSizeBytes == 0 {
+		c.ReadBufferSizeBytes = 1048576 * 2 // 2 MB
+	}
+
+	return c, nil
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -9,36 +10,11 @@ import (
 )
 
 func TestReadConfig(t *testing.T) {
+	exampleConfig, err := os.Open("example.yaml")
+	assert.NoError(t, err)
+	defer exampleConfig.Close()
 
-	// It's better not to require read access on the filesystem
-	// in tests if we can avoid it
-	const exampleConfig = `---
-api_hostname: https://app.datadoghq.com
-metric_max_length: 4096
-flush_max_per_body: 25000
-debug: true
-interval: "10s"
-key: "farts"
-num_workers: 96
-num_readers: 4
-percentiles:
-  - 0.5
-  - 0.75
-  - 0.99
-read_buffer_size_bytes: 2097152
-stats_address: "localhost:8125"
-tags:
- - "foo:bar"
-#  - "baz:gorch"
-udp_address: "localhost:8126"
-#http_address: "einhorn@0"
-http_address: "localhost:8127"
-forward_address: "http://veneur.example.com"
-# Defaults to the os.Hostname()!
-# hostname: foobar`
-
-	r := strings.NewReader(exampleConfig)
-	c, err := readConfig(r)
+	c, err := readConfig(exampleConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -44,6 +45,10 @@ forward_address: "http://veneur.example.com"
 
 	assert.Equal(t, "https://app.datadoghq.com", c.APIHostname)
 	assert.Equal(t, 96, c.NumWorkers)
+
+	interval, err := c.ParseInterval()
+	assert.NoError(t, err)
+	assert.Equal(t, interval, 10*time.Second)
 }
 
 func TestReadBadConfig(t *testing.T) {

--- a/example.yaml
+++ b/example.yaml
@@ -16,16 +16,18 @@ read_buffer_size_bytes: 2097152
 stats_address: "localhost:8125"
 tags:
  - "foo:bar"
-#  - "baz:gorch"
+ - "baz:quz"
 udp_address: "localhost:8126"
 #http_address: "einhorn@0"
 http_address: "localhost:8127"
 forward_address: "http://veneur.example.com"
-# Defaults to the os.Hostname()!
-# hostname: foobar
+sentry_dsn: http://4a21e883f6cf152b70b9af8f70280492b598f615:147347172408bac7999043eebc1a1fa0f19fb4c7@errors.example.com
 
-## Add these if you want to archive data to S3
-#aws_access_key_id: "foo"
-#aws_secret_access_key: "bar"
-#aws_region: "us-west-2"
-#aws_s3_bucket: "stripe-veneur"
+# If absent, defaults to the os.Hostname()!
+hostname: foobar
+
+# Include these if you want to archive data to S3
+aws_access_key_id: "foo"
+aws_secret_access_key: "bar"
+aws_region: "us-west-2"
+aws_s3_bucket: "stripe-veneur"

--- a/server.go
+++ b/server.go
@@ -68,9 +68,13 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.DDAPIKey = conf.Key
 	ret.HistogramPercentiles = conf.Percentiles
 
+	interval, err := time.ParseDuration(conf.Interval)
+	if err != nil {
+		return
+	}
 	ret.HTTPClient = &http.Client{
 		// make sure that POSTs to datadog do not overflow the flush interval
-		Timeout: conf.Interval * 9 / 10,
+		Timeout: interval * 9 / 10,
 		// we're fine with using the default transport and redirect behavior
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -313,7 +313,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 			// all is safe
 			return
 		case <-time.After(DefaultServerTimeout):
-			assert.Fail(t, "Global server did not complete all responses before test terminated!")
+			assert.Fail(t, "Remote server did not complete all responses before test terminated!")
 		}
 	}()
 

--- a/server_test.go
+++ b/server_test.go
@@ -73,9 +73,9 @@ func generateConfig(forwardAddr string) Config {
 		MetricMaxLength:     4096,
 		Percentiles:         []float64{.5, .75, .99},
 		ReadBufferSizeBytes: 2097152,
-		UDPAddr:             "localhost:8126",
-		HTTPAddr:            fmt.Sprintf("localhost:%d", port),
-		ForwardAddr:         forwardAddr,
+		UdpAddress:          "localhost:8126",
+		HTTPAddress:         fmt.Sprintf("localhost:%d", port),
+		ForwardAddress:      forwardAddr,
 		NumWorkers:          96,
 
 		// Use only one reader, so that we can run tests
@@ -85,10 +85,10 @@ func generateConfig(forwardAddr string) Config {
 		// Currently this points nowhere, which is intentional.
 		// We don't need internal metrics for the tests, and they make testing
 		// more complicated.
-		StatsAddr:  "localhost:8125",
-		Tags:       []string{},
-		SentryDSN:  "",
-		FlushLimit: 1024,
+		StatsAddress:    "localhost:8125",
+		Tags:            []string{},
+		SentryDsn:       "",
+		FlushMaxPerBody: 1024,
 	}
 }
 
@@ -232,7 +232,7 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 			LocalOnly:  true,
 		})
 	}
-	server.Flush(config.Interval, config.FlushLimit)
+	server.Flush(config.Interval, config.FlushMaxPerBody)
 }
 
 func TestGlobalServerFlush(t *testing.T) {
@@ -300,7 +300,7 @@ func TestGlobalServerFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushLimit)
+	server.Flush(config.Interval, config.FlushMaxPerBody)
 }
 
 func TestLocalServerMixedMetrics(t *testing.T) {
@@ -431,7 +431,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 
 	config := localConfig()
 	config.APIHostname = remoteServer.URL
-	config.ForwardAddr = globalVeneur.URL
+	config.ForwardAddress = globalVeneur.URL
 	config.NumWorkers = 1
 
 	server := setupVeneurServer(t, config)
@@ -465,7 +465,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushLimit)
+	server.Flush(config.Interval, config.FlushMaxPerBody)
 }
 
 func TestSplitBytes(t *testing.T) {
@@ -576,7 +576,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushLimit)
+	server.Flush(config.Interval, config.FlushMaxPerBody)
 }
 
 // TestGlobalServerS3PluginFlush tests that we are able to
@@ -652,7 +652,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushLimit)
+	server.Flush(config.Interval, config.FlushMaxPerBody)
 }
 
 func parseGzipTSV(r io.Reader) ([][]string, error) {

--- a/server_test.go
+++ b/server_test.go
@@ -68,7 +68,7 @@ func generateConfig(forwardAddr string) Config {
 		Hostname:    "localhost",
 
 		// Use a shorter interval for tests
-		Interval:            DefaultFlushInterval,
+		Interval:            DefaultFlushInterval.String(),
 		Key:                 "",
 		MetricMaxLength:     4096,
 		Percentiles:         []float64{.5, .75, .99},
@@ -232,7 +232,11 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 			LocalOnly:  true,
 		})
 	}
-	server.Flush(config.Interval, config.FlushMaxPerBody)
+
+	interval, err := config.ParseInterval()
+	assert.NoError(t, err)
+
+	server.Flush(interval, config.FlushMaxPerBody)
 }
 
 func TestGlobalServerFlush(t *testing.T) {
@@ -300,7 +304,10 @@ func TestGlobalServerFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushMaxPerBody)
+	interval, err := config.ParseInterval()
+	assert.NoError(t, err)
+
+	server.Flush(interval, config.FlushMaxPerBody)
 }
 
 func TestLocalServerMixedMetrics(t *testing.T) {
@@ -465,7 +472,10 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushMaxPerBody)
+	interval, err := config.ParseInterval()
+	assert.NoError(t, err)
+
+	server.Flush(interval, config.FlushMaxPerBody)
 }
 
 func TestSplitBytes(t *testing.T) {
@@ -576,7 +586,10 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushMaxPerBody)
+	interval, err := config.ParseInterval()
+	assert.NoError(t, err)
+
+	server.Flush(interval, config.FlushMaxPerBody)
 }
 
 // TestGlobalServerS3PluginFlush tests that we are able to
@@ -652,7 +665,10 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		})
 	}
 
-	server.Flush(config.Interval, config.FlushMaxPerBody)
+	interval, err := config.ParseInterval()
+	assert.NoError(t, err)
+
+	server.Flush(interval, config.FlushMaxPerBody)
 }
 
 func parseGzipTSV(r io.Reader) ([][]string, error) {


### PR DESCRIPTION
#### Summary

Thanks to @darrennoble, gojson now supports yaml output! (See https://github.com/ChimeraCoder/gojson/pull/28).

Now, if we ever decide to change the configuration - perhaps adding a new field - we can just type

```sh
$ go generate
```

to have the new Config struct generated for us.


(Unfortunately, gojson has know way of knowing that "10s" is meant to be of type `time.Duration` and not a string, so that still has to be changed manually - but that's a lot better than what we have now, seeing as veneur will not compile if those types don't match.)


#### Motivation

`example.yaml` should always be a working configuration file. Autogenerating the `Config` struct from it makes it less likely that they can get out of sync, and avoids subtle bugs (such as renaming a field in one but not the other). It also reduces manual work.

#### Test plan

Existing tests

#### Rollout/monitoring/revert plan

r? @tummychow || @gphat 
