### PR TITLE
add counters that are globally accumulated

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ With respect to the `tags` configuration option, the tags that will be added are
 
 If you want a metric to be strictly host-local, you can tell Veneur not to forward it by including a `veneurlocalonly` tag in the metric packet, eg `foo:1|h|#veneurlocalonly`. This tag will not actually appear in DataDog; Veneur removes it.
 
+Relatedly, if you want to forward a counter to the global veneur instance to reduce tag cardinality, you can tell Veneur to flush it to the global instance by including a `veneurglobalonly` tag in the count's metric packet. This tag will also not appear in Datadog. Note: for global counters to report correctly, the local and global veneur instances should be configured to have the same flush interval.
+
 Veneur also honors the same "magic" tags as the dogstatsd include in the agent. The tag `host` will override `Hostname` in the metric and `device` will override `DeviceName`.
 
 # Configuration

--- a/flusher.go
+++ b/flusher.go
@@ -83,7 +83,7 @@ func (s *Server) FlushLocal(interval time.Duration, metricLimit int) {
 
 	// we cannot do this until we're done using tempMetrics within this function,
 	// since not everything in tempMetrics is safe for sharing
-	go s.flushForward(tempMetrics, interval)
+	go s.flushForward(tempMetrics)
 
 	go func() {
 		for _, p := range s.getPlugins() {
@@ -320,7 +320,7 @@ func (s *Server) flushPart(metricSlice []samplers.DDMetric, wg *sync.WaitGroup) 
 	}, "flush", true)
 }
 
-func (s *Server) flushForward(wms []WorkerMetrics, interval time.Duration) {
+func (s *Server) flushForward(wms []WorkerMetrics) {
 	jmLength := 0
 	for _, wm := range wms {
 		jmLength += len(wm.histograms)

--- a/flusher.go
+++ b/flusher.go
@@ -38,7 +38,9 @@ func (s *Server) FlushGlobal(interval time.Duration, metricLimit int) {
 	tempMetrics, ms := s.tallyMetrics(percentiles)
 
 	// the global veneur instance is also responsible for reporting the sets
+	// and global counters
 	ms.totalLength += ms.totalSets
+	ms.totalLength += ms.totalGlobalCounters
 
 	finalMetrics := s.generateDDMetrics(interval, percentiles, tempMetrics, ms)
 
@@ -81,7 +83,7 @@ func (s *Server) FlushLocal(interval time.Duration, metricLimit int) {
 
 	// we cannot do this until we're done using tempMetrics within this function,
 	// since not everything in tempMetrics is safe for sharing
-	go s.flushForward(tempMetrics)
+	go s.flushForward(tempMetrics, interval)
 
 	go func() {
 		for _, p := range s.getPlugins() {
@@ -105,6 +107,8 @@ type metricsSummary struct {
 	totalHistograms int
 	totalSets       int
 	totalTimers     int
+
+	totalGlobalCounters int
 
 	totalLocalHistograms int
 	totalLocalSets       int
@@ -135,6 +139,8 @@ func (s *Server) tallyMetrics(percentiles []float64) ([]WorkerMetrics, metricsSu
 		ms.totalHistograms += len(wm.histograms)
 		ms.totalSets += len(wm.sets)
 		ms.totalTimers += len(wm.timers)
+
+		ms.totalGlobalCounters += len(wm.globalCounters)
 
 		ms.totalLocalHistograms += len(wm.localHistograms)
 		ms.totalLocalSets += len(wm.localSets)
@@ -200,6 +206,13 @@ func (s *Server) generateDDMetrics(interval time.Duration, percentiles []float64
 			for _, s := range wm.sets {
 				finalMetrics = append(finalMetrics, s.Flush()...)
 			}
+
+			// also do this for global counters
+			// global counters have no local parts, so if we're a local veneur,
+			// there's nothing to flush
+			for _, gc := range wm.globalCounters {
+				finalMetrics = append(finalMetrics, gc.Flush(interval)...)
+			}
 		}
 	}
 
@@ -225,7 +238,7 @@ func (s *Server) reportMetricsFlushCounts(ms metricsSummary) {
 }
 
 // reportGlobalMetricsFlushCounts reports the counts of
-// totalHistograms, totalSets, and totalTimers,
+// globalCounters, totalHistograms, totalSets, and totalTimers,
 // which are the three metrics reported *only* by the global
 // veneur instance.
 func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
@@ -234,6 +247,7 @@ func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
 	// this avoids double-counting problems where a local veneur reports
 	// histograms that it received, and then a global veneur reports them
 	// again
+	s.statsd.Count("worker.metrics_flushed_total", int64(ms.totalGlobalCounters), []string{"metric_type:global_counter"}, 1.0)
 	s.statsd.Count("worker.metrics_flushed_total", int64(ms.totalHistograms), []string{"metric_type:histogram"}, 1.0)
 	s.statsd.Count("worker.metrics_flushed_total", int64(ms.totalSets), []string{"metric_type:set"}, 1.0)
 	s.statsd.Count("worker.metrics_flushed_total", int64(ms.totalTimers), []string{"metric_type:timer"}, 1.0)
@@ -306,7 +320,7 @@ func (s *Server) flushPart(metricSlice []samplers.DDMetric, wg *sync.WaitGroup) 
 	}, "flush", true)
 }
 
-func (s *Server) flushForward(wms []WorkerMetrics) {
+func (s *Server) flushForward(wms []WorkerMetrics, interval time.Duration) {
 	jmLength := 0
 	for _, wm := range wms {
 		jmLength += len(wm.histograms)
@@ -317,6 +331,18 @@ func (s *Server) flushForward(wms []WorkerMetrics) {
 	jsonMetrics := make([]samplers.JSONMetric, 0, jmLength)
 	exportStart := time.Now()
 	for _, wm := range wms {
+		for _, count := range wm.globalCounters {
+			jm, err := count.Export()
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"type":          "counter",
+					"name":          count.Name,
+				}).Error("Could not export metric")
+				continue
+			}
+			jsonMetrics = append(jsonMetrics, jm)
+		}
 		for _, histo := range wm.histograms {
 			jm, err := histo.Export()
 			if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -113,12 +113,19 @@ func TestInvalidPackets(t *testing.T) {
 }
 
 func TestLocalOnlyEscape(t *testing.T) {
-	m, err := samplers.ParseMetric([]byte("a.b.c:1|h|#veneurlocalonly"))
+	m, err := samplers.ParseMetric([]byte("a.b.c:1|h|#veneurlocalonly,tag2:quacks"))
 	assert.NoError(t, err, "should have no error parsing")
-	assert.True(t, m.LocalOnly, "should have gotten local only metric")
-	for _, thisTag := range m.Tags {
-		assert.NotEqual(t, "veneurlocalonly", thisTag, "veneurlocalonly should not actually be a tag")
-	}
+	assert.Equal(t, samplers.LocalOnly, m.Scope, "should have gotten local only metric")
+	assert.NotContains(t, m.Tags, "veneurlocalonly", "veneurlocalonly should not actually be a tag")
+	assert.Contains(t, m.Tags, "tag2:quacks", "tag2 should be preserved in the list of tags after removing magic tags")
+}
+
+func TestGlobalOnlyEscape(t *testing.T) {
+	m, err := samplers.ParseMetric([]byte("a.b.c:1|h|#veneurglobalonly,tag2:quacks"))
+	assert.NoError(t, err, "should have no error parsing")
+	assert.Equal(t, samplers.GlobalOnly, m.Scope, "should have gotten local only metric")
+	assert.NotContains(t, m.Tags, "veneurglobalonly", "veneurlocalonly should not actually be a tag")
+	assert.Contains(t, m.Tags, "tag2:quacks", "tag2 should be preserved in the list of tags after removing magic tags")
 }
 
 func TestEvents(t *testing.T) {

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -19,8 +19,16 @@ type UDPMetric struct {
 	Value      interface{}
 	SampleRate float32
 	Tags       []string
-	LocalOnly  bool
+	Scope      MetricScope
 }
+
+type MetricScope int
+
+const (
+	MixedScope MetricScope = iota
+	LocalOnly
+	GlobalOnly
+)
 
 // MetricKey is a struct used to key the metrics into the worker's map. All fields must be comparable types.
 type MetricKey struct {
@@ -129,7 +137,12 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 				if tag == "veneurlocalonly" {
 					// delete the tag from the list
 					tags = append(tags[:i], tags[i+1:]...)
-					ret.LocalOnly = true
+					ret.Scope = LocalOnly
+					break
+				} else if tag == "veneurglobalonly" {
+					// delete the tag from the list
+					tags = append(tags[:i], tags[i+1:]...)
+					ret.Scope = GlobalOnly
 					break
 				}
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -234,7 +234,7 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  true,
+			Scope:      samplers.LocalOnly,
 		})
 	}
 
@@ -305,7 +305,7 @@ func TestGlobalServerFlush(t *testing.T) {
 			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  true,
+			Scope:      samplers.LocalOnly,
 		})
 	}
 
@@ -459,7 +459,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  false,
+			Scope:      samplers.MixedScope,
 		})
 	}
 
@@ -473,7 +473,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 			Value:      1.0,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  true,
+			Scope:      samplers.LocalOnly,
 		})
 	}
 
@@ -587,7 +587,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  true,
+			Scope:      samplers.LocalOnly,
 		})
 	}
 
@@ -666,7 +666,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 			Value:      value,
 			Digest:     12345,
 			SampleRate: 1.0,
-			LocalOnly:  true,
+			Scope:      samplers.LocalOnly,
 		})
 	}
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -40,7 +40,7 @@ func TestWorkerLocal(t *testing.T) {
 		Value:      1.0,
 		Digest:     12345,
 		SampleRate: 1.0,
-		LocalOnly:  true,
+		Scope:      samplers.LocalOnly,
 	}
 	w.ProcessMetric(&m)
 


### PR DESCRIPTION
#### Summary

Add the ability to merge counters.

#### Motivation

Reduce cardinality for metrics by merging counts from all hosts.

#### Test plan

Wrote automated tests

#### Rollout/monitoring/revert plan

Roll out a few metrics with the `forceGlobal` tag and compare against counts that are forwarded locally.
