### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/stripe/veneur.svg?branch=master)](https://travis-ci.org/stripe/veneur)
 [![GoDoc](https://godoc.org/github.com/stripe/veneur?status.svg)](http://godoc.org/github.com/stripe/veneur)
 
-Veneur (venn-urr) is a server implementation of the [DogStatsD protocol](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format) for aggregating metrics and sending them to downstream storage , typically [Datadog](http://datadoghq.com). It can also act as a [global aggregator](#global-aggregation) for histograms, sets and counters.
+Veneur (venn-urr) is a server implementation of the [DogStatsD protocol](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format) for aggregating metrics and sending them to downstream storage, typically [Datadog](http://datadoghq.com). It can also act as a [global aggregator](#global-aggregation) for histograms, sets and counters.
 
 More generically, Veneur is a convenient, host-local sink for various observability primitives.
 


### PR DESCRIPTION
Noticed this while writing the README for https://github.com/ChimeraCoder/veneur-docker.



r? @cory-stripe 
cc @stripe/observability 