### PR TITLE
Server.Shutdown: Close the trace listener gracefully.

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -98,8 +98,9 @@ func generateConfig(forwardAddr string) Config {
 		SentryDsn:       "",
 		FlushMaxPerBody: 1024,
 
-		TraceAddress:    "127.0.0.1:8128",
-		TraceAPIAddress: forwardAddr,
+		TraceAddress:        "127.0.0.1:8128",
+		TraceAPIAddress:     forwardAddr,
+		TraceMaxLengthBytes: 4096,
 	}
 }
 


### PR DESCRIPTION
#### Summary

Avoids an "address in use" error when running TestFlushTraces on Mac.
This uses the same approach as the TCP listener: Create the listen
socket when the Server is being initialized, then close it on
Shutdown. This causes the goroutine calling ReadFrom to get an error,
which is then handled.

ReadTraceSocket: Log a fatal error if packetPool is misconfigured. It
was not correctly configured in the unit tests. This fixes the
"received zero-length trace packet" visible in the test logs.


#### Motivation

There is an error in sentryHook that causes the goroutine that hits a Fatal error to hang, so this currently does NOT crash the server. However, with that change, it WILL. I'm splitting this since they can be reviewed independently. Another PR to come.