### PR TITLE
Various lint fixes

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -73,7 +73,7 @@ func (s sentryHook) Fire(e *logrus.Entry) error {
 	if err, ok := e.Data[logrus.ErrorKey].(error); ok {
 		p.Message = err.Error()
 		// don't send the error as an extra field
-		packetExtraLength -= 1
+		packetExtraLength--
 	} else {
 		p.Message = e.Message
 	}

--- a/server.go
+++ b/server.go
@@ -205,7 +205,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			}
 
 			clientAuthMode := tls.NoClientCert
-			var clientCAs *x509.CertPool = nil
+			var clientCAs *x509.CertPool
 			if conf.TLSAuthorityCertificate != "" {
 				// load the authority; require clients to present certificated signed by this authority
 				clientAuthMode = tls.RequireAndVerifyClientCert

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -35,8 +35,8 @@ func TestTracerRootSpan(t *testing.T) {
 
 	between := end.After(trace.Start) && trace.Start.After(start)
 
-	assert.Equal(t, trace.TraceId, trace.SpanId)
-	assert.Equal(t, trace.ParentId, expectedParent)
+	assert.Equal(t, trace.TraceID, trace.SpanID)
+	assert.Equal(t, trace.ParentID, expectedParent)
 	assert.Equal(t, trace.Resource, resource)
 	assert.True(t, between)
 }
@@ -63,7 +63,7 @@ func TestTracerChildSpan(t *testing.T) {
 	tracer := Tracer{}
 
 	parent := StartTrace(resource)
-	var expectedParent = parent.SpanId
+	var expectedParent = parent.SpanID
 
 	start := time.Now()
 	opts := []opentracing.StartSpanOption{
@@ -81,8 +81,8 @@ func TestTracerChildSpan(t *testing.T) {
 
 	assert.Equal(t, time.Unix(expectedTimestamp, 0), trace.Start)
 
-	assert.Equal(t, parent.TraceId, parent.SpanId)
-	assert.Equal(t, expectedParent, trace.ParentId)
+	assert.Equal(t, parent.TraceID, parent.SpanID)
+	assert.Equal(t, expectedParent, trace.ParentID)
 	assert.Equal(t, resource, trace.Resource)
 
 	assert.Len(t, trace.Tags, len(expectedTags))
@@ -167,10 +167,10 @@ func TestTracerInjectExtractBinary(t *testing.T) {
 
 	ctx := c.(*spanContext)
 
-	assert.Equal(t, trace.TraceId, ctx.TraceId())
+	assert.Equal(t, trace.TraceID, ctx.TraceID())
 
-	assert.Equal(t, trace.SpanId, ctx.SpanId(), "original trace and context should share the same SpanId")
-	assert.Equal(t, trace.ParentId, ctx.ParentId(), "original trace and context should share the same ParentId")
+	assert.Equal(t, trace.SpanID, ctx.SpanID(), "original trace and context should share the same SpanId")
+	assert.Equal(t, trace.ParentID, ctx.ParentID(), "original trace and context should share the same ParentId")
 	assert.Equal(t, trace.Resource, ctx.Resource())
 }
 
@@ -186,9 +186,9 @@ func TestTracerInjectTextMap(t *testing.T) {
 	err := tracer.Inject(trace.context(), opentracing.TextMap, tm)
 	assert.NoError(t, err)
 
-	assert.Equal(t, strconv.FormatInt(trace.TraceId, 10), tm["traceid"])
-	assert.Equal(t, strconv.FormatInt(trace.ParentId, 10), tm["parentid"])
-	assert.Equal(t, strconv.FormatInt(trace.SpanId, 10), tm["spanid"])
+	assert.Equal(t, strconv.FormatInt(trace.TraceID, 10), tm["traceid"])
+	assert.Equal(t, strconv.FormatInt(trace.ParentID, 10), tm["parentid"])
+	assert.Equal(t, strconv.FormatInt(trace.SpanID, 10), tm["spanid"])
 	assert.Equal(t, trace.Resource, tm["resource"])
 }
 
@@ -209,10 +209,10 @@ func TestTracerInjectExtractExtractTextMap(t *testing.T) {
 
 	ctx := c.(*spanContext)
 
-	assert.Equal(t, trace.TraceId, ctx.TraceId())
+	assert.Equal(t, trace.TraceID, ctx.TraceID())
 
-	assert.Equal(t, trace.SpanId, ctx.SpanId(), "original trace and context should share the same SpanId")
-	assert.Equal(t, trace.ParentId, ctx.ParentId(), "original trace and context should share the same ParentId")
+	assert.Equal(t, trace.SpanID, ctx.SpanID(), "original trace and context should share the same SpanId")
+	assert.Equal(t, trace.ParentID, ctx.ParentID(), "original trace and context should share the same ParentId")
 	assert.Equal(t, trace.Resource, ctx.Resource())
 }
 
@@ -236,10 +236,10 @@ func TestTracerInjectExtractHeader(t *testing.T) {
 
 	ctx := c.(*spanContext)
 
-	assert.Equal(t, trace.TraceId, ctx.TraceId())
+	assert.Equal(t, trace.TraceID, ctx.TraceID())
 
-	assert.Equal(t, trace.SpanId, ctx.SpanId(), "original trace and context should share the same SpanId")
-	assert.Equal(t, trace.ParentId, ctx.ParentId(), "original trace and context should share the same ParentId")
+	assert.Equal(t, trace.SpanID, ctx.SpanID(), "original trace and context should share the same SpanId")
+	assert.Equal(t, trace.ParentID, ctx.ParentID(), "original trace and context should share the same ParentId")
 	assert.Equal(t, trace.Resource, ctx.Resource())
 
 }
@@ -284,7 +284,7 @@ func TestInjectRequestExtractRequestChild(t *testing.T) {
 	span, err := tracer.ExtractRequestChild(childResource, req, traceName)
 	assert.NoError(t, err)
 
-	assert.NotEqual(t, trace.SpanId, span.SpanId, "original trace and child should have different SpanIds")
-	assert.Equal(t, trace.SpanId, span.ParentId, "child should have the original trace's SpanId as its ParentId")
-	assert.Equal(t, trace.TraceId, span.TraceId)
+	assert.NotEqual(t, trace.SpanID, span.SpanID, "original trace and child should have different SpanIds")
+	assert.Equal(t, trace.SpanID, span.ParentID, "child should have the original trace's SpanId as its ParentId")
+	assert.Equal(t, trace.TraceID, span.TraceID)
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -29,7 +29,7 @@ func init() {
 // Disabled controls if we'll actually emit the traces.
 // If this is set to true, traces will be generated but not
 // actually sent. This should only be set before any traces
-// are generated
+// are generated. Note: Very Experimental.
 var Disabled = false
 
 // Make an unexported `key` type that we use as a String such

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -26,15 +26,21 @@ func init() {
 	rand.Seed(time.Now().Unix())
 }
 
-// (Experimental)
-// If this is set to true,
-// traces will be generated but not actually sent.
-// This should only be set before any traces are generated
-var Disabled bool = false
+// Disabled controls if we'll actually emit the traces.
+// If this is set to true, traces will be generated but not
+// actually sent. This should only be set before any traces
+// are generated
+var Disabled = false
 
-const traceKey = "trace"
+// Make an unexported `key` type that we use as a String such
+// that we don't get lint warnings from using it as a key in
+// Context. See https://blog.golang.org/context#TOC_3.2.
+type key string
 
-// this should be set exactly once, at startup
+const traceKey key = "trace"
+
+// Service is our service name and should be set exactly once,
+// at startup
 var Service = ""
 
 const localVeneurAddress = "127.0.0.1:8128"
@@ -51,14 +57,14 @@ const errorStackTag = "error.stack"
 type Trace struct {
 	// the ID for the root span
 	// which is also the ID for the trace itself
-	TraceId int64
+	TraceID int64
 
 	// For the root span, this will be equal
 	// to the TraceId
-	SpanId int64
+	SpanID int64
 
 	// For the root span, this will be <= 0
-	ParentId int64
+	ParentID int64
 
 	// The Resource should be the same for all spans in the same trace
 	Resource string
@@ -107,9 +113,9 @@ func (t *Trace) SSFSample() *ssf.SSFSample {
 		Status:    t.Status,
 		Name:      *proto.String(name),
 		Trace: &ssf.SSFTrace{
-			TraceId:  t.TraceId,
-			Id:       t.SpanId,
-			ParentId: t.ParentId,
+			TraceId:  t.TraceID,
+			Id:       t.SpanID,
+			ParentId: t.ParentID,
 			Duration: duration,
 			Resource: t.Resource,
 		},
@@ -119,7 +125,7 @@ func (t *Trace) SSFSample() *ssf.SSFSample {
 	}
 }
 
-// ProtoMarshalText writes the Trace as a protocol buffer
+// ProtoMarshalTo writes the Trace as a protocol buffer
 // in text format to the specified writer.
 func (t *Trace) ProtoMarshalTo(w io.Writer) error {
 	packet, err := proto.Marshal(t.SSFSample())
@@ -149,9 +155,9 @@ func (t *Trace) Record(name string, tags []*ssf.SSFTag) error {
 		Status:    t.Status,
 		Name:      *proto.String(name),
 		Trace: &ssf.SSFTrace{
-			TraceId:  t.TraceId,
-			Id:       t.SpanId,
-			ParentId: t.ParentId,
+			TraceId:  t.TraceID,
+			Id:       t.SpanID,
+			ParentId: t.ParentID,
 			Duration: duration,
 			Resource: t.Resource,
 		},
@@ -228,8 +234,8 @@ func StartSpanFromContext(ctx context.Context, name string, opts ...opentracing.
 // SetParent updates the ParentId, TraceId, and Resource of a trace
 // based on the parent's values (SpanId, TraceId, Resource).
 func (t *Trace) SetParent(parent *Trace) {
-	t.ParentId = parent.SpanId
-	t.TraceId = parent.TraceId
+	t.ParentID = parent.SpanID
+	t.TraceID = parent.TraceID
 	t.Resource = parent.Resource
 }
 
@@ -240,9 +246,9 @@ func (t *Trace) context() *spanContext {
 
 	c := &spanContext{}
 	c.Init()
-	c.baggageItems["traceid"] = strconv.FormatInt(t.TraceId, 10)
-	c.baggageItems["parentid"] = strconv.FormatInt(t.ParentId, 10)
-	c.baggageItems["spanid"] = strconv.FormatInt(t.SpanId, 10)
+	c.baggageItems["traceid"] = strconv.FormatInt(t.TraceID, 10)
+	c.baggageItems["parentid"] = strconv.FormatInt(t.ParentID, 10)
+	c.baggageItems["spanid"] = strconv.FormatInt(t.SpanID, 10)
 	c.baggageItems["resource"] = t.Resource
 	return c
 }
@@ -254,8 +260,8 @@ func (t *Trace) contextAsParent() *spanContext {
 
 	c := &spanContext{}
 	c.Init()
-	c.baggageItems["traceid"] = strconv.FormatInt(t.TraceId, 10)
-	c.baggageItems["parentid"] = strconv.FormatInt(t.SpanId, 10)
+	c.baggageItems["traceid"] = strconv.FormatInt(t.TraceID, 10)
+	c.baggageItems["parentid"] = strconv.FormatInt(t.SpanID, 10)
 	c.baggageItems["resource"] = t.Resource
 	return c
 }
@@ -263,12 +269,12 @@ func (t *Trace) contextAsParent() *spanContext {
 // StartTrace is called by to create the root-level span
 // for a trace
 func StartTrace(resource string) *Trace {
-	traceId := proto.Int64(rand.Int63())
+	traceID := proto.Int64(rand.Int63())
 
 	t := &Trace{
-		TraceId:  *traceId,
-		SpanId:   *traceId,
-		ParentId: 0,
+		TraceID:  *traceID,
+		SpanID:   *traceID,
+		ParentID: 0,
 		Resource: resource,
 	}
 
@@ -278,9 +284,9 @@ func StartTrace(resource string) *Trace {
 
 // StartChildSpan creates a new Span with the specified parent
 func StartChildSpan(parent *Trace) *Trace {
-	spanId := proto.Int64(rand.Int63())
+	spanID := proto.Int64(rand.Int63())
 	span := &Trace{
-		SpanId: *spanId,
+		SpanID: *spanID,
 	}
 
 	span.SetParent(parent)
@@ -296,12 +302,12 @@ func sendSample(sample *ssf.SSFSample) error {
 		return nil
 	}
 
-	server_addr, err := net.ResolveUDPAddr("udp", localVeneurAddress)
+	serverAddr, err := net.ResolveUDPAddr("udp", localVeneurAddress)
 	if err != nil {
 		return err
 	}
 
-	conn, err := net.DialUDP("udp", nil, server_addr)
+	conn, err := net.DialUDP("udp", nil, serverAddr)
 	if err != nil {
 		return err
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -22,8 +22,8 @@ func TestStartTrace(t *testing.T) {
 
 	between := end.After(trace.Start) && trace.Start.After(start)
 
-	assert.Equal(t, trace.TraceId, trace.SpanId)
-	assert.Equal(t, trace.ParentId, expectedParent)
+	assert.Equal(t, trace.TraceID, trace.SpanID)
+	assert.Equal(t, trace.ParentID, expectedParent)
 	assert.Equal(t, trace.Resource, resource)
 	assert.True(t, between)
 }
@@ -140,11 +140,11 @@ func TestSpanFromContext(t *testing.T) {
 	ctx = child.Attach(context.Background())
 	grandchild := SpanFromContext(ctx)
 
-	assert.Equal(t, child.TraceId, trace.SpanId)
-	assert.Equal(t, child.TraceId, trace.TraceId)
-	assert.Equal(t, child.ParentId, trace.SpanId)
-	assert.Equal(t, grandchild.ParentId, child.SpanId)
-	assert.Equal(t, grandchild.TraceId, trace.SpanId)
+	assert.Equal(t, child.TraceID, trace.SpanID)
+	assert.Equal(t, child.TraceID, trace.TraceID)
+	assert.Equal(t, child.ParentID, trace.SpanID)
+	assert.Equal(t, grandchild.ParentID, child.SpanID)
+	assert.Equal(t, grandchild.TraceID, trace.SpanID)
 }
 
 func TestStartChildSpan(t *testing.T) {
@@ -156,12 +156,12 @@ func TestStartChildSpan(t *testing.T) {
 	assert.Equal(t, resource, child.Resource)
 	assert.Equal(t, resource, grandchild.Resource)
 
-	assert.Equal(t, root.SpanId, root.TraceId)
-	assert.Equal(t, root.SpanId, child.TraceId)
-	assert.Equal(t, root.SpanId, grandchild.TraceId)
+	assert.Equal(t, root.SpanID, root.TraceID)
+	assert.Equal(t, root.SpanID, child.TraceID)
+	assert.Equal(t, root.SpanID, grandchild.TraceID)
 
-	assert.Equal(t, root.SpanId, child.ParentId)
-	assert.Equal(t, child.SpanId, grandchild.ParentId)
+	assert.Equal(t, root.SpanID, child.ParentID)
+	assert.Equal(t, child.SpanID, grandchild.ParentID)
 }
 
 // Test that a Trace is correctly able to generate
@@ -173,8 +173,8 @@ func TestTraceContextAsParent(t *testing.T) {
 
 	ctx := trace.contextAsParent()
 
-	assert.Equal(t, trace.TraceId, ctx.TraceId())
-	assert.Equal(t, trace.SpanId, ctx.ParentId())
+	assert.Equal(t, trace.TraceID, ctx.TraceID())
+	assert.Equal(t, trace.SpanID, ctx.ParentID())
 	assert.Equal(t, trace.Resource, ctx.Resource())
 }
 


### PR DESCRIPTION
#### Summary
Fixes from various go lint pedantry.


#### Motivation
Because the linter said so. It's mostly `Id` -> `ID`.

#### Notes
I'm not sure this qualitatively improves anything, but it might spot something else.

#### Test plan
Existing tests.

r? @aditya-stripe 