### PR TITLE
Fix some races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bugfixes
 * Fix flusher_test to properly shutdown HTTP after handling. Thanks [evanj](https://github.com/evanj)!
 * Verify that `trace_max_length_bytes` is properly set. Thanks [evanj](https://github.com/evanj)!
+* Fix a race condition in testing.
 
 ## Improvements
 * Document performance cost of TLS with RSA and ECDH keys. Thanks [evanj](https://github.com/evanj)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bugfixes
 * Fix flusher_test to properly shutdown HTTP after handling. Thanks [evanj](https://github.com/evanj)!
 * Verify that `trace_max_length_bytes` is properly set. Thanks [evanj](https://github.com/evanj)!
-* Fix a race condition in testing.
+* Fix some race conditions in testing.
 
 ## Improvements
 * Document performance cost of TLS with RSA and ECDH keys. Thanks [evanj](https://github.com/evanj)!

--- a/server.go
+++ b/server.go
@@ -257,8 +257,9 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		if err != nil {
 			return
 		}
+		trace.Enable()
 	} else {
-		trace.Disabled = true
+		trace.Disable()
 	}
 
 	var svc s3iface.S3API

--- a/server_test.go
+++ b/server_test.go
@@ -747,7 +747,7 @@ func TestUDPMetrics(t *testing.T) {
 	conn.Write([]byte("foo.bar:1|c|#baz:gorch"))
 	// Add a bit of delay to ensure things get processed
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, int64(1), f.server.Workers[0].processed, "worker processed metric")
+	assert.Equal(t, int64(1), f.server.Workers[0].MetricsProcessedCount(), "worker processed metric")
 }
 
 func TestIgnoreLongUDPMetrics(t *testing.T) {

--- a/worker.go
+++ b/worker.go
@@ -151,6 +151,15 @@ func (w *Worker) Work() {
 	}
 }
 
+// MetricsProcessedCount is a convenince method for testing
+// that allows us to fetch the Worker's processed count
+// in a non-racey way.
+func (w *Worker) MetricsProcessedCount() int64 {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.processed
+}
+
 // ProcessMetric takes a Metric and samples it
 //
 // This is standalone to facilitate testing


### PR DESCRIPTION
#### Summary
Fixes some race conditions with:
* creation of the server's TCP listener(s)
* consecutive calls to `NewFromConfig`
* UDP test that inspects worker processed counts
* Checking `trace.Disabled`

#### TCP Listener
These were detected via `go test -race`. I don't think it's a real bug because it would require starting the TCP listener more than once!

I actually think that moving this here makes more sense, as I can't see a reason why we need to defer the "wrapping" of the TCP listener with the TLS one.

The underlying reason for this was to learn my way around the trace tool and to make it easier to test some future changes. :)

#### Logrus Hooks
Logrus has [some race issues](https://github.com/sirupsen/logrus/issues/295), at least according to the detector, but in this case it seems to be us adding the hook multiple times due to consecutive calls to `NewFromConfig`. I don't think this has any impact in production, but an easy patch.

#### UDP Process Count
The UDP metric test uses the `processed` var inside the worker as a test. Since this is not really a legit use — and only possible because of package stuff — I added a testing convenience getter that uses the worker's mutex. This is only useful for testing.

#### Trace Enable/Disable
Accessing `trace.Disabled` was unsafe, again, due to fiddling with it's value in `NewFromConfig`. The solution is to use a `RWMutex` on it so we can read it in `sendSample`. Note that this gives us overhead in every single call to `sendSample` which will impact performance since we call it on every received span. This might be bad, but it was my first shot at fixing. Ideas welcome!

#### Note
This fixes every race detected by `go test -race`! I'm happy none of these look to be real bugs and are only triggered by testing junk!

#### Test plan
Existing test coverage.

r? @aditya-stripe 
cc'ing @evanj in case I missed something here with the TCP listener.