### PR TITLE
Dial UDP connection for submitting traces exactly once

### DIFF
--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -163,6 +163,8 @@ type Span struct {
 
 	*Trace
 
+	recordErr error
+
 	// These are currently ignored
 	logLines []opentracinglog.Field
 }
@@ -196,7 +198,7 @@ func (s *Span) FinishWithOptions(opts opentracing.FinishOptions) {
 
 	// TODO remove the name tag from the slice of tags
 
-	s.Record(s.Name, s.Tags)
+	s.recordErr = s.Record(s.Name, s.Tags)
 }
 
 func (s *Span) Context() opentracing.SpanContext {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -203,11 +203,7 @@ func (t *Trace) Record(name string, tags map[string]string) error {
 	span := t.SSFSpan()
 	span.Tags[NameKey] = name
 
-	err := sendSample(span)
-	if err != nil {
-		logrus.WithError(err).Error("Error submitting sample")
-	}
-	return err
+	return sendSample(span)
 }
 
 func (t *Trace) Error(err error) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -8,6 +8,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"net"
@@ -42,6 +43,13 @@ func init() {
 var disabled bool = false
 
 var enabledMtx sync.RWMutex
+
+var udpConn *net.UDPConn
+
+// used to initialize udpConn inside sendSample
+var udpInitOnce sync.Once
+var udpInitFunc = func() { initUDPConn(localVeneurAddress) }
+var udpConnUninitializedErr = errors.New("UDP connection is not yet initialized")
 
 // Make an unexported `key` type that we use as a String such
 // that we don't get lint warnings from using it as a key in
@@ -329,29 +337,38 @@ func sendSample(sample *ssf.SSFSpan) error {
 		return nil
 	}
 
-	serverAddr, err := net.ResolveUDPAddr("udp", localVeneurAddress)
-	if err != nil {
-		return err
+	udpInitOnce.Do(udpInitFunc)
+	if udpConn == nil {
+		return udpConnUninitializedErr
 	}
-
-	conn, err := net.DialUDP("udp", nil, serverAddr)
-	if err != nil {
-		return err
-	}
-
-	defer conn.Close()
 
 	data, err := proto.Marshal(sample)
 	if err != nil {
 		return err
 	}
 
-	_, err = conn.Write(data)
+	_, err = udpConn.Write(data)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// initUDPConn will initialize the global UDP connection.
+// It will panic if it encounters an error.
+// It should only be called via the corresponding sync.Once
+func initUDPConn(address string) {
+	serverAddr, err := net.ResolveUDPAddr("udp", localVeneurAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	conn, err := net.DialUDP("udp", nil, serverAddr)
+	if err != nil {
+		panic(err)
+	}
+	udpConn = conn
 }
 
 // stripPackageName strips the package name from a function


### PR DESCRIPTION
#### Summary
Instead of redialing the connection every time, we should dial it the first time and cache it globally.

There are two downsides of this approach:

1) If dialing the connection fails the first time, it will never be retried
2) If multiple spans are submitted in short succession, the connection may still be in the process of initializing. Any spans submitted between the first call to `sendSample` and the initialization of the connection will be dropped (though subsequent spans will still be sent, assuming initialization succeeds).

I'm not convinced (2) is a big problem, since this is all happening over UDP anyway, and we can expect that number to be relatively small.

(1) is a bit more concerning. We could work around that by exporting an initialization function for the tracer itself which dials the connection as part of the setup. The reason I *didn't* do that right now is that it would require changing the tracing API, and currently Veneur and Baskerville use different parts of it.

#### Motivation
https://jira.corp.stripe.com/browse/OBS-1586 and https://jira.corp.stripe.com/browse/OBS-1582


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe 