### PR TITLE
Add README for plugins

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,10 @@
+Plugins
+================
+[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](https://godoc.org/github.com/stripe/veneur/plugins)
+
+Veneur supports the use of plugins to flush data to multiple destinations. For example, the S3 plugin can be used to archive data to S3 while also flushing to Datadog.
+
+Plugins may not carry the same stability guarantees as the rest of Veneur. For information on a specific plugin, consult the documentation for that particular plugin.
+
+
+For more information on writing your own flushing plugin for Veneur, see the [package documentation](https://godoc.org/github.com/stripe/veneur/plugins).

--- a/plugins/s3/README.md
+++ b/plugins/s3/README.md
@@ -1,0 +1,6 @@
+S3 Plugin
+===========
+
+The S3 plugin archives every flush to S3 as a separate S3 object.
+
+This plugin is still in an experimental state.


### PR DESCRIPTION
#### Summary

Add READMEs for the plugins directory and the S3 plugin specifically. In particular, document that the S3 plugin is still experimental, compared to the rest of Veneur.

Once we have the Redshift rollup working, we should document that in this README for the benefit of anybody else who wants to use the S3 plugin, but let's wait until we get that rolled out.



#### Motivation


This has been on my mental TODO list for a while, and pre-freeze is a good time to do that. :)

#### Test plan

N/A



r? @cory-stripe || @sjung-stripe 

