### PR TITLE
Adds a plugin to append metrics to a local file

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	AwsSecretAccessKey      string    `yaml:"aws_secret_access_key"`
 	Debug                   bool      `yaml:"debug"`
 	EnableProfiling         bool      `yaml:"enable_profiling"`
+	FlushFile               string    `yaml:"flush_file"`
 	FlushMaxPerBody         int       `yaml:"flush_max_per_body"`
 	ForwardAddress          string    `yaml:"forward_address"`
 	Hostname                string    `yaml:"hostname"`

--- a/example.yaml
+++ b/example.yaml
@@ -58,3 +58,6 @@ tls_certificate: ""
 
 # Authority certificate: requires clients to be authenticated
 tls_authority_certificate: ""
+
+# Include this if you want to archive data to a local file (which should then be rotated/cleaned)
+flush_file: ""

--- a/plugins/localfile/README.md
+++ b/plugins/localfile/README.md
@@ -1,0 +1,6 @@
+LocalFile Plugin
+==================
+
+The LocalFile Plugin appends each flush as TSV data to a specified file on the local system.  Since the file path is not parametrized with regards to date or time, the file with the TSV data should be rotated, processed, or removed to avoid problems with filling the disk.
+
+You can enable the LocalFile plugin by setting the `flush_file` key in the configuration to a file path.  The path must be writeable by Veneur, and if the file does not exist, Veneur will try to create it.

--- a/plugins/localfile/localfile.go
+++ b/plugins/localfile/localfile.go
@@ -1,0 +1,57 @@
+package localfile
+
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stripe/veneur/plugins"
+	"github.com/stripe/veneur/plugins/s3"
+	"github.com/stripe/veneur/samplers"
+)
+
+var _ plugins.Plugin = &Plugin{}
+
+// Plugin is the LocalFile plugin that we'll use in Veneur
+type Plugin struct {
+	FilePath string
+	Logger   *logrus.Logger
+}
+
+// Delimiter defines what kind of delimiter we'll use in the CSV format -- in this case, we want TSV
+const Delimiter = '\t'
+
+// Flush the metrics from the LocalFilePlugin
+func (p *Plugin) Flush(metrics []samplers.DDMetric, hostname string) error {
+	f, err := os.OpenFile(p.FilePath, os.O_RDWR|os.O_APPEND|os.O_CREATE, os.ModePerm)
+	defer f.Close()
+
+	if err != nil {
+		return fmt.Errorf("couldn't open %s for appending: %s", p.FilePath, err)
+	}
+	appendToWriter(f, metrics, hostname)
+	return nil
+}
+
+func appendToWriter(appender io.Writer, metrics []samplers.DDMetric, hostname string) error {
+	gzW := gzip.NewWriter(appender)
+	csvW := csv.NewWriter(gzW)
+	csvW.Comma = Delimiter
+
+	partitionDate := time.Now()
+	for _, metric := range metrics {
+		s3.EncodeDDMetricCSV(metric, csvW, &partitionDate, hostname)
+	}
+	csvW.Flush()
+	gzW.Close()
+	return csvW.Error()
+}
+
+// Name is the name of the LocalFilePlugin, i.e., "localfile"
+func (p *Plugin) Name() string {
+	return "localfile"
+}

