### PR TITLE
sentry.go: sentryHook.Fire: Don't hang for Fatal logs without Sentry

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -59,6 +59,11 @@ func (s sentryHook) Levels() []logrus.Level {
 }
 
 func (s sentryHook) Fire(e *logrus.Entry) error {
+	if s.c == nil {
+		// raven.Client works when it is nil, but skip the useless work and don't hang on Fatal
+		return nil
+	}
+
 	p := raven.Packet{
 		ServerName: s.hostname,
 		Interfaces: []raven.Interface{

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-
 	"github.com/getsentry/raven-go"
 )
 
@@ -72,9 +71,6 @@ func TestHookWithoutSentry(t *testing.T) {
 	entry := &logrus.Entry{}
 	// must use Fatal so the call to Fire blocks and we can check the result
 	entry.Level = logrus.FatalLevel
-	// entry.Time = time.Now()
-	// entry.Message = "received zero-length trace packet"
-	// fmt.Println("WTF???")f
 	err := hook.Fire(entry)
 	if err != nil {
 		t.Error("Fire returned an error:", err)

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -63,6 +63,23 @@ func TestConsumePanicWithSentry(t *testing.T) {
 	}
 }
 
+func TestHookWithoutSentry(t *testing.T) {
+	// hook with a nil sentry client is used when sentry is disabled
+	hook := &sentryHook{}
+
+	// entry without any tags
+	entry := &logrus.Entry{}
+	// must use Fatal so the call to Fire blocks and we can check the result
+	entry.Level = logrus.FatalLevel
+	// entry.Time = time.Now()
+	// entry.Message = "received zero-length trace packet"
+	// fmt.Println("WTF???")f
+	err := hook.Fire(entry)
+	if err != nil {
+		t.Error("Fire returned an error:", err)
+	}
+}
+
 func TestHook(t *testing.T) {
 	hook := &sentryHook{}
 	var err error

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -2,9 +2,10 @@ package veneur
 
 import (
 	"errors"
-	"github.com/Sirupsen/logrus"
 	"testing"
 	"time"
+
+	"github.com/Sirupsen/logrus"
 
 	"github.com/getsentry/raven-go"
 )

--- a/server.go
+++ b/server.go
@@ -639,6 +639,7 @@ func (s *Server) ReadTCPSocket() {
 			case <-s.shutdown:
 				// occurs when cleanly shutting down the server e.g. in tests; ignore errors
 				log.WithError(err).Info("Ignoring Accept error while shutting down")
+				return
 			default:
 			}
 			log.WithError(err).Fatal("TCP accept failed")

--- a/server.go
+++ b/server.go
@@ -641,8 +641,8 @@ func (s *Server) ReadTCPSocket() {
 				log.WithError(err).Info("Ignoring Accept error while shutting down")
 				return
 			default:
+				log.WithError(err).Fatal("TCP accept failed")
 			}
-			log.WithError(err).Fatal("TCP accept failed")
 		}
 
 		go s.handleTCPGoroutine(conn)

--- a/server.go
+++ b/server.go
@@ -243,7 +243,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			return
 		}
 	} else {
-		trace.Disabled = true
+		trace.Disable()
 	}
 
 	var svc s3iface.S3API

--- a/server.go
+++ b/server.go
@@ -136,6 +136,16 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		if err != nil {
 			return
 		}
+
+		log.Hooks.Add(sentryHook{
+			c:        ret.sentry,
+			hostname: ret.Hostname,
+			lv: []logrus.Level{
+				logrus.ErrorLevel,
+				logrus.FatalLevel,
+				logrus.PanicLevel,
+			},
+		})
 	}
 
 	if conf.Debug {
@@ -145,16 +155,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	if conf.EnableProfiling {
 		ret.enableProfiling = true
 	}
-
-	log.Hooks.Add(sentryHook{
-		c:        ret.sentry,
-		hostname: ret.Hostname,
-		lv: []logrus.Level{
-			logrus.ErrorLevel,
-			logrus.FatalLevel,
-			logrus.PanicLevel,
-		},
-	})
 
 	log.WithField("number", conf.NumWorkers).Info("Preparing workers")
 	// Allocate the slice, we'll fill it with workers later.

--- a/server_test.go
+++ b/server_test.go
@@ -32,6 +32,7 @@ import (
 	s3p "github.com/stripe/veneur/plugins/s3"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/tdigest"
+	"github.com/stripe/veneur/trace"
 )
 
 const ε = .00002
@@ -156,6 +157,8 @@ func assertMetric(t *testing.T, metrics DDMetricsRequest, metricName string, val
 // setupVeneurServer creates a local server from the specified config
 // and starts listening for requests. It returns the server for inspection.
 func setupVeneurServer(t *testing.T, config Config) Server {
+	trace.Enable()
+
 	server, err := NewFromConfig(config)
 	if err != nil {
 		t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -798,9 +798,7 @@ func TestTCPMetrics(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 
 				expectedSuccess := serverConfig.expectedConnectResults[i]
-				log.Info("asdfasdfsadf")
 				err := sendTCPMetrics(config.TcpAddress, clientConfig.tlsConfig, f)
-				log.Info("after")
 				if err != nil {
 					if expectedSuccess {
 						t.Errorf("server config: '%s' client config: '%s' failed: %s",

--- a/server_test.go
+++ b/server_test.go
@@ -792,23 +792,31 @@ func TestTCPMetrics(t *testing.T) {
 
 		// attempt to connect and send stats with each of the client configurations
 		for i, clientConfig := range clientConfigs {
-			expectedSuccess := serverConfig.expectedConnectResults[i]
-			err := sendTCPMetrics(config.TcpAddress, clientConfig.tlsConfig, f)
-			if err != nil {
-				if expectedSuccess {
-					t.Errorf("server config: '%s' client config: '%s' failed: %s",
-						serverConfig.name, clientConfig.name, err.Error())
+
+			testName := fmt.Sprintf("%s_%s", serverConfig.name, clientConfig.name)
+
+			t.Run(testName, func(t *testing.T) {
+
+				expectedSuccess := serverConfig.expectedConnectResults[i]
+				log.Info("asdfasdfsadf")
+				err := sendTCPMetrics(config.TcpAddress, clientConfig.tlsConfig, f)
+				log.Info("after")
+				if err != nil {
+					if expectedSuccess {
+						t.Errorf("server config: '%s' client config: '%s' failed: %s",
+							serverConfig.name, clientConfig.name, err.Error())
+					} else {
+						fmt.Printf("SUCCESS server config: '%s' client config: '%s' got expected error: %s\n",
+							serverConfig.name, clientConfig.name, err.Error())
+					}
+				} else if !expectedSuccess {
+					t.Errorf("server config: '%s' client config: '%s' worked; should fail!",
+						serverConfig.name, clientConfig.name)
 				} else {
-					fmt.Printf("SUCCESS server config: '%s' client config: '%s' got expected error: %s\n",
-						serverConfig.name, clientConfig.name, err.Error())
+					fmt.Printf("SUCCESS server config: '%s' client config: '%s'\n",
+						serverConfig.name, clientConfig.name)
 				}
-			} else if !expectedSuccess {
-				t.Errorf("server config: '%s' client config: '%s' worked; should fail!",
-					serverConfig.name, clientConfig.name)
-			} else {
-				fmt.Printf("SUCCESS server config: '%s' client config: '%s'\n",
-					serverConfig.name, clientConfig.name)
-			}
+			})
 		}
 
 		f.Close()


### PR DESCRIPTION
#### Summary

If `s.c` is `nil`, `s.c.Capture` returns a `nil` chan. Reading from it blocks
forever. This means if someone logs at logrus Fatal or Panic levels
without Sentry configured, the caller will hang instead of causing
the process. This is the same bug as commit d04711e9c2, just in a
different place.

It turns out the unit tests were depending on this behaviour, since they
were reusing ports and hitting this error. With this fix, they were crashing.
PR #134 fixes that problem.


#### Motivation

I was debugging something and found that Veneur was hanging, not crashing. This was the cause.


#### Test plan

So far, I've only run the unit tests.
