### PR TITLE
Remove support for Go 1.7 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.7
   - 1.8
   - tip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.4.0, 2017-06-09
+
+## Changes
+* Require Go 1.8+ and stop building against 1.7
+
 # 1.3.1, 2017-06-06
 
 ## Bugfixes


### PR DESCRIPTION
#### Summary

Remove support for Go 1.7 and below.

#### Motivation

My changes in the tracing branch use some changes that were introduced in Go 1.8, as does this PR: https://github.com/stripe/veneur/pull/163


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @cory-stripe 
cc @stripe/observability 