### PR TITLE
Re-resolve Lightstep collector host on every flush

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -511,7 +512,7 @@ func (s *Server) flushTraces(ctx context.Context) {
 	})
 
 	for _, sink := range s.tracerSinks {
-		sink.flush(span.Attach(ctx), s, sink.tracer, ssfSpans)
+		sink.flush(span.Attach(ctx), s, sink.tracerThunk, ssfSpans)
 		tags := []string{
 			fmt.Sprintf("sink:%s", sink.name),
 			fmt.Sprintf("service:%s", trace.Service),
@@ -700,9 +701,10 @@ func (s *Server) traceTags(ctx context.Context) [][2]string {
 }
 
 // TODO better name, also finalize type signature
-type traceFlusher func(context.Context, *Server, opentracing.Tracer, []ssf.SSFSpan)
+type traceFlusher func(context.Context, *Server, func() opentracing.Tracer, []ssf.SSFSpan)
 
-func flushSpansDatadog(ctx context.Context, s *Server, nilTracer opentracing.Tracer, ssfSpans []ssf.SSFSpan) {
+// flushSpansDatadog flushes spans to datadog. The niltracer argument is ignored.
+func flushSpansDatadog(ctx context.Context, s *Server, nilTracer func() opentracing.Tracer, ssfSpans []ssf.SSFSpan) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 
 	var finalTraces []*DatadogTraceSpan
@@ -773,7 +775,9 @@ func flushSpansDatadog(ctx context.Context, s *Server, nilTracer opentracing.Tra
 	}
 }
 
-func flushSpansLightstep(ctx context.Context, s *Server, lightstepTracer opentracing.Tracer, ssfSpans []ssf.SSFSpan) {
+func flushSpansLightstep(ctx context.Context, s *Server, tracerThunk func() opentracing.Tracer, ssfSpans []ssf.SSFSpan) {
+	lightstepTracer := tracerThunk()
+
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.Finish()
 	for _, ssfSpan := range ssfSpans {
@@ -827,4 +831,45 @@ func flushSpanLightstep(lightstepTracer opentracing.Tracer, ssfSpan ssf.SSFSpan)
 	sp.FinishWithOptions(opentracing.FinishOptions{
 		FinishTime: endTime,
 	})
+}
+
+func configureLightstepTracer(conf Config) func() opentracing.Tracer {
+	return func() opentracing.Tracer {
+		resolved, err := resolveEndpoint(conf.TraceLightstepCollectorHost)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				"host": conf.TraceLightstepCollectorHost,
+			}).Error("Error resolving Lightstep collector host")
+			return nil
+		}
+
+		host, err := url.Parse(resolved)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				"host":     conf.TraceLightstepCollectorHost,
+				"resolved": resolved,
+			}).Error("Error parsing Lightstep collector URL")
+			return nil
+		}
+
+		port, err := strconv.Atoi(host.Port())
+		if err != nil {
+			port = lightstepDefaultPort
+		}
+
+		log.WithFields(logrus.Fields{
+			"Host": host.Hostname(),
+			"Port": port,
+		}).Info("Dialing lightstep host")
+
+		return lightstep.NewTracer(lightstep.Options{
+			AccessToken: conf.TraceLightstepAccessToken,
+			Collector: lightstep.Endpoint{
+				Host:      host.Hostname(),
+				Port:      port,
+				Plaintext: true,
+			},
+			UseGRPC: true,
+		})
+	}
 }


### PR DESCRIPTION
#### Summary

We re-resolve the ddproxy on every flush, in case it changed in the meantime. We should do the same with the Lightstep collectors. Otherwise, if a collector goes offline, all hosts that were previously reporting to it will be unable to until their local Veneur instance is restarted.


This will also serve as better load-balancing between the collectors.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe 