### PR TITLE
sentry.go: sentryHook.Fire: Don't hang for Fatal logs without Sentry

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -62,6 +62,11 @@ func (s sentryHook) Levels() []logrus.Level {
 }
 
 func (s sentryHook) Fire(e *logrus.Entry) error {
+	if s.c == nil {
+		// raven.Client works when it is nil, but skip the useless work and don't hang on Fatal
+		return nil
+	}
+
 	p := raven.Packet{
 		ServerName: s.hostname,
 		Interfaces: []raven.Interface{

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-
 	"github.com/getsentry/raven-go"
 )
 
@@ -61,6 +60,19 @@ func TestConsumePanicWithSentry(t *testing.T) {
 	}
 	if len(fakeTransport.packets) != 1 {
 		t.Error("expected 1 packet:", fakeTransport.packets)
+	}
+}
+
+func TestHookWithoutSentry(t *testing.T) {
+	// hook with a nil sentry client is used when sentry is disabled
+	hook := &sentryHook{}
+
+	entry := &logrus.Entry{}
+	// must use Fatal so the call to Fire blocks and we can check the result
+	entry.Level = logrus.FatalLevel
+	err := hook.Fire(entry)
+	if err != nil {
+		t.Error("Fire returned an error:", err)
 	}
 }
 


### PR DESCRIPTION
#### Summary
If s.c is nil, s.c.Capture returns a nil chan. Reading from it blocks
forever. This means if someone logs at logrus Fatal or Panic levels
without Sentry configured, the caller will hang instead of causing
the process. This is the same bug as commit d04711e, just in a
different place.

This is a simplified version of #133, assuming the unit test issues have been fixed.


#### Motivation

I was debugging something and found that Veneur was hanging, not crashing. This was the cause.


#### Test plan

This patch has been running in Bluecore's Veneur version for a while.
