### PR TITLE
Adjust some error cases to be less Sentry-y and add a metric!

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -523,10 +523,9 @@ func (s *Server) flushTraces(ctx context.Context) {
 		if err == nil {
 			log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")
 		} else {
-			log.WithFields(
-				logrus.Fields{
-					"traces":        len(finalTraces),
-					logrus.ErrorKey: err}).Warn("Error flushing traces to Datadog")
+			log.WithFields(logrus.Fields{
+				"traces":        len(finalTraces),
+				logrus.ErrorKey: err}).Warn("Error flushing traces to Datadog")
 		}
 	} else {
 		log.Info("No traces to flush, skipping.")
@@ -565,10 +564,9 @@ func (s *Server) flushEventsChecks() {
 		if err == nil {
 			log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
 		} else {
-			log.WithFields(
-				logrus.Fields{
-					"events":        len(events),
-					logrus.ErrorKey: err}).Warn("Error flushing events to Datadog")
+			log.WithFields(logrus.Fields{
+				"events":        len(events),
+				logrus.ErrorKey: err}).Warn("Error flushing events to Datadog")
 		}
 	}
 
@@ -580,10 +578,9 @@ func (s *Server) flushEventsChecks() {
 		if err == nil {
 			log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
-			log.WithFields(
-				logrus.Fields{
-					"checks":        len(checks),
-					logrus.ErrorKey: err}).Warn("Error flushing checks to Datadog")
+			log.WithFields(logrus.Fields{
+				"checks":        len(checks),
+				logrus.ErrorKey: err}).Warn("Error flushing checks to Datadog")
 		}
 	}
 }

--- a/flusher.go
+++ b/flusher.go
@@ -526,7 +526,7 @@ func (s *Server) flushTraces(ctx context.Context) {
 			log.WithFields(
 				logrus.Fields{
 					"traces":        len(finalTraces),
-					logrus.ErrorKey: err}).Error("Error flushing traces to Datadog")
+					logrus.ErrorKey: err}).Warn("Error flushing traces to Datadog")
 		}
 	} else {
 		log.Info("No traces to flush, skipping.")
@@ -564,6 +564,11 @@ func (s *Server) flushEventsChecks() {
 		}, "flush_events", true)
 		if err == nil {
 			log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
+		} else {
+			log.WithFields(
+				logrus.Fields{
+					"events":        len(events),
+					logrus.ErrorKey: err}).Warn("Error flushing events to Datadog")
 		}
 	}
 
@@ -574,6 +579,11 @@ func (s *Server) flushEventsChecks() {
 		err := s.postHelper(context.TODO(), fmt.Sprintf("%s/api/v1/check_run?api_key=%s", s.DDHostname, s.DDAPIKey), checks, "flush_checks", false)
 		if err == nil {
 			log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
+		} else {
+			log.WithFields(
+				logrus.Fields{
+					"checks":        len(checks),
+					logrus.ErrorKey: err}).Warn("Error flushing checks to Datadog")
 		}
 	}
 }
@@ -675,7 +685,7 @@ func (s *Server) postHelper(ctx context.Context, endpoint string, bodyObject int
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		s.statsd.Count(action+".error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
-		resultLogger.Error("Could not POST")
+		resultLogger.Warn("Could not POST")
 		return err
 	}
 

--- a/sentry.go
+++ b/sentry.go
@@ -36,8 +36,8 @@ func (s *Server) ConsumePanic(err interface{}) {
 		default:
 			p.Message = fmt.Sprintf("%#v", e)
 		}
-
 		_, ch := s.sentry.Capture(&p, nil)
+		s.statsd.Count("sentry.errors_total", 1, nil, 1.0)
 		// we don't want the program to terminate before reporting to sentry
 		<-ch
 	}


### PR DESCRIPTION
#### Summary
Changes a bunch of error logs to be warns and adds a metric for things that _do_ go to Sentry.

#### Motivation
We sent a lot of "peaceful" errors to Sentry. Let's reduce that chunder! Specifically, the error re: sending events to Datadog. There's not much to learn from these since we tag the failures anyway.

#### Test plan
Just changing a log level, effectively. Assuming existing coverage is fine.

r? @aditya-stripe 