### PR TITLE
server.ReadTCPSocket: Remove useless defer; fix memory leak

### DIFF
--- a/server.go
+++ b/server.go
@@ -637,9 +637,6 @@ func (s *Server) ReadTCPSocket() {
 	}).Info("Listening for TCP connections")
 
 	for {
-		defer func() {
-			s.ConsumePanic(recover())
-		}()
 		conn, err := s.tcpListener.Accept()
 		if err != nil {
 			select {


### PR DESCRIPTION
#### Summary

ReadTCPSocket is called in a goroutine that is created in
Server.Start, and ConsumePanic is already called there. This extra
call does nothing. Even worse, it is in a loop, so it allocates a new
closure each time, leaking memory.

This was added by me in commit 7af6d66ede. I'm pretty sure this was a
refactoring error I introduced and overlooked.


#### Motivation

Avoid leaking memory! While checking on our deploy of #141, I noticed it still looks like it was leaking memory. In reviewing the code and the statistics, we no longer see goroutines piling up, but I noticed this defer in a loop that allocates memory. This explains why the `pprof` output shows `runtime.systemstack` allocating everything ... I guess this must be where closures are allocated or something?


#### Test plan

Unit tests pass. I'm going to deploy this to our production environment shortly.
