### PR TITLE
Configuration Improvements and Deprecations

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	AwsRegion                   string    `yaml:"aws_region"`
 	AwsS3Bucket                 string    `yaml:"aws_s3_bucket"`
 	AwsSecretAccessKey          string    `yaml:"aws_secret_access_key"`
+	DatadogAPIHostname          string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey               string    `yaml:"datadog_api_key"`
 	Debug                       bool      `yaml:"debug"`
 	EnableProfiling             bool      `yaml:"enable_profiling"`

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	AwsSecretAccessKey          string    `yaml:"aws_secret_access_key"`
 	DatadogAPIHostname          string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey               string    `yaml:"datadog_api_key"`
+	DatadogTraceAPIAddress      string    `yaml:"datadog_trace_api_address"`
 	Debug                       bool      `yaml:"debug"`
 	EnableProfiling             bool      `yaml:"enable_profiling"`
 	FlushFile                   string    `yaml:"flush_file"`
@@ -28,6 +29,7 @@ type Config struct {
 	Percentiles                 []float64 `yaml:"percentiles"`
 	ReadBufferSizeBytes         int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn                   string    `yaml:"sentry_dsn"`
+	SsfAddress                  string    `yaml:"ssf_address"`
 	SsfBufferSize               int       `yaml:"ssf_buffer_size"`
 	StatsAddress                string    `yaml:"stats_address"`
 	Tags                        []string  `yaml:"tags"`

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	AwsRegion                   string    `yaml:"aws_region"`
 	AwsS3Bucket                 string    `yaml:"aws_s3_bucket"`
 	AwsSecretAccessKey          string    `yaml:"aws_secret_access_key"`
+	DatadogAPIKey               string    `yaml:"datadog_api_key"`
 	Debug                       bool      `yaml:"debug"`
 	EnableProfiling             bool      `yaml:"enable_profiling"`
 	FlushFile                   string    `yaml:"flush_file"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -64,7 +64,7 @@ func readConfig(r io.Reader) (c Config, err error) {
 	}
 
 	if c.Key != "" {
-		log.Warn("The config key `key` is deprecated in and replaced with `datadog_api_key` and will be removed in 2.0!")
+		log.Warn("The config key `key` is deprecated and replaced with `datadog_api_key` and will be removed in 2.0!")
 		// If they set the DatadogAPIKey, favor it. Otherwise, replace it.
 		if c.DatadogAPIKey == "" {
 			c.DatadogAPIKey = c.Key

--- a/config_parse.go
+++ b/config_parse.go
@@ -64,10 +64,17 @@ func readConfig(r io.Reader) (c Config, err error) {
 	}
 
 	if c.Key != "" {
-		log.Warn("The config key `key` is deprecated and will be removed in 2.0!")
+		log.Warn("The config key `key` is deprecated in and replaced with `datadog_api_key` and will be removed in 2.0!")
 		// If they set the DatadogAPIKey, favor it. Otherwise, replace it.
 		if c.DatadogAPIKey == "" {
 			c.DatadogAPIKey = c.Key
+		}
+	}
+
+	if c.APIHostname != "" {
+		log.Warn("The config key `api_hostname` is deprecated and replaced with `datadog_api_hostname` and will be removed in 2.0!")
+		if c.DatadogAPIHostname == "" {
+			c.DatadogAPIHostname = c.APIHostname
 		}
 	}
 

--- a/config_parse.go
+++ b/config_parse.go
@@ -63,6 +63,14 @@ func readConfig(r io.Reader) (c Config, err error) {
 		c.ReadBufferSizeBytes = defaultBufferSizeBytes
 	}
 
+	if c.Key != "" {
+		log.Warn("The config key `key` is deprecated and will be removed in 2.0!")
+		// If they set the DatadogAPIKey, favor it. Otherwise, replace it.
+		if c.DatadogAPIKey == "" {
+			c.DatadogAPIKey = c.Key
+		}
+	}
+
 	return c, nil
 }
 

--- a/config_parse.go
+++ b/config_parse.go
@@ -78,6 +78,20 @@ func readConfig(r io.Reader) (c Config, err error) {
 		}
 	}
 
+	if c.TraceAPIAddress != "" {
+		log.Warn("The config key `datadog_trace_api_hostname` is deprecated and replaced with `datadog_trace_api_hostname` and will be removed in 2.0!")
+		if c.DatadogTraceAPIAddress == "" {
+			c.DatadogTraceAPIAddress = c.TraceAPIAddress
+		}
+	}
+
+	if c.TraceAddress != "" {
+		log.Warn("The config key `trace_address` is deprecated and replaced with `ssf_address` and will be removed in 2.0!")
+		if c.SsfAddress == "" {
+			c.SsfAddress = c.TraceAddress
+		}
+	}
+
 	return c, nil
 }
 

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -89,6 +89,10 @@ forward_address: "http://veneur.example.com"
 # The address on which we will listen for SSF packets via UDP
 ssf_address: "127.0.0.1:8128"
 
+# TRACING
+# The address on which we will listen for UDP trace data
+trace_address: "127.0.0.1:8128"
+
 # TLS
 # This is only useful in conjunction with `tcp_address`
 
@@ -104,6 +108,15 @@ tls_authority_certificate: ""
 
 # == Datadog ==
 # Datadog can be a sink for metrics, events, service checks and trace spans.
+
+# This is deprecated and will be removed in 2.0; use datadog_api_key
+key: "farts"
+
+# This is deprecated and will be removed in 2.0; use datadog_api_hostname
+api_hostname: https://app.datadoghq.com
+
+# This is deprecated and will be removed in 2.0; use datadog_trace_api_address
+trace_api_address: "http://localhost:7777"
 
 # Hostname to send Datadog data to.
 datadog_api_hostname: https://app.datadoghq.com

--- a/config_test.go
+++ b/config_test.go
@@ -19,14 +19,14 @@ func TestReadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "https://app.datadoghq.com", c.APIHostname)
+	assert.Equal(t, "https://app.datadoghq.com", c.DatadogAPIHostname)
 	assert.Equal(t, 96, c.NumWorkers)
 
 	interval, err := c.ParseInterval()
 	assert.NoError(t, err)
 	assert.Equal(t, interval, 10*time.Second)
 
-	assert.Equal(t, c.TraceAddress, "127.0.0.1:8128")
+	assert.Equal(t, "http://localhost:7777", c.DatadogTraceAPIAddress)
 
 }
 

--- a/example.yaml
+++ b/example.yaml
@@ -109,13 +109,13 @@ tls_authority_certificate: ""
 # == Datadog ==
 # Datadog can be a sink for metrics, events, service checks and trace spans.
 
-# This is deprecated and will be removed in 2.0, use datadog_api_key
+# This is deprecated and will be removed in 2.0; use datadog_api_key
 key: "farts"
 
-# This is deprecated and will be removed in 2.0, use datadog_api_hostname
+# This is deprecated and will be removed in 2.0; use datadog_api_hostname
 api_hostname: https://app.datadoghq.com
 
-# This is deprecated and will be removed in 2.0, use datadog_trace_api_address
+# This is deprecated and will be removed in 2.0; use datadog_trace_api_address
 trace_api_address: "http://localhost:7777"
 
 # Hostname to send Datadog data to.

--- a/example.yaml
+++ b/example.yaml
@@ -2,38 +2,81 @@
 metric_max_length: 4096
 trace_max_length_bytes: 16384
 flush_max_per_body: 25000
-debug: true
 enable_profiling: false
 interval: "10s"
 
-# This is deprecated and will be removed in 2.0, use datadog_api_key
-key: "farts"
-# This is deprecated and will be removed in 2.0, use datadog_api_hostname
-api_hostname: https://app.datadoghq.com
+# == PERFORMANCE ==
 
-# Datadog Keys
-datadog_api_hostname: https://app.datadoghq.com
+# The size of the buffer we'll use to buffer socket reads. Tune this if you
+# you think Veneur needs more room to keep up with all packets.
+read_buffer_size_bytes: 2097152
 
-datadog_api_key: "farts"
+# Adjusts the number of workers Veneur will distribute aggregation across.
+# More decreases contention but has diminishng returns.
+num_workers: 96
 
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
-num_workers: 96
 num_readers: 1
+
+# The number of SSF packets that can be processed
+# per flush interval
+ssf_buffer_size: 16384
+
+# == AGGREGATION ==
+
+# Set to floating point values that you'd like to putput percentiles for from
+# histograms.
 percentiles:
   - 0.5
   - 0.75
   - 0.99
+
+# Aggregations you'd like to putput for histograms. Possible values can be any
+# or all of:
+# - `min`: the minimum value in the histogram during the flush period
+# - `max`: the maximum value in the histogram during the flush period
+# -	`median`: the median value in the histogram during the flush period
+# -	`avg`: the average value in the histogram during the flush period
+# -	`count`: the number of values added to the histogram during the flush period
+# -	`sum`: the sum of all values added to the histogram during the flush period
 aggregates:
  - "min"
  - "max"
  - "count"
-read_buffer_size_bytes: 2097152
+
+# == DIAGNOSTICS ==
+
+# Enable debug logging
+debug: true
+
+# Providing a Sentry DSN here will send internal exceptions to Sentry
+sentry_dsn: ""
+
+# Where to send metrics about ourselves, can point this at ourself too!
 stats_address: "localhost:8125"
+
+# == FEATURES ==
+
+# Tags supplied here will be added to all metrics ingested by this instance.
 tags:
  - "foo:bar"
  - "baz:quz"
+
+# If absent, defaults to the os.Hostname()!
+hostname: foobar
+# If true and hostname is "" or absent, don't add the host tag
+omit_empty_hostname: false
+
+# The address on which to listen for metrics sent to this instance over UDP,
+# leave empty to disable.
 udp_address: "localhost:8126"
+
+# The address on which to listen for metrics sent to this instance over TCP,
+# leave empty to disable.
+tcp_address: ""
+
+# The address on which to listen for HTTP imports and/or healthchecks.
 #http_address: "einhorn@0"
 http_address: "localhost:8127"
 
@@ -41,42 +84,16 @@ http_address: "localhost:8127"
 # Use a static host for forwarding
 forward_address: "http://veneur.example.com"
 
+### SSF
+# The address on which we will listen for SSF packets via UDP
+ssf_address: "127.0.0.1:8128"
+
 ### TRACING
 # The address on which we will listen for UDP trace data
 trace_address: "127.0.0.1:8128"
-# Use a static host to send datadog traces to
-trace_api_address: "http://localhost:7777"
 
-# If present, lightstep will be enabled as a tracing sink
-# and this access token will be used
-trace_lightstep_access_token: ""
-trace_lightstep_collector_host: ""
-
-
-# The number of SSF packets that can be processed
-# per flush interval
-ssf_buffer_size: 16384
-
-sentry_dsn: ""
-
-# If absent, defaults to the os.Hostname()!
-hostname: foobar
-# If true and hostname is "" or absent, don't add the host tag
-omit_empty_hostname: false
-
-# Include these if you want to archive data to S3
-aws_access_key_id: ""
-aws_secret_access_key: ""
-aws_region: ""
-aws_s3_bucket: ""
-
-# Influde these if you want write to InfluxDB
-influx_address: http://localhost:8086
-influx_consistency: one
-influx_db_name: mydb
-
-# Listen address for statsd over TCP
-tcp_address: ""
+# TLS
+# This is only useful in conjunction with `tcp_address`
 
 # TLS server private key and certificate for encryption (specify both)
 # These are the key/certificate contents, not a file path
@@ -86,5 +103,61 @@ tls_certificate: ""
 # Authority certificate: requires clients to be authenticated
 tls_authority_certificate: ""
 
+# == SINKS ==
+
+# == Datadog ==
+# Datadog can be a sink for metrics, events, service checks and trace spans.
+
+# This is deprecated and will be removed in 2.0, use datadog_api_key
+key: "farts"
+
+# This is deprecated and will be removed in 2.0, use datadog_api_hostname
+api_hostname: https://app.datadoghq.com
+
+# This is deprecated and will be removed in 2.0, use datadog_trace_api_address
+trace_api_address: "http://localhost:7777"
+
+# Hostname to send Datadog data to.
+datadog_api_hostname: https://app.datadoghq.com
+
+# API key for acessing Datadog
+datadog_api_key: "farts"
+
+# Hostname to send Datadog trace data to.
+datadog_trace_api_address: "http://localhost:7777"
+
+# == InfluxDB ==
+# InfluxDB can be a sink for metrics.
+
+# Hostname to send Influx metrics to
+influx_address: http://localhost:8086
+
+# Consistency level for writes
+influx_consistency: one
+
+# Name of database to which metrics will be written.
+influx_db_name: mydb
+
+# == LightStep ==
+# LightStep can be a sink for trace spans.
+
+# If present, lightstep will be enabled as a tracing sink
+# and this access token will be used
+# Access token for accessing LightStep
+trace_lightstep_access_token: ""
+
+# Host to send trace data to
+trace_lightstep_collector_host: ""
+
+### PLUGINS
+
+# S3 Output
+# Include these if you want to archive data to S3
+aws_access_key_id: ""
+aws_secret_access_key: ""
+aws_region: ""
+aws_s3_bucket: ""
+
+# LocalFile Output
 # Include this if you want to archive data to a local file (which should then be rotated/cleaned)
 flush_file: ""

--- a/example.yaml
+++ b/example.yaml
@@ -53,7 +53,8 @@ debug: true
 # Providing a Sentry DSN here will send internal exceptions to Sentry
 sentry_dsn: ""
 
-# Where to send metrics about ourselves, can point this at ourself too!
+# Veneur emits it's own metrics, this configures where we send them. It's ok
+# to point veneur at itself for metrics consumption!
 stats_address: "localhost:8125"
 
 # == FEATURES ==

--- a/example.yaml
+++ b/example.yaml
@@ -1,15 +1,21 @@
 ---
-api_hostname: https://app.datadoghq.com
 metric_max_length: 4096
 trace_max_length_bytes: 16384
 flush_max_per_body: 25000
 debug: true
 enable_profiling: false
 interval: "10s"
+
 # This is deprecated and will be removed in 2.0, use datadog_api_key
 key: "farts"
+# This is deprecated and will be removed in 2.0, use datadog_api_hostname
+api_hostname: https://app.datadoghq.com
+
+# Datadog Keys
+datadog_api_hostname: https://app.datadoghq.com
 
 datadog_api_key: "farts"
+
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
 num_workers: 96

--- a/example.yaml
+++ b/example.yaml
@@ -6,7 +6,10 @@ flush_max_per_body: 25000
 debug: true
 enable_profiling: false
 interval: "10s"
+# This is deprecated and will be removed in 2.0, use datadog_api_key
 key: "farts"
+
+datadog_api_key: "farts"
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
 num_workers: 96

--- a/example.yaml
+++ b/example.yaml
@@ -80,15 +80,15 @@ tcp_address: ""
 #http_address: "einhorn@0"
 http_address: "localhost:8127"
 
-### FORWARDING
+# FORWARDING
 # Use a static host for forwarding
 forward_address: "http://veneur.example.com"
 
-### SSF
+# SSF
 # The address on which we will listen for SSF packets via UDP
 ssf_address: "127.0.0.1:8128"
 
-### TRACING
+# TRACING
 # The address on which we will listen for UDP trace data
 trace_address: "127.0.0.1:8128"
 
@@ -149,15 +149,15 @@ trace_lightstep_access_token: ""
 # Host to send trace data to
 trace_lightstep_collector_host: ""
 
-### PLUGINS
+# == PLUGINS ==
 
-# S3 Output
+# == S3 Output ==
 # Include these if you want to archive data to S3
 aws_access_key_id: ""
 aws_secret_access_key: ""
 aws_region: ""
 aws_s3_bucket: ""
 
-# LocalFile Output
+# == LocalFile Output ==
 # Include this if you want to archive data to a local file (which should then be rotated/cleaned)
 flush_file: ""

--- a/generate.go
+++ b/generate.go
@@ -1,6 +1,6 @@
 package veneur
 
 //go:generate protoc --go_out=. ssf/sample.proto
-//go:generate gojson -input example.yaml -o config.go -fmt yaml -pkg veneur -name Config
+//go:generate gojson -input config_spec.yaml -o config.go -fmt yaml -pkg veneur -name Config
 //go:generate gojson -input example_proxy.yaml -o config_proxy.go -fmt yaml -pkg veneur -name ProxyConfig
 //TODO(aditya) reenable go:generate gojson -input fixtures/datadog_trace.json -o datadog_trace_span.go -fmt json -pkg veneur -name DatadogTraceSpan

--- a/server.go
+++ b/server.go
@@ -127,7 +127,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.Hostname = conf.Hostname
 	ret.Tags = conf.Tags
 	ret.DDHostname = conf.APIHostname
-	ret.DDAPIKey = conf.Key
+	ret.DDAPIKey = conf.DatadogAPIKey
 	ret.DDTraceAddress = conf.TraceAPIAddress
 	ret.traceLightstepAccessToken = conf.TraceLightstepAccessToken
 	ret.HistogramPercentiles = conf.Percentiles


### PR DESCRIPTION
#### Summary
* Add a datadog api key config and mark current deprecated so we can do multiple sinks more easily.
* Use a new config file (`config_spec.yaml`) as the canonical source for `config.go` since we now need our tests to use the non-deprecated version for tests!

#### Motivation
Veneur began as a DogStatsD replacement, but we're growing up to support more backends. To that end we need to disambiguate the config.

This change deprecates the following keys and emits a warning if you use the "old" key. All will still work for now.
* `datadog_api_key` replaces `key`
* `datadog_api_hostname` replaces `api_hostname`
* `datadog_trace_api_address` replaces `trace_api_address`
* `ssf_address` replaces `trace_address`

Since this causes emission of deprecation warnings, we've also forked off a `config_spec.yaml` which is the canonical file used by `gojson` to generate our `config.go`. I've also adjusted the tests and `example.yaml` to no longer use the deprecated keys.

#### Test plan
Unit tests!

#### Rollout/monitoring/revert plan
Is a noop for now, we'll follow up with changes in our own deployments to use these.

r? @aditya-stripe 
cc @redsn0w422 @stripe/observability 

