### PR TITLE
server.go: Correctly ignore Accept error during shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -772,9 +772,10 @@ func (s *Server) ReadTCPSocket() {
 			case <-s.shutdown:
 				// occurs when cleanly shutting down the server e.g. in tests; ignore errors
 				log.WithError(err).Info("Ignoring Accept error while shutting down")
+				return
 			default:
+				log.WithError(err).Fatal("TCP accept failed")
 			}
-			log.WithError(err).Fatal("TCP accept failed")
 		}
 
 		go s.handleTCPGoroutine(conn)


### PR DESCRIPTION
#### Summary

Commit 2c4428a47f attempted to ignore errors that are returned by
Accept() when the server is gracefully shutting down. However, it
omitted a return, so log.Fatal was called anyway. This bug is hidden
by a hang bug when calling log.Fatal. This must get fixed before the
unit tests for that change can pass.


#### Motivation

Required so #194 can pass.

#### Test plan

Unit tests!
