### PR TITLE
Tighten up "is tracing enabled" logic, add healthcheck endpoint and tests

### DIFF
--- a/http.go
+++ b/http.go
@@ -23,6 +23,15 @@ func (s *Server) Handler() http.Handler {
 		w.Write([]byte("ok\n"))
 	})
 
+	mux.HandleFuncC(pat.Get("/healthcheck/tracing"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
+		if s.TracingEnabled() {
+			w.Write([]byte("ok\n"))
+		} else {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("nok\n"))
+		}
+	})
+
 	mux.Handle(pat.Post("/import"), handleImport(s))
 
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))

--- a/http_test.go
+++ b/http_test.go
@@ -248,6 +248,52 @@ func TestServerImportEmptyListError(t *testing.T) {
 	testServerImportHelper(t, data)
 }
 
+func TestGeneralHealthCheck(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+
+	config := localConfig()
+	s := setupVeneurServer(t, config)
+	defer s.Shutdown()
+
+	w := httptest.NewRecorder()
+
+	handler := s.Handler()
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Healthcheck did not succeed")
+}
+
+func TestOkTraceHealthCheck(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/healthcheck/tracing", nil)
+
+	config := localConfig()
+	s := setupVeneurServer(t, config)
+	defer s.Shutdown()
+
+	w := httptest.NewRecorder()
+
+	handler := s.Handler()
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Trace healthcheck did not succeed")
+}
+
+func TestNokTraceHealthCheck(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/healthcheck/tracing", nil)
+
+	config := localConfig()
+	config.TraceAddress = ""
+	s := setupVeneurServer(t, config)
+	defer s.Shutdown()
+
+	w := httptest.NewRecorder()
+
+	handler := s.Handler()
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "Trace healthcheck succeeded when disabled")
+}
+
 func testServerImportHelper(t *testing.T, data interface{}) {
 	var b bytes.Buffer
 	err := json.NewEncoder(&b).Encode(data)

--- a/http_test.go
+++ b/http_test.go
@@ -269,6 +269,7 @@ func TestOkTraceHealthCheck(t *testing.T) {
 	config := localConfig()
 	s := setupVeneurServer(t, config)
 	defer s.Shutdown()
+	HTTPAddrPort++
 
 	w := httptest.NewRecorder()
 
@@ -285,6 +286,7 @@ func TestNokTraceHealthCheck(t *testing.T) {
 	config.TraceAddress = ""
 	s := setupVeneurServer(t, config)
 	defer s.Shutdown()
+	HTTPAddrPort++
 
 	w := httptest.NewRecorder()
 
@@ -307,6 +309,7 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	config := localConfig()
 	s := setupVeneurServer(t, config)
 	defer s.Shutdown()
+	HTTPAddrPort++
 
 	handler := handleImport(&s)
 	handler.ServeHTTP(w, r)

--- a/server.go
+++ b/server.go
@@ -313,7 +313,7 @@ func (s *Server) Start() {
 		s.EventWorker.Work()
 	}()
 
-	if s.TraceWorker != nil {
+	if s.TracingEnabled() {
 		log.Info("Starting Trace worker")
 		go func() {
 			defer func() {
@@ -366,17 +366,16 @@ func (s *Server) Start() {
 	}
 
 	// Read Traces Forever!
-	go func() {
-		defer func() {
-			s.ConsumePanic(recover())
-		}()
-		if s.TraceAddr != nil {
-			// If we ever use multiple readers, pass in the appropriate reuseport option
+	if s.TracingEnabled() {
+		go func() {
+			defer func() {
+				s.ConsumePanic(recover())
+			}()
 			s.ReadTraceSocket(tracePool)
-		} else {
-			logrus.Info("Tracing not configured - not reading trace socket")
-		}
-	}()
+		}()
+	} else {
+		logrus.Info("Tracing not configured - not reading trace socket")
+	}
 
 	// Flush every Interval forever!
 	go func() {

--- a/socket_test.go
+++ b/socket_test.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -24,9 +25,10 @@ func writeReadUDP(t *testing.T, sock net.PacketConn, addr string) {
 }
 
 func TestSocket(t *testing.T) {
-	const portString = "8200"
-	const v4Localhost = "127.0.0.1:" + portString
-	const v6Localhost = "[::1]:" + portString
+	HTTPAddrPort++
+	portString := fmt.Sprintf("%d", HTTPAddrPort)
+	v4Localhost := "127.0.0.1:" + portString
+	v6Localhost := "[::1]:" + portString
 
 	// see if the system supports ipv6 by listening to a port
 	systemSupportsV6 := true


### PR DESCRIPTION
#### Summary
Add an endpoint `/healthcheck/tracing` to determine if this Veneur is accepting traces.

#### Motivation
We might want to split metric imports and traces in the future, so we should have different health checks for this.

#### Note
I ran in to port reuse problems here and had to add some stuff to shore that up.

#### Test plan
We didn't have any tests for the health check endpoint. No big deal, since it just returns a 200/OK. But since I was in the 'hood I figured I should test 'em all.

#### Rollout/monitoring/revert plan
Pretty much a noop, since nothing uses this yet.

r? @aditya-stripe 

