### PR TITLE
add Dockerfile for alpine linux and ignore ./build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bin
 _work
 /veneur
 /cmd/veneur/veneur
+/build
 
 *.swp
 *.swo

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,41 @@
+FROM alpine:3.5
+MAINTAINER The Stripe Observability Team <support@stripe.com>
+
+RUN mkdir -p /build
+ENV GOPATH=/go
+ENV PATH=$PATH:$GOPATH/bin
+RUN apk add --no-cache go zip git musl-dev ca-certificates libressl protobuf
+RUN go get -u -v github.com/kardianos/govendor
+RUN go get -u -v github.com/ChimeraCoder/gojson/gojson
+RUN go get -u github.com/golang/protobuf/protoc-gen-go
+
+WORKDIR /go/src/github.com/stripe/veneur
+ADD . /go/src/github.com/stripe/veneur
+
+# If running locally, ignore any changes since
+# the last commit
+RUN git reset --hard HEAD && git status
+
+# Unlike the travis build file, we do NOT need to
+# ignore changes to protobuf-generated output
+# because we are guaranteed only one version of Go
+# used to build protoc-gen-go
+RUN go generate
+RUN gofmt -w .
+
+# Stage any changes caused by go generate and gofmt,
+# then confirm that there are no staged changes.
+#
+# If `go generate` or `gofmt` yielded any changes,
+# this will fail with an error message like "too many arguments"
+# or "M: binary operator expected"
+# Due to overlayfs peculiarities, running git diff-index without --cached
+# won't work, because it'll compare the mtimes (which have changed), and
+# therefore reports that the file may have changed (ie, a series of 0s)
+# See https://github.com/stripe/veneur/pull/110#discussion_r92843581
+RUN git add .
+RUN git diff-index --cached --exit-code HEAD
+
+
+RUN govendor test -v -timeout 15s +local
+CMD cp -r henson /build/ && go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur ./cmd/veneur


### PR DESCRIPTION
#### Summary
- add a dockerfile for alpine linux
- git ignore the ./build directory

#### Motivation
- alpine is getting popular for lightweight containers and uses musl
- allow for building binary on host filesystem by mounting build folder into container without accidently commiting to repo


#### Test plan
- No code changes

#### Rollout/monitoring/revert plan
1. `mkdir ./build`
1. `docker build -f Dockerfile.alpine -t localhost:veneur .`
1. `docker run -v "$PWD/build":/build localhost:veneur`
1. `file build/veneur`