### PR TITLE
Report initialization errors to Sentry from main

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"os"
+	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/getsentry/raven-go"
 	"github.com/stripe/veneur"
 	"github.com/stripe/veneur/trace"
 )
@@ -27,9 +30,34 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error reading config file")
 	}
+
 	server, err := veneur.NewFromConfig(conf)
 	if err != nil {
-		logrus.WithError(err).Fatal("Could not initialize server")
+		e := err
+
+		logrus.WithError(e).Error("Error initializing server")
+		var sentry *raven.Client
+		if conf.SentryDsn != "" {
+			sentry, err = raven.New(conf.SentryDsn)
+			if err != nil {
+				logrus.WithError(err).Error("Error initializing Sentry client")
+			}
+		}
+
+		hostname, _ := os.Hostname()
+
+		p := raven.NewPacket(e.Error())
+		if hostname != "" {
+			p.ServerName = hostname
+		}
+
+		_, ch := sentry.Capture(p, nil)
+		select {
+		case <-ch:
+		case <-time.After(10 * time.Second):
+		}
+
+		logrus.WithError(e).Fatal("Could not initialize server")
 	}
 	defer func() {
 		veneur.ConsumePanic(server.Sentry, server.Statsd, server.Hostname, recover())


### PR DESCRIPTION
#### Summary

Similar to https://github.com/stripe/veneur/pull/172, except this doesn't require resolving https://github.com/stripe/veneur/pull/133 before merging.

If we encounter fatal errors when initializing Veneur, we should send those to Sentry (if possible), rather than (just) logging them.

#### Motivation

See #172 


#### Test plan
Tested locally by providing a bad configuration:

```
$ go build && ./veneur -f ../../example.yaml
INFO[0000] Preparing workers                             number=2
ERRO[0000] Error initializing server                     error=address h::::: too many colons in address
FATA[0010] Could not initialize server                   error=address h::::: too many colons in address
```


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 