### PR TITLE
socket_linux.go: Support "all interfaces" addr e.g. :12345

### DIFF
--- a/socket_linux.go
+++ b/socket_linux.go
@@ -12,7 +12,7 @@ import (
 func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, error) {
 	// default to AF_INET6 to be equivalent to net.ListenUDP()
 	domain := unix.AF_INET6
-	if len(addr.IP) == net.IPv4len {
+	if addr.IP.To4() != nil {
 		domain = unix.AF_INET
 	}
 	sockFD, err := unix.Socket(domain, unix.SOCK_DGRAM|syscall.SOCK_CLOEXEC|syscall.SOCK_NONBLOCK, 0)
@@ -36,7 +36,7 @@ func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, 
 		sockaddr := &unix.SockaddrInet4{
 			Port: addr.Port,
 		}
-		if copied := copy(sockaddr.Addr[:], addr.IP); copied != net.IPv4len {
+		if copied := copy(sockaddr.Addr[:], addr.IP.To4()); copied != net.IPv4len {
 			panic("did not copy enough bytes of ip address")
 		}
 		sa = sockaddr
@@ -45,7 +45,7 @@ func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, 
 			Port: addr.Port,
 		}
 		// addr.IP will be length 0 for "bind all interfaces"
-		if copied := copy(sockaddr.Addr[:], addr.IP); !(copied == net.IPv6len || copied == 0) {
+		if copied := copy(sockaddr.Addr[:], addr.IP.To16()); !(copied == net.IPv6len || copied == 0) {
 			panic("did not copy enough bytes of ip address")
 		}
 		sa = sockaddr

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -10,7 +10,12 @@ import (
 
 // see also https://github.com/jbenet/go-reuseport/blob/master/impl_unix.go#L279
 func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, error) {
-	sockFD, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|syscall.SOCK_CLOEXEC|syscall.SOCK_NONBLOCK, 0)
+	// default to AF_INET6 to be equivalent to net.ListenUDP()
+	domain := unix.AF_INET6
+	if len(addr.IP) == net.IPv4len {
+		domain = unix.AF_INET
+	}
+	sockFD, err := unix.Socket(domain, unix.SOCK_DGRAM|syscall.SOCK_CLOEXEC|syscall.SOCK_NONBLOCK, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -26,13 +31,26 @@ func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, 
 		return nil, err
 	}
 
-	sockaddr := unix.SockaddrInet4{
-		Port: addr.Port,
+	var sa unix.Sockaddr
+	if domain == unix.AF_INET {
+		sockaddr := &unix.SockaddrInet4{
+			Port: addr.Port,
+		}
+		if copied := copy(sockaddr.Addr[:], addr.IP); copied != net.IPv4len {
+			panic("did not copy enough bytes of ip address")
+		}
+		sa = sockaddr
+	} else {
+		sockaddr := &unix.SockaddrInet6{
+			Port: addr.Port,
+		}
+		// addr.IP will be length 0 for "bind all interfaces"
+		if copied := copy(sockaddr.Addr[:], addr.IP); !(copied == net.IPv6len || copied == 0) {
+			panic("did not copy enough bytes of ip address")
+		}
+		sa = sockaddr
 	}
-	if copied := copy(sockaddr.Addr[:], addr.IP); copied != net.IPv4len {
-		panic("did not copy enough bytes of ip address")
-	}
-	if err = unix.Bind(sockFD, &sockaddr); err != nil {
+	if err = unix.Bind(sockFD, sa); err != nil {
 		return nil, err
 	}
 

--- a/socket_test.go
+++ b/socket_test.go
@@ -49,7 +49,6 @@ func TestSocket(t *testing.T) {
 
 	for _, test := range tests {
 		if test.addr == v6Localhost && !systemSupportsV6 {
-			t.Error("skipping v6Localhost because the system does not support it")
 			continue
 		}
 

--- a/socket_test.go
+++ b/socket_test.go
@@ -32,10 +32,10 @@ func TestSocket(t *testing.T) {
 	systemSupportsV6 := true
 	conn, err := net.ListenPacket("udp", "[::1]:0")
 	if err != nil {
-		t.Error("IPv6 not supported?", err)
 		systemSupportsV6 = false
+	} else {
+		conn.Close()
 	}
-	conn.Close()
 
 	tests := []struct {
 		addr         string

--- a/socket_test.go
+++ b/socket_test.go
@@ -7,16 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSocket(t *testing.T) {
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:8200")
-	assert.NoError(t, err, "should have constructed udp address correctly")
-
-	sock, err := NewSocket(addr, 2*1024*1024, false)
-	assert.NoError(t, err, "should have constructed socket correctly")
-
-	client, err := net.DialUDP("udp", nil, addr)
+func writeReadUDP(t *testing.T, sock net.PacketConn, addr string) {
+	client, err := net.Dial("udp", addr)
 	assert.NoError(t, err, "should have connected to socket")
-
 	_, err = client.Write([]byte("hello world"))
 	assert.NoError(t, err, "should have written to socket")
 
@@ -26,4 +19,40 @@ func TestSocket(t *testing.T) {
 	assert.Equal(t, n, 11, "should have read 11 bytes from socket")
 	assert.Equal(t, "hello world", string(b[:n]), "should have gotten message from socket")
 	assert.Equal(t, client.LocalAddr().String(), laddr.String(), "should have gotten message from client's address")
+	err = client.Close()
+	assert.NoError(t, err, "client.Close should not fail")
+}
+
+func TestSocket(t *testing.T) {
+	const portString = "8200"
+	const v4Localhost = "127.0.0.1:" + portString
+	const v6Localhost = "[::1]:" + portString
+
+	tests := []struct {
+		addr         string
+		supportsIPv4 bool
+		supportsIPv6 bool
+	}{
+		{v4Localhost, true, false},
+		{v6Localhost, false, true},
+		{":" + portString, true, true},
+	}
+
+	for _, test := range tests {
+		addr, err := net.ResolveUDPAddr("udp", test.addr)
+		assert.NoError(t, err, "should have resolved udp address %s correctly", test.addr)
+
+		sock, err := NewSocket(addr, 2*1024*1024, false)
+		assert.NoError(t, err, "should have constructed socket correctly")
+
+		if test.supportsIPv4 {
+			writeReadUDP(t, sock, v4Localhost)
+		}
+		if test.supportsIPv6 {
+			writeReadUDP(t, sock, v6Localhost)
+		}
+
+		err = sock.Close()
+		assert.NoError(t, err, "close should not fail")
+	}
 }


### PR DESCRIPTION
#### Summary
NewSocket will bind to IPv6 "all interfaces" if no IP is specified,
which matches the behaviour of net.ListenUDP.
Add a unit test to check IPv4 localhost, IPv6 localhost, and both.

The result of calling ResolveUDPAddr("udp", ":12345") is a
zero-length addr.IP, representing "all interfaces". Previously
NewSocket would panic with "did not copy enough bytes of ip address"
since it would copy zero bytes into the SockaddrInet4.


#### Motivation
I tried to use a standard Go "all interfaces" string like ":12345" and in worked on Mac OS X but panicked on Linux.


#### Test plan
Unit tests plus running a test instance of Veneur with this change, and a configuration that previously did not work.


#### Rollout/monitoring/revert plan
Should have no change to existing deployments
