### PR TITLE
Add SSF metric support to veneur

### DIFF
--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -85,7 +85,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	h.Write([]byte(ret.JoinedTags))
 	ret.Digest = h.Sum32()
 	fmt.Println(ret)
-	return nil, nil
+	return ret, nil
 }
 
 // ParseMetric converts the incoming packet from Datadog DogStatsD

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -51,7 +51,6 @@ func (m *MetricKey) String() string {
 
 // ParseMetricSSF converts an incoming SSF packet to a Metric.
 func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
-	fmt.Println(metric)
 	ret := &UDPMetric{
 		SampleRate: 1.0,
 	}
@@ -78,7 +77,6 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	for key, value := range metric.Tags {
 		tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
 	}
-	// fmt.Println(tempTags)
 	sort.Strings(tempTags)
 	ret.Tags = tempTags
 	ret.JoinedTags = strings.Join(tempTags, ",")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -71,7 +71,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 		return nil, errors.New("Invalid type for metric")
 	}
 	h.Write([]byte(ret.Type))
-	ret.Value = metric.Value
+	ret.Value = float64(metric.Value)
 	ret.SampleRate = metric.SampleRate
 	// TODO: figure out localonly vs globalonly
 	tempTags := make([]string, len(metric.Tags))
@@ -84,7 +84,6 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	ret.JoinedTags = strings.Join(tempTags, ",")
 	h.Write([]byte(ret.JoinedTags))
 	ret.Digest = h.Sum32()
-	fmt.Println(ret)
 	return ret, nil
 }
 

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
+var invalidMetricTypeError = errors.New("Invalid type for metric")
+
 // UDPMetric is a representation of the sample provided by a client. The tag list
 // should be deterministically ordered.
 type UDPMetric struct {
@@ -67,7 +69,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	case ssf.SSFSample_SET:
 		ret.Type = "set"
 	default:
-		return nil, errors.New("Invalid type for metric")
+		return nil, invalidMetricTypeError
 	}
 	h.Write([]byte(ret.Type))
 	ret.Value = float64(metric.Value)
@@ -131,7 +133,7 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 	case 's':
 		ret.Type = "set"
 	default:
-		return nil, errors.New("Invalid type for metric")
+		return nil, invalidMetricTypeError
 	}
 	// Add the type to the digest
 	h.Write([]byte(ret.Type))

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -77,7 +77,17 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	// TODO: figure out localonly vs globalonly
 	tempTags := make([]string, len(metric.Tags))
 	for key, value := range metric.Tags {
-		tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
+		if key == "veneurlocalonly" {
+			// delete the tag from the list
+			ret.Scope = LocalOnly
+			break
+		} else if key == "veneurglobalonly" {
+			// delete the tag from the list
+			ret.Scope = GlobalOnly
+			break
+		} else {
+			tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
+		}
 	}
 	sort.Strings(tempTags)
 	ret.Tags = tempTags

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -74,7 +74,6 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 	h.Write([]byte(ret.Type))
 	ret.Value = float64(metric.Value)
 	ret.SampleRate = metric.SampleRate
-	// TODO: figure out localonly vs globalonly
 	tempTags := make([]string, len(metric.Tags))
 	for key, value := range metric.Tags {
 		if key == "veneurlocalonly" {

--- a/server.go
+++ b/server.go
@@ -611,8 +611,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 			s.Statsd.Count("packet.error_total", 1, []string{"packet_type:ssf_metric", "reason:parse"}, 1.0)
 			return
 		}
-		fmt.Println(*metric)
-		// s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
+		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
 	}
 	s.TraceWorker.TraceChan <- *newSample
 }

--- a/server.go
+++ b/server.go
@@ -577,6 +577,16 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 	return nil
 }
 
+// ValidTrace takes in an SSF span and determines if it is valid or not.
+func ValidTrace(sample ssf.SSFSpan) bool {
+	ret := true
+	ret = ret && sample.Id != 0
+	ret = ret && sample.TraceId != 0
+	ret = ret && sample.StartTimestamp != 0
+	ret = ret && sample.EndTimestamp != 0
+	return ret
+}
+
 // HandleTracePacket accepts an incoming packet as bytes and sends it to the
 // appropriate worker.
 func (s *Server) HandleTracePacket(packet []byte) {
@@ -610,7 +620,9 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		}
 		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
 	}
-	s.TraceWorker.TraceChan <- *newSample
+	if ValidTrace(*newSample) {
+		s.TraceWorker.TraceChan <- *newSample
+	}
 }
 
 // ReadMetricSocket listens for available packets to handle.

--- a/server.go
+++ b/server.go
@@ -621,6 +621,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
 	}
 	if ValidTrace(*newSample) {
+		s.Statsd.Incr("packet.spans.received_total", nil, 1)
 		s.TraceWorker.TraceChan <- *newSample
 	}
 }

--- a/server.go
+++ b/server.go
@@ -572,7 +572,6 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 			s.Statsd.Count("packet.error_total", 1, []string{"packet_type:metric", "reason:parse"}, 1.0)
 			return err
 		}
-		fmt.Println(*metric)
 		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
 	}
 	return nil
@@ -599,8 +598,6 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		log.WithError(err).Warn("Trace unmarshaling error")
 		return
 	}
-	// fmt.Println(*newSample)
-	// fmt.Println(newSample.Metrics)
 	for _, metricPacket := range newSample.Metrics {
 		metric, err := samplers.ParseMetricSSF(metricPacket)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -590,8 +590,7 @@ func ValidTrace(sample ssf.SSFSpan) bool {
 // HandleTracePacket accepts an incoming packet as bytes and sends it to the
 // appropriate worker.
 func (s *Server) HandleTracePacket(packet []byte) {
-	//TODO increment at .1
-	s.Statsd.Incr("packet.received_total", nil, 1)
+	s.Statsd.Incr("packet.received_total", nil, .1)
 	// Unlike metrics, protobuf shouldn't have an issue with 0-length packets
 	if len(packet) == 0 {
 		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:unknown", "reason:zerolength"}, 1.0)
@@ -621,7 +620,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
 	}
 	if ValidTrace(*newSample) {
-		s.Statsd.Incr("packet.spans.received_total", nil, 1)
+		s.Statsd.Incr("packet.spans.received_total", nil, .1)
 		s.TraceWorker.TraceChan <- *newSample
 	}
 }


### PR DESCRIPTION
#### Summary
Veneur now parses and accepts metric data via SSF.


#### Motivation
Jira: OBS-1421


#### Test plan
Tested on devbox - ~needs to be tested more thoroughly.~ I've updated the tests in `server_test.go`.


#### Rollout/monitoring/revert plan
Puppet the world!

TODO: 
- [x] Update tests in `*_test.go` (veneur-emit's tests are already updated.)

r? @ChimeraCoder 