### PR TITLE
Move EncodeCSV to S3 plugin

### DIFF
--- a/plugins/s3/csv.go
+++ b/plugins/s3/csv.go
@@ -1,0 +1,106 @@
+package s3
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stripe/veneur/samplers"
+)
+
+const PartitionDateFormat = "20060102"
+const RedshiftDateFormat = "2006-01-02 03:04:05"
+
+type tsvField int
+
+const (
+	// the order in which these appear determines the
+	// order of the fields in the resultant TSV
+	TsvName tsvField = iota
+	TsvTags
+	TsvMetricType
+
+	// The hostName attached to the metric
+	TsvHostname
+
+	// The hostName of the server flushing the data
+	TsvVeneurHostname
+
+	TsvDeviceName
+	TsvInterval
+
+	TsvTimestamp
+	TsvValue
+
+	// This is the _partition field
+	// required by the Redshift IncrementalLoader.
+	// For our purposes, the current date is a good partition.
+	TsvPartition
+)
+
+var tsvSchema = [...]string{
+	TsvName:           "Name",
+	TsvTags:           "Tags",
+	TsvMetricType:     "MetricType",
+	TsvHostname:       "Hostname",
+	TsvDeviceName:     "DeviceName",
+	TsvInterval:       "Interval",
+	TsvVeneurHostname: "VeneurHostname",
+	TsvTimestamp:      "Timestamp",
+	TsvValue:          "Value",
+	TsvPartition:      "Partition",
+}
+
+// EncodeDDMetricCSV generates a newline-terminated CSV row that describes
+// the data represented by the DDMetric.
+// The caller is responsible for setting w.Comma as the appropriate delimiter.
+// For performance, encodeCSV does not flush after every call; the caller is
+// expected to flush at the end of the operation cycle
+func EncodeDDMetricCSV(d samplers.DDMetric, w *csv.Writer, partitionDate *time.Time, hostName string) error {
+
+	timestamp := d.Value[0][0]
+	value := strconv.FormatFloat(d.Value[0][1], 'f', -1, 64)
+	interval := strconv.Itoa(int(d.Interval))
+
+	// TODO(aditya) some better error handling for this
+	// to guarantee that the result is proper JSON
+	tags := "{" + strings.Join(d.Tags, ",") + "}"
+
+	fields := [...]string{
+		// the order here doesn't actually matter
+		// as long as the keys are right
+		TsvName:           d.Name,
+		TsvTags:           tags,
+		TsvMetricType:     d.MetricType,
+		TsvHostname:       d.Hostname,
+		TsvDeviceName:     d.DeviceName,
+		TsvInterval:       interval,
+		TsvVeneurHostname: hostName,
+		TsvValue:          value,
+
+		TsvTimestamp: time.Unix(int64(timestamp), 0).UTC().Format(RedshiftDateFormat),
+
+		// TODO avoid edge case at midnight
+		TsvPartition: partitionDate.UTC().Format(PartitionDateFormat),
+	}
+
+	w.Write(fields[:])
+	return w.Error()
+}
+
+// String returns the field Name.
+// eg tsvName.String() returns "Name"
+func (f tsvField) String() string {
+	return fmt.Sprintf(strings.Replace(tsvSchema[f], "tsv", "", 1))
+}
+
+// each key in tsvMapping is guaranteed to have a unique value
+var tsvMapping = map[string]int{}
+
+func init() {
+	for i, field := range tsvSchema {
+		tsvMapping[field] = i
+	}
+}

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -107,16 +107,16 @@ func EncodeDDMetricsCSV(metrics []samplers.DDMetric, delimiter rune, includeHead
 		headers := [...]string{
 			// the order here doesn't actually matter
 			// as long as the keys are right
-			samplers.TsvName:           samplers.TsvName.String(),
-			samplers.TsvTags:           samplers.TsvTags.String(),
-			samplers.TsvMetricType:     samplers.TsvMetricType.String(),
-			samplers.TsvHostname:       samplers.TsvHostname.String(),
-			samplers.TsvDeviceName:     samplers.TsvDeviceName.String(),
-			samplers.TsvInterval:       samplers.TsvInterval.String(),
-			samplers.TsvVeneurHostname: samplers.TsvVeneurHostname.String(),
-			samplers.TsvValue:          samplers.TsvValue.String(),
-			samplers.TsvTimestamp:      samplers.TsvTimestamp.String(),
-			samplers.TsvPartition:      samplers.TsvPartition.String(),
+			TsvName:           TsvName.String(),
+			TsvTags:           TsvTags.String(),
+			TsvMetricType:     TsvMetricType.String(),
+			TsvHostname:       TsvHostname.String(),
+			TsvDeviceName:     TsvDeviceName.String(),
+			TsvInterval:       TsvInterval.String(),
+			TsvVeneurHostname: TsvVeneurHostname.String(),
+			TsvValue:          TsvValue.String(),
+			TsvTimestamp:      TsvTimestamp.String(),
+			TsvPartition:      TsvPartition.String(),
 		}
 
 		w.Write(headers[:])
@@ -125,7 +125,7 @@ func EncodeDDMetricsCSV(metrics []samplers.DDMetric, delimiter rune, includeHead
 	// TODO avoid edge case at midnight
 	partitionDate := time.Now()
 	for _, metric := range metrics {
-		metric.EncodeCSV(w, &partitionDate, hostname)
+		EncodeDDMetricCSV(metric, w, &partitionDate, hostname)
 	}
 
 	w.Flush()

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -1,20 +1,15 @@
 package samplers
 
 import (
-	"encoding/csv"
 	"fmt"
 	"hash/fnv"
 	"math"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/clarkduvall/hyperloglog"
 	"github.com/stripe/veneur/tdigest"
 )
-
-const PartitionDateFormat = "20060102"
-const RedshiftDateFormat = "2006-01-02 03:04:05"
 
 // DDMetric is a data structure that represents the JSON that Datadog
 // wants when posting to the API
@@ -60,98 +55,6 @@ var aggregates = [...]string{
 	AggregateAverage: "avg",
 	AggregateCount:   "count",
 	AggregateSum:     "sum",
-}
-
-// EncodeCSV generates a newline-terminated CSV row that describes
-// the data represented by the DDMetric.
-// The caller is responsible for setting w.Comma as the appropriate delimiter.
-// For performance, encodeCSV does not flush after every call; the caller is
-// expected to flush at the end of the operation cycle
-func (d DDMetric) EncodeCSV(w *csv.Writer, partitionDate *time.Time, hostName string) error {
-
-	timestamp := d.Value[0][0]
-	value := strconv.FormatFloat(d.Value[0][1], 'f', -1, 64)
-	interval := strconv.Itoa(int(d.Interval))
-
-	// TODO(aditya) some better error handling for this
-	// to guarantee that the result is proper JSON
-	tags := "{" + strings.Join(d.Tags, ",") + "}"
-
-	fields := [...]string{
-		// the order here doesn't actually matter
-		// as long as the keys are right
-		TsvName:           d.Name,
-		TsvTags:           tags,
-		TsvMetricType:     d.MetricType,
-		TsvHostname:       d.Hostname,
-		TsvDeviceName:     d.DeviceName,
-		TsvInterval:       interval,
-		TsvVeneurHostname: hostName,
-		TsvValue:          value,
-
-		TsvTimestamp: time.Unix(int64(timestamp), 0).UTC().Format(RedshiftDateFormat),
-
-		// TODO avoid edge case at midnight
-		TsvPartition: partitionDate.UTC().Format(PartitionDateFormat),
-	}
-
-	w.Write(fields[:])
-	return w.Error()
-}
-
-type tsvField int
-
-const (
-	// the order in which these appear determines the
-	// order of the fields in the resultant TSV
-	TsvName tsvField = iota
-	TsvTags
-	TsvMetricType
-
-	// The hostName attached to the metric
-	TsvHostname
-
-	// The hostName of the server flushing the data
-	TsvVeneurHostname
-
-	TsvDeviceName
-	TsvInterval
-
-	TsvTimestamp
-	TsvValue
-
-	// This is the _partition field
-	// required by the Redshift IncrementalLoader.
-	// For our purposes, the current date is a good partition.
-	TsvPartition
-)
-
-var tsvSchema = [...]string{
-	TsvName:           "Name",
-	TsvTags:           "Tags",
-	TsvMetricType:     "MetricType",
-	TsvHostname:       "Hostname",
-	TsvDeviceName:     "DeviceName",
-	TsvInterval:       "Interval",
-	TsvVeneurHostname: "VeneurHostname",
-	TsvTimestamp:      "Timestamp",
-	TsvValue:          "Value",
-	TsvPartition:      "Partition",
-}
-
-// String returns the field Name.
-// eg tsvName.String() returns "Name"
-func (f tsvField) String() string {
-	return fmt.Sprintf(strings.Replace(tsvSchema[f], "tsv", "", 1))
-}
-
-// each key in tsvMapping is guaranteed to have a unique value
-var tsvMapping = map[string]int{}
-
-func init() {
-	for i, field := range tsvSchema {
-		tsvMapping[field] = i
-	}
 }
 
 // JSONMetric is used to represent a metric that can be remarshaled with its

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -1,15 +1,9 @@
 package samplers
 
 import (
-	"bytes"
-	"encoding/csv"
-	"fmt"
-	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -285,115 +279,4 @@ func TestHistoMerge(t *testing.T) {
 	assert.InDelta(t, 1.0, h2.LocalWeight, 0.02, "merged histogram should have count of 1 after adding a value")
 	assert.InDelta(t, 1.0, h2.LocalMin, 0.02, "merged histogram should have min of 1 after adding a value")
 	assert.InDelta(t, 1.0, h2.LocalMax, 0.02, "merged histogram should have max of 1 after adding a value")
-}
-
-type CSVTestCase struct {
-	Name     string
-	DDMetric DDMetric
-	Row      io.Reader
-}
-
-func CSVTestCases() []CSVTestCase {
-
-	partition := time.Now().UTC().Format("20060102")
-
-	return []CSVTestCase{
-		{
-			Name: "BasicDDMetric",
-			DDMetric: DDMetric{
-				Name: "a.b.c.max",
-				Value: [1][2]float64{[2]float64{1476119058,
-					100}},
-				Tags: []string{"foo:bar",
-					"baz:quz"},
-				MetricType: "gauge",
-				Hostname:   "globalstats",
-				DeviceName: "food",
-				Interval:   0,
-			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\tgauge\tglobalstats\ttestbox-c3eac9\tfood\t0\t2016-10-10 05:04:18\t100\t%s\n", partition)),
-		},
-		{
-			// Test that we are able to handle a missing field (DeviceName)
-			Name: "MissingDeviceName",
-			DDMetric: DDMetric{
-				Name: "a.b.c.max",
-				Value: [1][2]float64{[2]float64{1476119058,
-					100}},
-				Tags: []string{"foo:bar",
-					"baz:quz"},
-				MetricType: "rate",
-				Hostname:   "localhost",
-				DeviceName: "",
-				Interval:   10,
-			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t{foo:bar,baz:quz}\trate\tlocalhost\ttestbox-c3eac9\t\t10\t2016-10-10 05:04:18\t100\t%s\n", partition)),
-		},
-		{
-			// Test that we are able to handle tags which have tab characters in them
-			// by quoting the entire field
-			// (tags shouldn't do this, but we should handle them properly anyway)
-			Name: "TabTag",
-			DDMetric: DDMetric{
-				Name: "a.b.c.max",
-				Value: [1][2]float64{[2]float64{1476119058,
-					100}},
-				Tags: []string{"foo:b\tar",
-					"baz:quz"},
-				MetricType: "rate",
-				Hostname:   "localhost",
-				DeviceName: "eniac",
-				Interval:   10,
-			},
-			Row: strings.NewReader(fmt.Sprintf("a.b.c.max\t\"{foo:b\tar,baz:quz}\"\trate\tlocalhost\ttestbox-c3eac9\teniac\t10\t2016-10-10 05:04:18\t100\t%s\n", partition)),
-		},
-	}
-}
-
-func TestEncodeCSV(t *testing.T) {
-	testCases := CSVTestCases()
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-
-			b := &bytes.Buffer{}
-
-			w := csv.NewWriter(b)
-			w.Comma = '\t'
-
-			tm := time.Now()
-			err := tc.DDMetric.EncodeCSV(w, &tm, "testbox-c3eac9")
-			assert.NoError(t, err)
-
-			// We need to flush or there won't actually be any data there
-			w.Flush()
-			assert.NoError(t, err)
-
-			assertReadersEqual(t, tc.Row, b)
-		})
-	}
-}
-
-// Helper function for determining that two readers are equal
-func assertReadersEqual(t *testing.T, expected io.Reader, actual io.Reader) {
-
-	// If we can seek, ensure that we're starting at the beginning
-	for _, reader := range []io.Reader{expected, actual} {
-		if readerSeeker, ok := reader.(io.ReadSeeker); ok {
-			readerSeeker.Seek(0, io.SeekStart)
-		}
-	}
-
-	// do the lazy thing for now
-	bts, err := ioutil.ReadAll(expected)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	bts2, err := ioutil.ReadAll(actual)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, string(bts), string(bts2))
 }


### PR DESCRIPTION
#### Summary

This was less work than I'd thought it would be. EncodeCSV belongs in the s3 plugin, since that's the only place it's used, and it depends on the Redshift date format anyway. The downside to this is that `EncodeDDMetricCSV` is no longer a method of `DDMetric`, but there's nothing that can be done about that.

#### Motivation

Consolidate code

#### Test plan

Moved test files over and deleted redundant code.

#### Rollout/monitoring/revert plan


N/A



r? @tummychow 
