### PR TITLE
server_test.go: Use new ports to avoid address in use errors

### DIFF
--- a/server.go
+++ b/server.go
@@ -680,6 +680,8 @@ func (s *Server) Shutdown() {
 	// TODO(aditya) shut down workers and socket readers
 	log.Info("Shutting down server gracefully")
 	if s.tcpListener != nil {
+		// TODO: the socket is in use until there are no goroutines blocked in Accept
+		// we should wait until the accepting goroutine exits
 		err := s.tcpListener.Close()
 		if err != nil {
 			log.WithError(err).Warn("Ignoring error closing TCP listener")

--- a/server_test.go
+++ b/server_test.go
@@ -66,7 +66,12 @@ func globalConfig() Config {
 // generateConfig is not called config to avoid
 // accidental variable shadowing
 func generateConfig(forwardAddr string) Config {
+	// we don't shut down ports so avoid address in use errors
 	port := HTTPAddrPort
+	HTTPAddrPort++
+	metricsPort := HTTPAddrPort
+	HTTPAddrPort++
+	tracePort := HTTPAddrPort
 	HTTPAddrPort++
 
 	return Config{
@@ -81,7 +86,7 @@ func generateConfig(forwardAddr string) Config {
 		Percentiles:         []float64{.5, .75, .99},
 		Aggregates:          []string{"min", "max", "count"},
 		ReadBufferSizeBytes: 2097152,
-		UdpAddress:          "localhost:8126",
+		UdpAddress:          fmt.Sprintf("localhost:%d", metricsPort),
 		HTTPAddress:         fmt.Sprintf("localhost:%d", port),
 		ForwardAddress:      forwardAddr,
 		NumWorkers:          4,
@@ -98,7 +103,8 @@ func generateConfig(forwardAddr string) Config {
 		SentryDsn:       "",
 		FlushMaxPerBody: 1024,
 
-		TraceAddress:    "127.0.0.1:8128",
+		// Don't use the default port 8128: Veneur sends its own traces there, causing failures
+		TraceAddress:    fmt.Sprintf("127.0.0.1:%d", tracePort),
 		TraceAPIAddress: forwardAddr,
 	}
 }


### PR DESCRIPTION
#### Summary

`Server.Shutdown` does not stop the metrics or trace listeners. This
causes address in use errors that cause a call to `logrus.Fatal`.
Currently this is being masked due to a bug in `sentryHook.Fire` which
causes it to hang instead of exit. However, fixing that bug requires
this to be fixed.

`server.go`: Document that the way we shut down the TCP listener is not
completely correct.


#### Motivation

I want to fix the bug in sentryHook.Fire. See PR #133 which requires this change.


#### Test plan

I've only ran the unit tests so far.