--- a/plugins/localfile/localfile_test.go
+++ b/plugins/localfile/localfile_test.go
@@ -27,10 +27,16 @@ func TestAppendToWriter(t *testing.T) {
 	metrics := []samplers.DDMetric{
 		samplers.DDMetric{
 			Name: "a.b.c.max",
-			Value: [1][2]float64{[2]float64{1476119058,
-				100}},
-			Tags: []string{"foo:bar",
-				"baz:quz"},
+			Value: [1][2]float64{
+				[2]float64{
+					1476119058,
+					100,
+				},
+			},
+			Tags: []string{
+				"foo:bar",
+				"baz:quz",
+			},
 			MetricType: "gauge",
 			Hostname:   "globalstats",
 			DeviceName: "food",

--- a/plugins/localfile/localfile_test.go
+++ b/plugins/localfile/localfile_test.go
@@ -1,0 +1,94 @@
+package localfile
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/samplers"
+)
+
+type badWriter struct{}
+
+func (w *badWriter) Write(b []byte) (n int, err error) {
+	return 0, fmt.Errorf("This writer fails when you try to write!")
+}
+
+func TestName(t *testing.T) {
+	plugin := Plugin{FilePath: "doesntexist.txt", Logger: logrus.New()}
+	assert.Equal(t, plugin.Name(), "localfile")
+}
+
+func TestAppendToWriter(t *testing.T) {
+	b := &bytes.Buffer{}
+
+	metrics := []samplers.DDMetric{
+		samplers.DDMetric{
+			Name: "a.b.c.max",
+			Value: [1][2]float64{[2]float64{1476119058,
+				100}},
+			Tags: []string{"foo:bar",
+				"baz:quz"},
+			MetricType: "gauge",
+			Hostname:   "globalstats",
+			DeviceName: "food",
+			Interval:   0,
+		},
+	}
+
+	err := appendToWriter(b, metrics, metrics[0].Hostname)
+	assert.NoError(t, err)
+	assert.NotEqual(t, b.Len(), 0)
+}
+
+func TestHandlesErrorsInAppendToWriter(t *testing.T) {
+	b := &badWriter{}
+
+	err := appendToWriter(b, []samplers.DDMetric{
+		samplers.DDMetric{
+			Name:       "sketchy.metric",
+			Value:      [1][2]float64{[2]float64{1476119058, 100}},
+			Tags:       []string{"skepticism:high"},
+			MetricType: "gauge",
+			Hostname:   "globblestoots",
+			DeviceName: "¬_¬",
+			Interval:   -1,
+		},
+	}, "globblestoots")
+
+	assert.Error(t, err)
+}
+
+func TestWritesToDevNull(t *testing.T) {
+	plugin := Plugin{FilePath: "/dev/null", Logger: logrus.New()}
+	err := plugin.Flush([]samplers.DDMetric{
+		samplers.DDMetric{
+			Name:       "sketchy.metric",
+			Value:      [1][2]float64{[2]float64{1476119058, 100}},
+			Tags:       []string{"skepticism:high"},
+			MetricType: "gauge",
+			Hostname:   "globblestoots",
+			DeviceName: "¬_¬",
+			Interval:   -1,
+		},
+	}, "globblestoots")
+	assert.NoError(t, err)
+}
+
+func TestFailsWritingToInvalidPath(t *testing.T) {
+	plugin := Plugin{FilePath: "", Logger: logrus.New()}
+	err := plugin.Flush([]samplers.DDMetric{
+		samplers.DDMetric{
+			Name:       "sketchy.metric",
+			Value:      [1][2]float64{[2]float64{1476119058, 100}},
+			Tags:       []string{"skepticism:high"},
+			MetricType: "gauge",
+			Hostname:   "globblestoots",
+			DeviceName: "¬_¬",
+			Interval:   -1,
+		},
+	}, "globblestoots")
+	assert.Error(t, err)
+}

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/stripe/veneur/plugins"
 	"github.com/stripe/veneur/plugins/influxdb"
+	localfilep "github.com/stripe/veneur/plugins/localfile"
 	s3p "github.com/stripe/veneur/plugins/s3"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/trace"
@@ -38,6 +40,9 @@ import (
 // VERSION stores the current veneur version.
 // It must be a var so it can be set at link time.
 var VERSION = "dirty"
+
+// REDACTED should be a constant since we use it enough.
+const REDACTED = "REDACTED"
 
 var profileStartOnce = sync.Once{}
 
@@ -189,6 +194,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.HTTPAddr = conf.HTTPAddress
 	ret.ForwardAddr = conf.ForwardAddress
 
+<<<<<<< HEAD
 	if conf.TcpAddress != "" {
 		ret.TCPAddr, err = net.ResolveTCPAddr("tcp", conf.TcpAddress)
 		if err != nil {
@@ -228,9 +234,9 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		}
 	}
 
-	conf.Key = "REDACTED"
-	conf.SentryDsn = "REDACTED"
-	conf.TLSKey = "REDACTED"
+	conf.Key = REDACTED
+	conf.SentryDsn = REDACTED
+	conf.TLSKey = REDACTED
 	log.WithField("config", conf).Debug("Initialized server")
 
 	if len(conf.TraceAddress) > 0 && len(conf.TraceAPIAddress) > 0 {
@@ -253,8 +259,8 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	awsID := conf.AwsAccessKeyID
 	awsSecret := conf.AwsSecretAccessKey
 
-	conf.AwsAccessKeyID = "REDACTED"
-	conf.AwsSecretAccessKey = "REDACTED"
+	conf.AwsAccessKeyID = REDACTED
+	conf.AwsSecretAccessKey = REDACTED
 
 	if len(awsID) > 0 && len(awsSecret) > 0 {
 		sess, err := session.NewSession(&aws.Config{
@@ -292,6 +298,15 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			log, conf.InfluxAddress, conf.InfluxConsistency, conf.InfluxDBName, ret.HTTPClient, ret.statsd,
 		)
 		ret.registerPlugin(plugin)
+    }
+
+	if conf.FlushFile != "" {
+		localFilePlugin := &localfilep.Plugin{
+			FilePath: conf.FlushFile,
+			Logger:   log,
+		}
+		ret.registerPlugin(localFilePlugin)
+		log.Info(fmt.Sprintf("Local file logging to %s", conf.FlushFile))
 	}
 
 	// closed in Shutdown; Same approach and http.Shutdown

--- a/server.go
+++ b/server.go
@@ -41,7 +41,7 @@ import (
 // It must be a var so it can be set at link time.
 var VERSION = "dirty"
 
-// REDACTED should be a constant since we use it enough.
+// REDACTED is used to replace values that we don't want to leak into loglines (e.g., credentials)
 const REDACTED = "REDACTED"
 
 var profileStartOnce = sync.Once{}
@@ -194,7 +194,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.HTTPAddr = conf.HTTPAddress
 	ret.ForwardAddr = conf.ForwardAddress
 
-<<<<<<< HEAD
 	if conf.TcpAddress != "" {
 		ret.TCPAddr, err = net.ResolveTCPAddr("tcp", conf.TcpAddress)
 		if err != nil {
@@ -298,7 +297,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			log, conf.InfluxAddress, conf.InfluxConsistency, conf.InfluxDBName, ret.HTTPClient, ret.statsd,
 		)
 		ret.registerPlugin(plugin)
-    }
+	}
 
 	if conf.FlushFile != "" {
 		localFilePlugin := &localfilep.Plugin{

--- a/server_test.go
+++ b/server_test.go
@@ -90,6 +90,7 @@ func generateConfig(forwardAddr string) Config {
 		HTTPAddress:         fmt.Sprintf("localhost:%d", port),
 		ForwardAddress:      forwardAddr,
 		NumWorkers:          4,
+		FlushFile:           "/dev/null",
 
 		// Use only one reader, so that we can run tests
 		// on platforms which do not support SO_REUSEPORT
@@ -545,10 +546,12 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 
 	s3p := &s3p.S3Plugin{Logger: log, Svc: client}
 
+	pluginCount := len(f.server.getPlugins())
+
 	f.server.registerPlugin(s3p)
 
 	plugins := f.server.getPlugins()
-	assert.Equal(t, 1, len(plugins))
+	assert.Equal(t, pluginCount+1, len(plugins))
 
 	for _, value := range metricValues {
 		f.server.Workers[0].ProcessMetric(&samplers.UDPMetric{


### PR DESCRIPTION
#### Summary
- Adds a plugin such that, if `flush_file` is specified in the config yaml, metrics will be written to that file
- Assorted linter-y fixes as my editor complained at me

#### Motivation
This change lets us batch metrics into larger buckets than the flush interval, which makes processing them easier.

#### Test plan
I wrote unit tests and did a few additional tests in creating `.tsv.gz` files with Veneur and then `gunzip`ing them and reading them.

#### Notes
I’d only recommend enabling this flag if you have some sort of a cron job set up to clean these files on a regular basis, because otherwise writing metrics to disk indefinitely is a pretty scary prospect.