### PR TITLE
Extract and set host header, return X-Powered-By

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -656,15 +656,18 @@ func postHelper(ctx context.Context, forwardedAddr string, httpClient *http.Clie
 		return err
 	}
 
-	hostUrl, hostPort, err := extractHostPort(forwardedAddr)
+	if forwardedAddr != "" {
+		hostURL, hostPort, err := extractHostPort(forwardedAddr)
 
-	if err != nil {
-		stats.Count(action+".error_total", 1, []string{"cause:extract"}, 1.0)
-		innerLogger.WithError(err).Error("Could not extract host and port from forwarded address")
-		return err
+		if err != nil {
+			stats.Count(action+".error_total", 1, []string{"cause:extract"}, 1.0)
+			innerLogger.WithError(err).Error("Could not extract host and port from forwarded address")
+			return err
+		}
+
+		req.Host = hostURL + ":" + hostPort
 	}
 
-	req.Host = hostUrl + ":" + hostPort
 	req.Header.Set("Content-Type", "application/json")
 	if compress {
 		req.Header.Set("Content-Encoding", "deflate")

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -31,6 +31,13 @@ func TestServerTags(t *testing.T) {
 	assert.Contains(t, metrics[0].Tags, "a:b", "Tags should contain server tags")
 }
 
+func TestHostPortExtract(t *testing.T) {
+	h, p, _ := extractHostPort("https://github.com/stripe/veneur")
+
+	assert.Equal(t, "github.com", h, "Host should contain extracted host")
+	assert.Equal(t, "443", p, "Port should contain extracted port")
+}
+
 func TestHostMagicTag(t *testing.T) {
 	metrics := []samplers.DDMetric{{
 		Name:       "foo.bar.baz",

--- a/http.go
+++ b/http.go
@@ -19,6 +19,15 @@ import (
 func (s *Server) Handler() http.Handler {
 	mux := goji.NewMux()
 
+	// Add a default X-Powered-By header
+	mux.Use(func(h http.Handler) http.Handler {
+		mw := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Powered-By", "Veneur")
+			h.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(mw)
+	})
+
 	mux.HandleFuncC(pat.Get("/healthcheck"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))
 	})

--- a/proxy.go
+++ b/proxy.go
@@ -282,7 +282,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// this endpoint is not documented to take an array... but it does
 			// another curious constraint of this endpoint is that it does not
 			// support "Content-Encoding: deflate"
-			err = postHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, endpoint, batch, "flush_traces", false)
+			err = postHelper(span.Attach(ctx), endpoint, p.HTTPClient, p.Statsd, endpoint, batch, "flush_traces", false)
 
 			if err == nil {
 				log.WithFields(logrus.Fields{
@@ -347,7 +347,7 @@ func (p *Proxy) doPost(wg *sync.WaitGroup, destination string, batch []samplers.
 		return
 	}
 
-	err = postHelper(context.TODO(), p.HTTPClient, p.Statsd, endpoint, batch, "forward", true)
+	err = postHelper(context.TODO(), endpoint, p.HTTPClient, p.Statsd, endpoint, batch, "forward", true)
 	if err == nil {
 		log.WithField("metrics", batchSize).Debug("Completed forward to upstream Veneur")
 	} else {


### PR DESCRIPTION
Summary

In order to use Veneur behind a webserver or a proxy, some changes need to be applied.
Veneur modifies the endpoint to avoid dns-caching and not preserving the original host header, this breaks Veneur if it sits behind a proxy that is listening to more than one site.

Motivation

Support usage of veneur behind another webserver / proxy (Nginx, Apache, etc...)
Adding visibility once it reached the veneur instance using X-Powered-By

Test plan

I wrote a test to verify the new extractHostPort works as expected and that I didn't break any other tests.