### PR TITLE
samplers.DDMetric: Mark Hostname DeviceName with json:"omitempty"

### DIFF
--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -20,8 +20,8 @@ type DDMetric struct {
 	Value      [1][2]float64 `json:"points"`
 	Tags       []string      `json:"tags,omitempty"`
 	MetricType string        `json:"type"`
-	Hostname   string        `json:"host"`
-	DeviceName string        `json:"device_name"`
+	Hostname   string        `json:"host,omitempty"`
+	DeviceName string        `json:"device_name,omitempty"`
 	Interval   int32         `json:"interval,omitempty"`
 }
 


### PR DESCRIPTION
Feel free to reject this change: it hardly matters.


#### Summary
samplers.DDMetric: Mark Hostname DeviceName with json:"omitempty"


#### Motivation
These fields are not required. Currently Veneur will send them as
empty strings when they are not set, which Datadog seems to ignore.
Omit them completely if they are not set to save bytes.


#### Test plan
We've been testing this patch and sending stats to datadog that don't have this set and they seem to work? This passes the existing tests locally.

