### PR TITLE
Add instance-global tags to traces

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -474,6 +474,8 @@ func (s *Server) flushTraces(ctx context.Context) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.Finish()
 
+	tags := s.traceTags(span.Attach(ctx))
+
 	traceRing := s.TraceWorker.Flush()
 
 	ssfSpans := make([]ssf.SSFSpan, 0, traceRing.Len())
@@ -500,6 +502,10 @@ func (s *Server) flushTraces(ctx context.Context) {
 				s.Statsd.Incr("worker.trace.sink.timestamp_error", []string{timeErr}, 1)
 			}
 
+			// this will overwrite tags already present on the span
+			for _, tag := range tags {
+				ssfSpan.Tags[tag[0]] = tag[1]
+			}
 			ssfSpans = append(ssfSpans, ssfSpan)
 		}
 	})
@@ -678,6 +684,19 @@ func postHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Clie
 	stats.Count(action+".error_total", 0, nil, 1.0)
 	resultLogger.Debug("POSTed successfully")
 	return nil
+}
+
+func (s *Server) traceTags(ctx context.Context) [][2]string {
+	tags := make([][2]string, len(s.Tags))
+	for i, tag := range s.Tags {
+		splt := strings.SplitN(tag, ":", 2)
+		if len(splt) < 2 {
+			tags[i] = [2]string{tag, ""}
+			continue
+		}
+		tags[i] = [2]string{splt[0], splt[1]}
+	}
+	return tags
 }
 
 // TODO better name, also finalize type signature


### PR DESCRIPTION
#### Summary

We already set these on metrics, but we should set them on traces as well.


I started to write tests for this, but it's actually kind of annoying to do without duplicating a whole lot of code. I'll add that, but putting this branch here so we can at least use it for QA testing.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 