### PR TITLE
Remove deprecated const

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -11,10 +11,6 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
-// spanBufferSize is the default maximum number of spans that
-// we can flush per flush-interval
-const spanBufferSize = 1 << 14
-
 // Worker is the doodad that does work.
 type Worker struct {
 	id         int


### PR DESCRIPTION
#### Summary
We've moved defining the ring buffer size to the config file, and so this small PR removes the const we had defined in the past.


#### Motivation
We want the ring buffer size to be easily tunable, and having it defined in the config file makes more sense. Having this extra, unused variable makes the tuning process confusing.


#### Test plan
N/A


#### Rollout/monitoring/revert plan
Puppet the world!

r? @cory-stripe 
cc @stripe/observability 