### PR TITLE
Remove per-worker metrics, reducing tag cardinality.

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -253,8 +253,8 @@ func (w *Worker) Flush() WorkerMetrics {
 		1.0,
 	)
 
-	w.stats.Count("worker.metrics_processed_total", processed, []string{fmt.Sprintf("worker:%d", w.id)}, 1.0)
-	w.stats.Count("worker.metrics_imported_total", imported, []string{fmt.Sprintf("worker:%d", w.id)}, 1.0)
+	w.stats.Count("worker.metrics_processed_total", processed, []string{}, 1.0)
+	w.stats.Count("worker.metrics_imported_total", imported, []string{}, 1.0)
 
 	return ret
 }

--- a/worker.go
+++ b/worker.go
@@ -1,7 +1,6 @@
 package veneur
 
 import (
-	"fmt"
 	"sync"
 	"time"
 


### PR DESCRIPTION
#### Summary
Remove per-worker tag from two metrics.

#### Motivation
Since we run 96 workers we're getting `96 * num workers` timeseries, which is a waste. We don't need this to be per-worker.

#### Test plan
Letting unit tests work. We don't use this tag in any dashboards.  It's unusable and our single biggest cardinality metric.

r? @aditya-stripe 