### PR TITLE
Don't pin 1.8 to a point release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.2
+FROM golang:1.8
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build


### PR DESCRIPTION
#### Summary

This uses `1.8` as the base image instead of `1.8.2`.

[Previously](https://github.com/stripe/veneur/pull/159), I forced `1.8.2` as the base image, because the base image tags hadn't been updated upstream, and so the build would fail until those were updated - ensuring we didn't upgrade until we picked up `1.8.2` as well.  Now, though, `1.8` should always point to the latest point release (which is actually `1.8.3` at this point).


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 
