### PR TITLE
sentry.go: Fix hang and a panic on log.Error with no fields

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -15,30 +15,32 @@ func (s *Server) ConsumePanic(err interface{}) {
 		return
 	}
 
-	p := raven.Packet{
-		Level:      raven.FATAL,
-		ServerName: s.Hostname,
-		Interfaces: []raven.Interface{
-			// ignore 2 stack frames:
-			// - the frame for ConsumePanic itself
-			// - the frame for the deferred function that invoked ConsumePanic
-			raven.NewStacktrace(2, 3, []string{"main", "github.com/stripe/veneur"}),
-		},
-	}
+	if s.sentry != nil {
+		p := raven.Packet{
+			Level:      raven.FATAL,
+			ServerName: s.Hostname,
+			Interfaces: []raven.Interface{
+				// ignore 2 stack frames:
+				// - the frame for ConsumePanic itself
+				// - the frame for the deferred function that invoked ConsumePanic
+				raven.NewStacktrace(2, 3, []string{"main", "github.com/stripe/veneur"}),
+			},
+		}
 
-	// remember to block, since we're about to re-panic, which will probably terminate
-	switch e := err.(type) {
-	case error:
-		p.Message = e.Error()
-	case fmt.Stringer:
-		p.Message = e.String()
-	default:
-		p.Message = fmt.Sprintf("%#v", e)
-	}
+		// remember to block, since we're about to re-panic, which will probably terminate
+		switch e := err.(type) {
+		case error:
+			p.Message = e.Error()
+		case fmt.Stringer:
+			p.Message = e.String()
+		default:
+			p.Message = fmt.Sprintf("%#v", e)
+		}
 
-	_, ch := s.sentry.Capture(&p, nil)
-	// we don't want the program to terminate before reporting to sentry
-	<-ch
+		_, ch := s.sentry.Capture(&p, nil)
+		// we don't want the program to terminate before reporting to sentry
+		<-ch
+	}
 
 	panic(err)
 }

--- a/sentry.go
+++ b/sentry.go
@@ -69,13 +69,16 @@ func (s sentryHook) Fire(e *logrus.Entry) error {
 		},
 	}
 
+	packetExtraLength := len(e.Data)
 	if err, ok := e.Data[logrus.ErrorKey].(error); ok {
 		p.Message = err.Error()
+		// don't send the error as an extra field
+		packetExtraLength -= 1
 	} else {
 		p.Message = e.Message
 	}
 
-	p.Extra = make(map[string]interface{}, len(e.Data)-1)
+	p.Extra = make(map[string]interface{}, packetExtraLength)
 	for k, v := range e.Data {
 		if k == logrus.ErrorKey {
 			continue // already handled this key, don't put it into the Extra hash

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -1,0 +1,61 @@
+package veneur
+
+import (
+	"testing"
+
+	"github.com/getsentry/raven-go"
+)
+
+// returns the result of calling recover() after s.ConsumePanic()
+func consumeAndCatchPanic(s *Server) (result interface{}) {
+	defer func() {
+		result = recover()
+	}()
+	s.ConsumePanic("panic")
+	return
+}
+
+func TestConsumePanicWithoutSentry(t *testing.T) {
+	s := &Server{}
+	// does nothing
+	s.ConsumePanic(nil)
+
+	recovered := consumeAndCatchPanic(s)
+	if recovered != "panic" {
+		t.Error("ConsumePanic should panic", recovered)
+	}
+}
+
+type FakeSentryTransport struct {
+	packets []*raven.Packet
+}
+
+func (t *FakeSentryTransport) Send(url string, authHeader string, packet *raven.Packet) error {
+	t.packets = append(t.packets, packet)
+	return nil
+}
+
+func TestConsumePanicWithSentry(t *testing.T) {
+	s := &Server{}
+	var err error
+	s.sentry, err = raven.NewClient("", nil)
+	if err != nil {
+		t.Fatal("failed to create sentry client:", err)
+	}
+	fakeTransport := &FakeSentryTransport{}
+	s.sentry.Transport = fakeTransport
+
+	// nil does nothing
+	s.ConsumePanic(nil)
+	if len(fakeTransport.packets) != 0 {
+		t.Error("ConsumePanic(nil) should not send data:", fakeTransport.packets)
+	}
+
+	recovered := consumeAndCatchPanic(s)
+	if recovered != "panic" {
+		t.Error("ConsumePanic should panic", recovered)
+	}
+	if len(fakeTransport.packets) != 1 {
+		t.Error("expected 1 packet:", fakeTransport.packets)
+	}
+}


### PR DESCRIPTION
#### Summary
If s.sentry is nil, s.sentry.Capture returns a nil chan. Reading from
a nil chan blocks forever. Don't call it if s.sentry is nil.

sentryHook.Fire: Don't make map with negative length. When called
with a logrus.Entry without any tags (e.g. log.Error("error")),
the length of e.Data is 0, so it tried to make a map with length -1.
This caused a panic: panic: makemap: size out of range. Add a unit
test to check this case.

sentry_test.go: Add unit tests with and without s.sentry set.


#### Motivation
We don't use sentry. I found a different bug that was causing the process to hang instead of crash. This causes the hang. When fixing that, the unit test revealed the bug in sentryHook.Fire.


#### Test plan
See the new unit test. This is also running on Bluecore's test Veneur instance.


#### Rollout/monitoring/revert plan
There should be no impact to existing code.
