### PR TITLE
socket_linux.go: NewSocket: Close sockFD if returning with error

### DIFF
--- a/socket_linux.go
+++ b/socket_linux.go
@@ -24,10 +24,12 @@ func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, 
 	// https://github.com/golang/go/issues/16075
 	if reuseport {
 		if err := unix.SetsockoptInt(sockFD, unix.SOL_SOCKET, 0xf, 1); err != nil {
+			unix.Close(sockFD)
 			return nil, err
 		}
 	}
 	if err = unix.SetsockoptInt(sockFD, unix.SOL_SOCKET, unix.SO_RCVBUF, recvBuf); err != nil {
+		unix.Close(sockFD)
 		return nil, err
 	}
 
@@ -51,6 +53,7 @@ func NewSocket(addr *net.UDPAddr, recvBuf int, reuseport bool) (net.PacketConn, 
 		sa = sockaddr
 	}
 	if err = unix.Bind(sockFD, sa); err != nil {
+		unix.Close(sockFD)
 		return nil, err
 	}
 


### PR DESCRIPTION
#### Summary
If NewSocket hits an error after calling unix.Socket, it leaves the
file descriptor open. This adds calls to unix.Close on early returns.
Noticed while changing this function in commit 54d767a096.

#### Motivation
This is extremely unlikely to happen but is probably "more correct". It probably doesn't really matter since typically veneur will panic when one of these errors happens anyway.


#### Test plan
The unit tests pass? I'll be adding this to my veneur fork later today for testing, but given that these error paths are hopefully never executed, it isn't well tested :)


As an alternative: Its possible it would be "cleaner" to use `defer unix.Close(sockFD)` after `unix.Socket` succeeds, although I would have to remove the `defer osFD.Close()` call later, to avoid double-closing. I'm happy to make that change if that seems better.
