### PR TITLE
Honor static forward and trace data, as well as debug flag.

### DIFF
--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -10,13 +10,13 @@ stats_address: "localhost:8125"
 
 ### FORWARDING
 # Use a static host for forwarding
-forward_address: "http://veneur.example.com"
+#forward_address: "http://veneur.example.com"
 # Or use a consul service for consistent forwarding.
 consul_forward_service_name: "forwardServiceName"
 
 ### TRACING
 # The address on which we will listen for trace data
-trace_address: "127.0.0.1:8128"
+#trace_address: "127.0.0.1:8128"
 # Use a static host to send traces to
 trace_api_address: "http://localhost:7777"
 # Ose us a consul service for sending all spans belonging to the same parent

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -10,13 +10,13 @@ stats_address: "localhost:8125"
 
 ### FORWARDING
 # Use a static host for forwarding
-#forward_address: "http://veneur.example.com"
+forward_address: "http://veneur.example.com"
 # Or use a consul service for consistent forwarding.
 consul_forward_service_name: "forwardServiceName"
 
 ### TRACING
 # The address on which we will listen for trace data
-#trace_address: "127.0.0.1:8128"
+trace_address: "127.0.0.1:8128"
 # Use a static host to send traces to
 trace_api_address: "http://localhost:7777"
 # Ose us a consul service for sending all spans belonging to the same parent

--- a/proxy.go
+++ b/proxy.go
@@ -176,10 +176,10 @@ func (p *Proxy) Start() {
 			}()
 			ticker := time.NewTicker(p.ConsulInterval)
 			for range ticker.C {
-				if p.AcceptingForwards {
+				if p.AcceptingForwards && p.ConsulForwardService != "" {
 					p.RefreshDestinations(p.ConsulForwardService, p.ForwardDestinations, &p.ForwardDestinationsMtx)
 				}
-				if p.AcceptingTraces {
+				if p.AcceptingTraces && p.ConsulTraceService != "" {
 					p.RefreshDestinations(p.ConsulTraceService, p.TraceDestinations, &p.TraceDestinationsMtx)
 				}
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -108,7 +108,7 @@ func NewProxyFromConfig(conf ProxyConfig) (p Proxy, err error) {
 	}
 
 	if !p.AcceptingForwards && !p.AcceptingTraces {
-		err = errors.New("Refusing to start with no Consul service names or static addresses in config.")
+		err = errors.New("refusing to start with no Consul service names or static addresses in config")
 		log.WithError(err).WithFields(logrus.Fields{
 			"consul_forward_service_name": p.ConsulForwardService,
 			"consul_trace_service_name":   p.ConsulTraceService,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -93,8 +93,22 @@ func (rt *ConsulTwoMetricRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	return rec.Result(), nil
 }
 
+func TestAllowStaticServices(t *testing.T) {
+	proxyConfig := generateProxyConfig()
+	proxyConfig.ConsulForwardServiceName = ""
+	proxyConfig.ConsulTraceServiceName = ""
+	proxyConfig.ForwardAddress = "localhost:1234"
+	proxyConfig.TraceAddress = "localhost:1234"
+
+	server, error := NewProxyFromConfig(proxyConfig)
+	assert.NoError(t, error, "Should start with just static services")
+	assert.False(t, server.usingConsul, "Server isn't using consul")
+}
+
 func TestMissingServices(t *testing.T) {
 	proxyConfig := generateProxyConfig()
+	proxyConfig.ForwardAddress = ""
+	proxyConfig.TraceAddress = ""
 	proxyConfig.ConsulForwardServiceName = ""
 	proxyConfig.ConsulTraceServiceName = ""
 
@@ -105,6 +119,7 @@ func TestMissingServices(t *testing.T) {
 func TestAcceptingBooleans(t *testing.T) {
 	proxyConfig := generateProxyConfig()
 	proxyConfig.ConsulTraceServiceName = ""
+	proxyConfig.TraceAddress = ""
 
 	server, _ := NewProxyFromConfig(proxyConfig)
 	assert.True(t, server.AcceptingForwards, "Server accepts forwards")


### PR DESCRIPTION
#### Summary
The config values for `forward_address` and `trace_address` do not work as intended. Basically veneur-proxy can only function with Consul until this fix.

#### Motivation
In the rush to get veneur-proxy wrapped up, we missed our simple case of "work with static destinations for tracing and forwards". The logic wasn't tested and veneur-proxy would refuse to start.

Furthermore, we weren't honoring the `debug` option at all! This made it even harder to debug.

#### Test plan
I added some tests to ensure everything still works.

r? @stripe/observability 
