### PR TITLE
Unescape newlines in event/check text

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -178,3 +178,17 @@ func TestServiceChecks(t *testing.T) {
 		assert.Contains(t, err.Error(), errContent, "Error should have contained text")
 	}
 }
+
+func TestEventMessageUnescape(t *testing.T) {
+	packet := []byte("_e{3,15}:foo|foo\\nbar\\nbaz\\n")
+	evt, err := samplers.ParseEvent(packet)
+	assert.NoError(t, err, "Should have parsed correctly")
+	assert.Equal(t, "foo\nbar\nbaz\n", evt.Text, "Should contain newline")
+}
+
+func TestServiceCheckMessageUnescape(t *testing.T) {
+	packet := []byte("_sc|foo|0|m:foo\\nbar\\nbaz\\n")
+	svcheck, err := samplers.ParseServiceCheck(packet)
+	assert.NoError(t, err, "Should have parsed correctly")
+	assert.Equal(t, "foo\nbar\nbaz\n", svcheck.Message, "Should contain newline")
+}

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -221,7 +221,7 @@ func ParseEvent(packet []byte) (*UDPEvent, error) {
 	if len(textChunk) != textExpectedLength {
 		return nil, errors.New("Invalid event packet, actual text length did not match encoded length")
 	}
-	ret.Text = string(textChunk)
+	ret.Text = strings.Replace(string(textChunk), "\\n", "\n", -1)
 
 	var (
 		foundTimestamp   bool
@@ -380,7 +380,7 @@ func ParseServiceCheck(packet []byte) (*UDPServiceCheck, error) {
 			if foundMessage {
 				return nil, errors.New("Invalid service check packet, multiple message sections")
 			}
-			ret.Message = string(pipeSplitter.Chunk()[2:])
+			ret.Message = strings.Replace(string(pipeSplitter.Chunk()[2:]), "\\n", "\n", -1)
 			foundMessage = true
 		case pipeSplitter.Chunk()[0] == '#':
 			if ret.Tags != nil || foundMessage {


### PR DESCRIPTION
#### Summary

Add newline unescaping to event and service check messages
#### Motivation

it's what dogstatsd does, and some of our users would benefit from it
#### Test plan

added appropriate tests
#### Rollout/monitoring/revert plan

probably percolate to the world

r? @gphat || @ChimeraCoder 
