### PR TITLE
config: omit_empty_hostname: Allow not sending hostname to Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Veneur expects to have a config file supplied via `-f PATH`. The include `exampl
 * `flush_max_per_body` - how many metrics to include in each JSON body POSTed to Datadog. Veneur will POST multiple bodies in parallel if it goes over this limit. A value around 5k-10k is recommended; in practice we've seen Datadog reject bodies over about 195k.
 * `debug` - Should we output lots of debug info? :)
 * `hostname` - The hostname to be used with each metric sent. Defaults to `os.Hostname()`
+* `omit_empty_hostname` - If true and `hostname` is empty (`""`) Veneur will *not* add a host tag to its own metrics.
 * `interval` - How often to flush. Something like 10s seems good. **Note: If you change this, it breaks all kinds of things on Datadog's side. You'll have to change all your metric's metadata.**
 * `key` - Your Datadog API key
 * `percentiles` - The percentiles to generate from our timers and histograms. Specified as array of float64s

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MetricMaxLength     int       `yaml:"metric_max_length"`
 	NumReaders          int       `yaml:"num_readers"`
 	NumWorkers          int       `yaml:"num_workers"`
+	OmitEmptyHostname   bool      `yaml:"omit_empty_hostname"`
 	Percentiles         []float64 `yaml:"percentiles"`
 	ReadBufferSizeBytes int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn           string    `yaml:"sentry_dsn"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const defaultBufferSizeBytes = 1048576 * 2 // 2 MB
+
 // ReadConfig unmarshals the config file and slurps in it's data.
 func ReadConfig(path string) (c Config, err error) {
 	f, err := os.Open(path)
@@ -33,12 +35,12 @@ func readConfig(r io.Reader) (c Config, err error) {
 		return
 	}
 
-	if c.Hostname == "" {
+	if c.Hostname == "" && !c.OmitEmptyHostname {
 		c.Hostname, _ = os.Hostname()
 	}
 
 	if c.ReadBufferSizeBytes == 0 {
-		c.ReadBufferSizeBytes = 1048576 * 2 // 2 MB
+		c.ReadBufferSizeBytes = defaultBufferSizeBytes
 	}
 
 	return c, nil

--- a/config_test.go
+++ b/config_test.go
@@ -38,3 +38,30 @@ func TestReadBadConfig(t *testing.T) {
 	assert.NotNil(t, err, "Should have encountered parsing error when reading invalid config file")
 	assert.Equal(t, c, Config{}, "Parsing invalid config file should return zero struct")
 }
+
+func TestHostname(t *testing.T) {
+	const hostnameConfig = "hostname: foo"
+	r := strings.NewReader(hostnameConfig)
+	c, err := readConfig(r)
+	assert.Nil(t, err, "Should parsed valid config file: %s", hostnameConfig)
+	assert.Equal(t, c, Config{Hostname: "foo", ReadBufferSizeBytes: defaultBufferSizeBytes},
+		"Should have parsed hostname into Config")
+
+	const noHostname = "hostname: ''"
+	r = strings.NewReader(noHostname)
+	c, err = readConfig(r)
+	assert.Nil(t, err, "Should parsed valid config file: %s", noHostname)
+	currentHost, err := os.Hostname()
+	assert.Nil(t, err, "Could not get current hostname")
+	assert.Equal(t, c, Config{Hostname: currentHost, ReadBufferSizeBytes: defaultBufferSizeBytes},
+		"Should have used current hostname in Config")
+
+	const omitHostname = "omit_empty_hostname: true"
+	r = strings.NewReader(omitHostname)
+	c, err = readConfig(r)
+	assert.Nil(t, err, "Should parsed valid config file: %s", omitHostname)
+	assert.Equal(t, c, Config{
+		Hostname:            "",
+		ReadBufferSizeBytes: defaultBufferSizeBytes,
+		OmitEmptyHostname:   true})
+}

--- a/example.yaml
+++ b/example.yaml
@@ -34,6 +34,8 @@ trace_api_address: "http://localhost:7777"
 
 # If absent, defaults to the os.Hostname()!
 hostname: foobar
+# If true and hostname is "" or absent, don't add the host tag
+omit_empty_hostname: false
 
 # Include these if you want to archive data to S3
 aws_access_key_id: ""


### PR DESCRIPTION
#### Summary
By default, Veneur drops the host tag for global metrics, and always
tags local metrics. This adds an option to not tag local metrics, by
specifying `hostname: ""` and `omit_empty_hostname: true`. 


#### Motivation
In Bluecore's case, we are currently using a
single Veneur instance to aggegrate metrics from an existing system,
so our metrics are "local", but the host tag doesn't make sense.

We could specify a generic host tag, like "veneur", but we think
it is less confusing to omit it. Additionally at some point we might
need to use a "tree" of Veneur instances if we are lucky enough to
need to scale up to large numbers of metrics.

This is another one of "our use case is a bit weird" so maybe it shouldn't be included upstream. Its been useful for us though!


#### Test plan
There is a unit test! Also we've been using it at Bluecore.


#### Rollout/monitoring/revert plan
Backwards-compatible: just don't specify the option