### PR TITLE
Log error when dialing UDP connection in tracing client

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -336,7 +336,7 @@ func sendSample(sample *ssf.SSFSpan) (err error) {
 			if !ok {
 				err = fmt.Errorf("encountered panic while sending sample %#v", err)
 			}
-			log.WithError(err).Error("Panicked while dialing UDP connection - traces will not be sent")
+			logrus.WithError(err).Error("Panicked while dialing UDP connection - traces will not be sent")
 		}
 	}()
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -336,6 +336,7 @@ func sendSample(sample *ssf.SSFSpan) (err error) {
 			if !ok {
 				err = fmt.Errorf("encountered panic while sending sample %#v", err)
 			}
+			log.WithError(err).Error("Panicked while dialing UDP connection - traces will not be sent")
 		}
 	}()
 


### PR DESCRIPTION
#### Summary

Help debug this, since errors mean no traces will be sent until the process restarts.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @cory-stripe 