### PR TITLE
Extract and set host header, return X-Powered-By

### DIFF
--- a/flusher_test.go
+++ b/flusher_test.go
@@ -29,6 +29,13 @@ func TestServerTags(t *testing.T) {
 	assert.Contains(t, metrics[0].Tags, "a:b", "Tags should contain server tags")
 }
 
+func TestHostPortExtract(t *testing.T) {
+	h, p, _ := extractHostPort("https://github.com/stripe/veneur")
+
+	assert.Equal(t, "github.com", h, "Host should contain extracted host")
+	assert.Equal(t, "443", p, "Port should contain extracted port")
+}
+
 func TestHostMagicTag(t *testing.T) {
 	metrics := []samplers.DDMetric{{
 		Name:       "foo.bar.baz",

--- a/http.go
+++ b/http.go
@@ -19,6 +19,15 @@ import (
 func (s *Server) Handler() http.Handler {
 	mux := goji.NewMux()
 
+	// Add a default X-Powered-By header
+	mux.Use(func(h http.Handler) http.Handler {
+		mw := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Powered-By", "Veneur")
+			h.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(mw)
+	})
+
 	mux.HandleFuncC(pat.Get("/healthcheck"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))
 	})


### PR DESCRIPTION
#### Summary
In order to use Veneur behind a webserver or a proxy, some changes need to be applied.
Veneur modifies the endpoint to avoid dns-caching and not preserving the original host header, this breaks Veneur if it sits behind a proxy that is listening to more than one site.

#### Motivation
Support usage of veneur behind another webserver / proxy (Nginx, Apache, etc...)
Adding visibility once it reached the veneur instance using X-Powered-By

#### Test plan
I wrote a test to verify the new extractHostPort works as expected and that I didn't break any other tests.

