### PR TITLE
Emit GC metrics at flush time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ## Added
 * Adds [events](https://docs.datadoghq.com/guides/dogstatsd/#events-1) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks-1) to `veneur-emit`. Thanks [redsn0w422](https://github.com/redsn0w422)!
-* Switch to [dep](https://github.com/golang/dep/) for managing the `vendor` directory.
-* Remove support for `govendor`.
+* Switch to [dep](https://github.com/golang/dep/) for managing the `vendor` directory. Thanks [chimeracoder](https://github.com/chimeracoder)!
+* Remove support for `govendor`. Thanks [chimeracoder](https://github.com/chimeracoder)!
+* Emit GC metrics at flush time. This feature is best used with Go 1.9 as previous versions cause GC pauses when collecting this information from go. Thanks [gphat](https://github.com/gphat)!
 
 ## Improvements
 * Added tests for `parseMetricSSF`. Thanks [redsn0w422](https://github.com/redsn0w422)!

--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ Veneur will emit metrics to the `stats_address` configured above in DogStatsD fo
 * `veneur.flush.error_total` - Number of errors received POSTing to Datadog.
 * `veneur.forward.error_total` - Number of errors received POSTing to an upstream Veneur. See also `import.request_error_total` below.
 * `veneur.flush.worker_duration_ns` - Per-worker timing — tagged by `worker` - for flush. This is important as it is the time in which the worker holds a lock and is unavailable for other work.
+* `veneur.gc.number` - Number of completed GC cycles.
+* `veneur.gc.pause_total_ns` - Total seconds of STW GC since the program started.
+* `veneur.mem.heap_alloc_bytes` - Total number of reachable and unreachable but uncollected heap objects in bytes.
 * `veneur.worker.metrics_processed_total` - Total number of metric packets processed between flushes by workers, tagged by `worker`. This helps you find hot spots where a single worker is handling a lot of metrics. The sum across all workers should be approximately proportional to the number of packets received.
 * `veneur.worker.metrics_flushed_total` - Total number of metrics flushed at each flush time, tagged by `metric_type`. A "metric", in this context, refers to a unique combination of name, tags and metric type. You can use this metric to detect when your clients are introducing new instrumentation, or when you acquire new clients.
 * `veneur.worker.metrics_imported_total` - Total number of metrics received via the importing endpoint. A "metric", in this context, refers to a unique combination of name, tags, type _and originating host_. This metric indicates how much of a Veneur instance's load is coming from imports.


### PR DESCRIPTION
#### Summary
Emit GC metrics at each remote metrics flush.

Adds:
* A gauge `veneur.mem.heap_alloc_bytes` tracking the size of the allocated heap in bytes
* A gauge `veneur.gc.number` tracking the number of GC runs
* A gauge `veneur.gc.pause_total_ns` tracking the total duration of GC pauses

#### Motivation
Now that we're using 1.9 RCs for our deploys, it's safe to merge this. In past versions Go would do a Stop-The-World collection when we asked for these stats. [1.9 fixes that](https://github.com/golang/go/commit/4a7cf960c38d72e9f0c6f00e46e013be2a35d56e).

We're adding this because, before now, it was difficult to measure the impact that changes to veneur's code had on production machines.

With these metrics we can determine if changes such as increasing ringbuffer sizes for traces or using a new HLL implementation in #190 have an impact either to the amount of memory allocated or the amount of time spend GCing.

These metrics will be invaluable as Veneur grows!

#### Test plan
Just metric emission, so should be fine.

#### Rollout/monitoring/revert plan
Deploy to globals and monitor. Eventually merge to fleet and let it naturally work it's way out.

r? @aditya-stripe 