### PR TITLE
Bump ring buffer size to hold up to 2**14 spans

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Percentiles                 []float64 `yaml:"percentiles"`
 	ReadBufferSizeBytes         int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn                   string    `yaml:"sentry_dsn"`
+	SsfBufferSize               int       `yaml:"ssf_buffer_size"`
 	StatsAddress                string    `yaml:"stats_address"`
 	Tags                        []string  `yaml:"tags"`
 	TcpAddress                  string    `yaml:"tcp_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -43,6 +43,11 @@ trace_api_address: "http://localhost:7777"
 trace_lightstep_access_token: ""
 trace_lightstep_collector_host: ""
 
+
+# The number of SSF packets that can be processed
+# per flush interval
+ssf_buffer_size: 16384
+
 sentry_dsn: ""
 
 # If absent, defaults to the os.Hostname()!

--- a/server.go
+++ b/server.go
@@ -274,7 +274,12 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	// Configure tracing workers and sinks
 	if len(conf.TraceAddress) > 0 && ret.tracingSinkEnabled() {
 
-		ret.TraceWorker = NewTraceWorker(ret.Statsd)
+		bufferSize := conf.SsfBufferSize
+		if bufferSize == 0 {
+			bufferSize = spanBufferSize
+		}
+
+		ret.TraceWorker = NewTraceWorker(ret.Statsd, bufferSize)
 
 		ret.TraceAddr, err = net.ResolveUDPAddr("udp", conf.TraceAddress)
 		log.WithField("traceaddr", ret.TraceAddr).Info("Listening for trace spans on address")

--- a/server_test.go
+++ b/server_test.go
@@ -107,6 +107,7 @@ func generateConfig(forwardAddr string) Config {
 		TraceAddress:        fmt.Sprintf("127.0.0.1:%d", tracePort),
 		TraceAPIAddress:     forwardAddr,
 		TraceMaxLengthBytes: 4096,
+		SsfBufferSize:       32,
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
+// spanBufferSize is the maximum number of spans that
+// we can flush per flush-interval
+const spanBufferSize = 1 << 14
+
 // Worker is the doodad that does work.
 type Worker struct {
 	id         int
@@ -366,7 +370,7 @@ func (tw *TraceWorker) Flush() *ring.Ring {
 	tw.mutex.Lock()
 
 	rettraces := tw.traces
-	tw.traces = ring.New(12) // TODO CONFIGURABLE
+	tw.traces = ring.New(spanBufferSize) // TODO CONFIGURABLE
 
 	tw.mutex.Unlock()
 	tw.stats.TimeInMilliseconds("flush.event_worker_duration_ns", float64(time.Since(start).Nanoseconds()), nil, 1.0)


### PR DESCRIPTION
#### Summary

Bump the size of the ring buffer that holds the spans to `2¹⁴ = 16,384` spans. For a flushing interval of 10s, this allows us to handle a rate of 1,638 spans/second on each host.

Considerations:

We are not currently concerned with UDP packet drops for either spans or metrics (and we already have a monitor for this). The extra CPU utilization here should be minimal, as spans are less complex to process than metrics are.

As for the memory utilization: each span has to fit inside a UDP packet already - the unmarshalled size may end up being a little larger than the MTU, but not by much. The worst-case for this comes out to 16,000 * 65 KB = 1 GB`, which is admittedly large, but within the bounds of what we have available on apiboxes.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe