### PR TITLE
samplers: allow avg aggregate without sum

### DIFF
--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -317,16 +317,19 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Tags:       tags,
 			MetricType: "gauge",
 		})
-		if (aggregates.Value&AggregateAverage) == AggregateAverage && h.LocalWeight != 0 {
-			// we need both a rate and a non-zero sum before it will make sense
-			// to submit an average
-			metrics = append(metrics, DDMetric{
-				Name:       fmt.Sprintf("%s.avg", h.Name),
-				Value:      [1][2]float64{{now, h.LocalSum / h.LocalWeight}},
-				Tags:       tags,
-				MetricType: "gauge",
-			})
-		}
+	}
+
+	if (aggregates.Value&AggregateAverage) == AggregateAverage && h.LocalSum != 0 && h.LocalWeight != 0 {
+		// we need both a rate and a non-zero sum before it will make sense
+		// to submit an average
+		tags := make([]string, len(h.Tags))
+		copy(tags, h.Tags)
+		metrics = append(metrics, DDMetric{
+			Name:       fmt.Sprintf("%s.avg", h.Name),
+			Value:      [1][2]float64{{now, h.LocalSum / h.LocalWeight}},
+			Tags:       tags,
+			MetricType: "gauge",
+		})
 	}
 
 	if (aggregates.Value&AggregateCount) == AggregateCount && rate != 0 {


### PR DESCRIPTION
#### Summary
This change allows the AverageAggregate to be collected properly
even if the SumAggregate is not being requested.


#### Motivation
I don't want to have to collect the sum aggregate as I don't find it useful, but I would like the average aggregate. Doesn't seem to make sense that collecting the sum aggregate is necessary.


#### Test plan
I added an automated test to cover this situation


#### Rollout/monitoring/revert plan
No changes should be required, but now if you have `avg` specified as an aggregate, but not `sum` it will be output.

