### PR TITLE
Refactor Server to add Start() function

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -36,6 +36,7 @@ func main() {
 	defer func() {
 		server.ConsumePanic(recover())
 	}()
+	server.Start()
 
 	packetPool := &sync.Pool{
 		New: func() interface{} {

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"flag"
-	"sync"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stripe/veneur"
@@ -37,55 +35,6 @@ func main() {
 		server.ConsumePanic(recover())
 	}()
 	server.Start()
-
-	packetPool := &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, conf.MetricMaxLength)
-		},
-	}
-
-	tracePool := &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, conf.TraceMaxLengthBytes)
-		},
-	}
-
-	// Read forever!
-	for i := 0; i < conf.NumReaders; i++ {
-		go func() {
-			defer func() {
-				server.ConsumePanic(recover())
-			}()
-			server.ReadMetricSocket(packetPool, conf.NumReaders != 1)
-		}()
-	}
-
-	// Trace reader
-	go func() {
-		defer func() {
-			server.ConsumePanic(recover())
-		}()
-		if server.TraceAddr != nil {
-			server.ReadTraceSocket(tracePool, conf.NumReaders != 1)
-		} else {
-			logrus.Info("Tracing not configured - not reading trace socket")
-		}
-	}()
-
-	interval, err := conf.ParseInterval()
-	if err != nil {
-		logrus.Fatalf("Error parsing configuration %s", err)
-	}
-
-	go func() {
-		defer func() {
-			server.ConsumePanic(recover())
-		}()
-		ticker := time.NewTicker(interval)
-		for range ticker.C {
-			server.Flush(interval, conf.FlushMaxPerBody)
-		}
-	}()
 
 	server.HTTPServe()
 }

--- a/flusher.go
+++ b/flusher.go
@@ -188,7 +188,7 @@ func (s *Server) generateDDMetrics(ctx context.Context, percentiles []float64, t
 	finalMetrics := make([]samplers.DDMetric, 0, ms.totalLength)
 	for _, wm := range tempMetrics {
 		for _, c := range wm.counters {
-			finalMetrics = append(finalMetrics, c.Flush(s.Interval)...)
+			finalMetrics = append(finalMetrics, c.Flush(s.interval)...)
 		}
 		for _, g := range wm.gauges {
 			finalMetrics = append(finalMetrics, g.Flush()...)
@@ -196,10 +196,10 @@ func (s *Server) generateDDMetrics(ctx context.Context, percentiles []float64, t
 		// if we're a local veneur, then percentiles=nil, and only the local
 		// parts (count, min, max) will be flushed
 		for _, h := range wm.histograms {
-			finalMetrics = append(finalMetrics, h.Flush(s.Interval, percentiles, s.HistogramAggregates)...)
+			finalMetrics = append(finalMetrics, h.Flush(s.interval, percentiles, s.HistogramAggregates)...)
 		}
 		for _, t := range wm.timers {
-			finalMetrics = append(finalMetrics, t.Flush(s.Interval, percentiles, s.HistogramAggregates)...)
+			finalMetrics = append(finalMetrics, t.Flush(s.interval, percentiles, s.HistogramAggregates)...)
 		}
 
 		// local-only samplers should be flushed in their entirety, since they
@@ -207,13 +207,13 @@ func (s *Server) generateDDMetrics(ctx context.Context, percentiles []float64, t
 		// we still want percentiles for these, even if we're a local veneur, so
 		// we use the original percentile list when flushing them
 		for _, h := range wm.localHistograms {
-			finalMetrics = append(finalMetrics, h.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates)...)
+			finalMetrics = append(finalMetrics, h.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates)...)
 		}
 		for _, s := range wm.localSets {
 			finalMetrics = append(finalMetrics, s.Flush()...)
 		}
 		for _, t := range wm.localTimers {
-			finalMetrics = append(finalMetrics, t.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates)...)
+			finalMetrics = append(finalMetrics, t.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates)...)
 		}
 
 		// TODO (aditya) refactor this out so we don't
@@ -229,7 +229,7 @@ func (s *Server) generateDDMetrics(ctx context.Context, percentiles []float64, t
 			// global counters have no local parts, so if we're a local veneur,
 			// there's nothing to flush
 			for _, gc := range wm.globalCounters {
-				finalMetrics = append(finalMetrics, gc.Flush(s.Interval)...)
+				finalMetrics = append(finalMetrics, gc.Flush(s.interval)...)
 			}
 		}
 	}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -128,6 +128,7 @@ func testFlushTrace(t *testing.T, protobuf, jsn io.Reader) {
 	config.TraceAPIAddress = remoteServer.URL
 
 	server := setupVeneurServer(t, config)
+	server.Start()
 	defer server.Shutdown()
 
 	assert.Equal(t, server.DDTraceAddress, config.TraceAPIAddress)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -128,7 +128,6 @@ func testFlushTrace(t *testing.T, protobuf, jsn io.Reader) {
 	config.TraceAPIAddress = remoteServer.URL
 
 	server := setupVeneurServer(t, config)
-	server.Start()
 	defer server.Shutdown()
 
 	assert.Equal(t, server.DDTraceAddress, config.TraceAPIAddress)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -137,7 +137,6 @@ func testFlushTrace(t *testing.T, protobuf, jsn io.Reader) {
 
 	server.HandleTracePacket(packet)
 
-	interval, err := config.ParseInterval()
 	assert.NoError(t, err)
-	server.Flush(interval, config.FlushMaxPerBody)
+	server.Flush()
 }

--- a/server.go
+++ b/server.go
@@ -310,6 +310,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 	// Unlike metrics, protobuf shouldn't have an issue with 0-length packets
 	if len(packet) == 0 {
 		log.Error("received zero-length trace packet")
+		return
 	}
 
 	// Technically this could be anything, but we're only consuming trace spans

--- a/server.go
+++ b/server.go
@@ -288,7 +288,7 @@ func (s *Server) Start() {
 		}()
 	}
 
-	// Trace reader
+	// Read Traces Forever!
 	go func() {
 		defer func() {
 			s.ConsumePanic(recover())
@@ -300,6 +300,7 @@ func (s *Server) Start() {
 		}
 	}()
 
+	// Flush every Interval forever!
 	go func() {
 		defer func() {
 			s.ConsumePanic(recover())

--- a/server_test.go
+++ b/server_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
-	"sync"
 	"testing"
 	"time"
 
@@ -152,42 +151,6 @@ func setupVeneurServer(t *testing.T, config Config) Server {
 
 	server.Start()
 
-	packetPool := &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, config.MetricMaxLength)
-		},
-	}
-
-	// Metrics reader
-	for i := 0; i < config.NumReaders; i++ {
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					assert.Fail(t, "reader panicked while reading from socket", err)
-				}
-			}()
-			server.ReadMetricSocket(packetPool, config.NumReaders != 1)
-		}()
-	}
-
-	tracePool := &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, config.TraceMaxLengthBytes)
-		},
-	}
-
-	// Trace reader
-	go func() {
-		defer func() {
-			server.ConsumePanic(recover())
-		}()
-		if server.TraceAddr != nil {
-			server.ReadTraceSocket(tracePool, config.NumReaders != 1)
-		} else {
-			logrus.Info("Tracing not configured - not reading trace socket")
-		}
-	}()
-
 	go server.HTTPServe()
 	return server
 }
@@ -261,10 +224,7 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 		})
 	}
 
-	interval, err := config.ParseInterval()
-	assert.NoError(t, err)
-
-	f.server.Flush(interval, config.FlushMaxPerBody)
+	f.server.Flush()
 
 	ddmetrics := <-f.ddmetrics
 	assert.Equal(t, 6, len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
@@ -290,10 +250,7 @@ func TestGlobalServerFlush(t *testing.T) {
 		})
 	}
 
-	interval, err := config.ParseInterval()
-	assert.NoError(t, err)
-
-	f.server.Flush(interval, config.FlushMaxPerBody)
+	f.server.Flush()
 
 	ddmetrics := <-f.ddmetrics
 	assert.Equal(t, len(expectedMetrics), len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
@@ -403,10 +360,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 		})
 	}
 
-	interval, err := config.ParseInterval()
-	assert.NoError(t, err)
-
-	f.server.Flush(interval, config.FlushMaxPerBody)
+	f.server.Flush()
 
 	// the global veneur instance should get valid data
 	td := <-globalTD
@@ -517,10 +471,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 		})
 	}
 
-	interval, err := config.ParseInterval()
-	assert.NoError(t, err)
-
-	f.server.Flush(interval, config.FlushMaxPerBody)
+	f.server.Flush()
 }
 
 // TestGlobalServerS3PluginFlush tests that we are able to
@@ -588,10 +539,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		})
 	}
 
-	interval, err := config.ParseInterval()
-	assert.NoError(t, err)
-
-	f.server.Flush(interval, config.FlushMaxPerBody)
+	f.server.Flush()
 }
 
 func parseGzipTSV(r io.Reader) ([][]string, error) {

--- a/server_test.go
+++ b/server_test.go
@@ -80,7 +80,7 @@ func generateConfig(forwardAddr string) Config {
 		UdpAddress:          "localhost:8126",
 		HTTPAddress:         fmt.Sprintf("localhost:%d", port),
 		ForwardAddress:      forwardAddr,
-		NumWorkers:          96,
+		NumWorkers:          4,
 
 		// Use only one reader, so that we can run tests
 		// on platforms which do not support SO_REUSEPORT
@@ -150,6 +150,8 @@ func setupVeneurServer(t *testing.T, config Config) Server {
 		t.Fatal(err)
 	}
 
+	server.Start()
+
 	packetPool := &sync.Pool{
 		New: func() interface{} {
 			return make([]byte, config.MetricMaxLength)
@@ -187,7 +189,6 @@ func setupVeneurServer(t *testing.T, config Config) Server {
 	}()
 
 	go server.HTTPServe()
-	server.Start()
 	return server
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -187,6 +187,7 @@ func setupVeneurServer(t *testing.T, config Config) Server {
 	}()
 
 	go server.HTTPServe()
+	server.Start()
 	return server
 }
 


### PR DESCRIPTION
#### Summary
Add a `Server.Start()` that actually starts goroutinues and background work.  

Also:
* Fixes a bug that zero-length traces should not continue past the initial detection (return immediately)
* Improves test output readability by reducing the worker count from the rather silly 96 in `server_test`.

#### Motivation
This thins out `NewFromConfig` such that it's easier to test. This means we don't have a bunch of stuff happening behind the scenes just from the constructor.

#### Notes 
This is a step. We might want to do more? Sort of a strawman / first-step.

#### Test plan
Existing tests, as they make heavy use of `NewFromConfig`.

r? @aditya-stripe 