### PR TITLE
Disallow NaN and Inf, which go happily parses otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.1, UNRELEASED
+
+## Bugfixes
+* No longer allow clients to pass in `nan`, `+inf` or `-inf` as a value for a metric, as this caused errors on flush.
+
 # 1.2.0, 2017-04-24
 
 ## Bugfixes

--- a/parser_test.go
+++ b/parser_test.go
@@ -92,17 +92,21 @@ func TestParserWithSampleRateAndTags(t *testing.T) {
 
 func TestInvalidPackets(t *testing.T) {
 	table := map[string]string{
-		"foo":               "1 colon",
-		"foo:1":             "1 pipe",
-		"foo:1||":           "metric type",
-		"foo:|c|":           "metric value",
-		"foo:1|foo|":        "Invalid type",
-		"foo:1|c||":         "pipes",
-		"foo:1|c|foo":       "unknown section",
-		"foo:1|c|@-0.1":     ">0",
-		"foo:1|c|@1.1":      "<=1",
-		"foo:1|c|@0.5|@0.2": "multiple sample rates",
-		"foo:1|c|#foo|#bar": "multiple tag sections",
+		"foo":                                "1 colon",
+		"foo:1":                              "1 pipe",
+		"foo:1||":                            "metric type",
+		"foo:|c|":                            "metric value",
+		"this_is_a_bad_metric:nan|g|#shell":  "metric value",
+		"this_is_a_bad_metric:NaN|g|#shell":  "metric value",
+		"this_is_a_bad_metric:-inf|g|#shell": "metric value",
+		"this_is_a_bad_metric:+inf|g|#shell": "metric value",
+		"foo:1|foo|":                         "Invalid type",
+		"foo:1|c||":                          "pipes",
+		"foo:1|c|foo":                        "unknown section",
+		"foo:1|c|@-0.1":                      ">0",
+		"foo:1|c|@1.1":                       "<=1",
+		"foo:1|c|@0.5|@0.2":                  "multiple sample rates",
+		"foo:1|c|#foo|#bar":                  "multiple tag sections",
 	}
 
 	for packet, errContent := range table {

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -93,7 +94,7 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 		ret.Value = string(valueChunk)
 	} else {
 		v, err := strconv.ParseFloat(string(valueChunk), 64)
-		if err != nil {
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
 			return nil, fmt.Errorf("Invalid number for metric value: %s", valueChunk)
 		}
 		ret.Value = v


### PR DESCRIPTION
#### Summary
Disallow packets with `nan`, `+inf`, and `-inf` as the metric value.

#### Motivation
As reported in #157 Veneur would happily parse `nan`, because `math.ParseFloat` considers it a valid number. Unfortunately this is not the case when we flush, which causes the entire flush operation to fail. This is bad!

@areitz-stripe pointed out that `+/-info` worked too. So we'll get those.

#### Test plan
I added a `math.isNaN` and `math.IsInf` to abort the packet and a unit test to ensure it DWIMs.

#### Rollout/monitoring/revert plan
I will merge this but not necessarily rush it out. Since @areitz-stripe noticed and fixed this, there's no pressing reason to rush it out. We'll have some other changes soon to ship and this will go with those.

As it stands, it's pretty innocuous.

Thanks @areitz-stripe!

r? @aditya-stripe 
cc @areitz-stripe 

