### PR TITLE
server.go: ReadTraceSocket: Verify packetPool is configured correctly

### DIFF
--- a/server.go
+++ b/server.go
@@ -504,6 +504,12 @@ func (s *Server) ReadTraceSocket(packetPool *sync.Pool) {
 	if s.TraceAddr == nil {
 		log.WithField("s.TraceAddr", s.TraceAddr).Fatal("Cannot listen on nil trace address")
 	}
+	p := packetPool.Get().([]byte)
+	if len(p) == 0 {
+		log.WithField("len", len(p)).Fatal(
+			"packetPool making empty slices: trace_max_length_bytes must be >= 0")
+	}
+	packetPool.Put(p)
 
 	// if we want to use multiple readers, make reuseport a parameter, like ReadMetricSocket.
 	serverConn, err := NewSocket(s.TraceAddr, s.RcvbufBytes, false)

--- a/server_test.go
+++ b/server_test.go
@@ -104,8 +104,9 @@ func generateConfig(forwardAddr string) Config {
 		FlushMaxPerBody: 1024,
 
 		// Don't use the default port 8128: Veneur sends its own traces there, causing failures
-		TraceAddress:    fmt.Sprintf("127.0.0.1:%d", tracePort),
-		TraceAPIAddress: forwardAddr,
+		TraceAddress:        fmt.Sprintf("127.0.0.1:%d", tracePort),
+		TraceAPIAddress:     forwardAddr,
+		TraceMaxLengthBytes: 4096,
 	}
 }
 


### PR DESCRIPTION
#### Summary

Previously the tests did not specify TraceMaxLengthBytes, causing the
trace packetPool to allocate zero-length slices. This causes ReadFrom
to return immediately, causing this goroutine to spin. Change it to
crash if it is misconfigured.


#### Motivation

This cleans up the test output and should help avoid server misconfigurations.


#### Test plan

I've only ran the unit tests.