### PR TITLE
Reduce allocations in metric parsing

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -811,3 +811,19 @@ func TestTCPMetrics(t *testing.T) {
 		f.Close()
 	}
 }
+
+func BenchmarkMetricParsing(b *testing.B) {
+	config := localConfig()
+	config.Interval = "300s"
+	config.TraceAddress = ""
+	config.ForwardAddress = ""
+	server, _ := NewFromConfig(config)
+
+	packet := []byte("a.b.c:123|c|@1.0|#host_env:prod,host_type:bar,thing1:thing2")
+
+	for i := 0; i < b.N; i++ {
+		server.HandleMetricPacket(packet)
+	}
+
+	server.Shutdown()
+}


### PR DESCRIPTION
#### Summary
Reduces allocations in `ParseMetric` whilst also making things a tiny, not really useful bit faster.

#### Motivation
This is a premature optimization, but I was interested in learning how to more effectively benchmark and measure allocations. This was primarily motivated by reading more about Go's GC. Regardless, this patch reduces allocations by reusing the hash and using a single buffer without allocation for `[]byte` conversions and such, since the buffer has nice things like `WriteString`.

A downside is that `ParseMetric` is no longer thread-safe because it assumes only one call at a time will manipulate the buffer and hash. This seems perfectly fine since `ReadMetricSocket` isn't goroutined.

#### Test plan
Existing unit tests are there, but also added a benchmark for future use. Here's sample output:

Old ParseMetrics:
`1000000	      1909 ns/op	     360 B/op	      10 allocs/op`
New ParseMetrics:
`1000000	      1921 ns/op	     424 B/op	      13 allocs/op`

r? @aditya-stripe 
cc