### PR TITLE
server_test.go: TestLocalFilePluginRegister: Don't start server

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -511,7 +511,10 @@ func TestLocalFilePluginRegister(t *testing.T) {
 	config := globalConfig()
 	config.FlushFile = "/dev/null"
 
-	server := setupVeneurServer(t, config, nil)
+	server, err := NewFromConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, 1, len(server.getPlugins()))
 }


### PR DESCRIPTION
#### Summary

This test only needs to create the server from the configuration, it
does not need to start it. Previously, this test did not shut down
the server, which caused lots of confusing log output for all tests
that ran after it, since the server was running continuously.


#### Motivation

I can't currently run the unit tests on my Mac. This is not a critical problem, but it does make the logs much cleaner.

#### Test plan

This is a test-only change.