### PR TITLE
Add test for creating root span from StartSpanFromContext

### DIFF
--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -145,6 +145,18 @@ func TestSpanFromContext(t *testing.T) {
 	assert.Equal(t, grandchild.TraceID, trace.SpanID)
 }
 
+// StartSpanFromContext should create a brand-new root span
+// if the context does not contain a span
+func TestSpanFromContextNoParent(t *testing.T) {
+	const resource = "example"
+	ctx := context.Background()
+
+	span, _ := StartSpanFromContext(ctx, resource)
+
+	assert.Equal(t, span.TraceID, span.SpanID)
+	assert.Equal(t, int64(0), span.ParentID)
+}
+
 func TestStartChildSpan(t *testing.T) {
 	const resource = "Robert'); DROP TABLE students;"
 	root := StartTrace(resource)

--- a/trace/whitebox_test.go
+++ b/trace/whitebox_test.go
@@ -30,12 +30,33 @@ func TestStartSpanFromContextDefaultName(t *testing.T) {
 
 	ctx := context.Background()
 	tracer := trace.Tracer{}
-	span := tracer.StartSpan(resource).(*trace.Span)
-	ctx = span.Attach(ctx)
+	root := tracer.StartSpan(resource).(*trace.Span)
+	ctx = root.Attach(ctx)
 
-	span, _ = trace.StartSpanFromContext(ctx, "")
+	span, _ := trace.StartSpanFromContext(ctx, "")
 
 	assert.Equal(t, span.Resource, resource)
 	assert.Equal(t, span.Name, expectedName)
+	assert.Equal(t, span.ParentID, root.SpanID)
+	assert.Equal(t, span.TraceID, root.SpanID)
 
+	ctx = span.Attach(ctx)
+
+	grandchild, _ := trace.StartSpanFromContext(ctx, "")
+
+	assert.Equal(t, grandchild.TraceID, root.SpanID)
+	assert.Equal(t, grandchild.ParentID, span.SpanID)
+
+}
+
+// StartSpanFromContext should create a brand-new root span
+// if the context does not contain a span
+func TestSpanFromContextNoParent(t *testing.T) {
+	const resource = "example"
+	ctx := context.Background()
+
+	span, _ := trace.StartSpanFromContext(ctx, resource)
+
+	assert.Equal(t, span.TraceID, span.SpanID)
+	assert.Equal(t, int64(0), span.ParentID)
 }


### PR DESCRIPTION
#### Summary

Add test to ensure StartSpanFromContext will correctly generate a root span, if no existing span is found in the context. Otherwise, it will create a child span of the span provided in the context.


This was already partly tested, but I'm creating it as a whitebox test, to ensure that our public interface for this always behaves as expected.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 