### PR TITLE
Emit metrics on bad packets, adjust tags and add one for "long" packets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Deal with server shutdown without inspecting errors strings. Thanks [evanj](https://github.com/evanj)!
 * Decrease the number of things we send to Sentry as "errors".
 * Add a metric `veneur.sentry.errors_total` for number of errors we send to Sentry.
+* Detect and emit a metric `veneur.packet.error_total` tagged `reason:toolong` for metrics that exceed the metric max length.
+* Emit a metric `veneur.packet.error_total` tagged `reason:zerolength` for metrics have no contents.
 
 # 1.1.0, 2017-03-02
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ When forwarding you'll want to also monitor the global nodes you're using for ag
 
 Veneur will emit metrics to the `stats_address` configured above in DogStatsD form. Those metrics are:
 
-* `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client.
+* `veneur.packet.error_total` - Number of packets that Veneur could not parse due to some sort of formatting error by the client. Tagged by `packet_type` and `reason`.
 * `veneur.flush.post_metrics_total` - The total number of time-series points that will be submitted to Datadog via POST. Datadog's rate limiting is roughly proportional to this number.
 * `veneur.forward.post_metrics_total` - Indicates how many metrics are being forwarded in a given POST request. A "metric", in this context, refers to a unique combination of name, tags and metric type.
 * `veneur.*.content_length_bytes.*` - The number of bytes in a single POST body. Remember that Veneur POSTs large sets of metrics in multiple separate bodies in parallel. Uses a histogram, so there are multiple metrics generated depending on your local DogStatsD config.

--- a/server_test.go
+++ b/server_test.go
@@ -754,6 +754,8 @@ func TestIgnoreLongUDPMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	defer conn.Close()
 
+	// nb this metric is bad because it's too long based on the `MetricMaxLength`
+	// we set above!
 	conn.Write([]byte("foo.bar:1|c|#baz:gorch,long:tag,is:long"))
 	// Add a bit of delay to ensure things get processed
 	time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
#### Summary
Improve tagging one failed packets and add metrics for zero-length and too-long packets.

#### Motivation
Sometimes people send us packets that are longer than the configured max. Read 1 more byte and complain if our limit is exceeded. Also improve other metrics while were here.

#### Test plan
Added tests to ensure that the normal and "long" case both work as expected. I'm seeing this fail, however, with `go test`…
