### PR TITLE
server.NewFromConfig: Use the new config variables

### DIFF
--- a/config_parse.go
+++ b/config_parse.go
@@ -79,7 +79,7 @@ func readConfig(r io.Reader) (c Config, err error) {
 	}
 
 	if c.TraceAPIAddress != "" {
-		log.Warn("The config key `datadog_trace_api_hostname` is deprecated and replaced with `datadog_trace_api_hostname` and will be removed in 2.0!")
+		log.Warn("The config key `trace_api_address` is deprecated and replaced with `datadog_trace_api_hostname` and will be removed in 2.0!")
 		if c.DatadogTraceAPIAddress == "" {
 			c.DatadogTraceAPIAddress = c.TraceAPIAddress
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -39,6 +39,24 @@ func TestReadBadConfig(t *testing.T) {
 	assert.Equal(t, c, Config{}, "Parsing invalid config file should return zero struct")
 }
 
+func TestReadConfigBackwardsCompatible(t *testing.T) {
+	// set the deprecated config options
+	const config = `api_hostname: "http://api"
+key: apikey
+trace_api_address: http://trace_api
+trace_address: trace_address:12345`
+	c, err := readConfig(strings.NewReader(config))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// they should get copied to the new config options
+	assert.Equal(t, "http://api", c.DatadogAPIHostname)
+	assert.Equal(t, "apikey", c.DatadogAPIKey)
+	assert.Equal(t, "http://trace_api", c.DatadogTraceAPIAddress)
+	assert.Equal(t, "trace_address:12345", c.SsfAddress)
+}
+
 func TestHostname(t *testing.T) {
 	const hostnameConfig = "hostname: foo"
 	r := strings.NewReader(hostnameConfig)

--- a/example.yaml
+++ b/example.yaml
@@ -12,7 +12,7 @@ interval: "10s"
 read_buffer_size_bytes: 2097152
 
 # Adjusts the number of workers Veneur will distribute aggregation across.
-# More decreases contention but has diminishng returns.
+# More decreases contention but has diminishing returns.
 num_workers: 96
 
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -127,7 +127,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	defer remoteServer.Close()
 
 	config := globalConfig()
-	config.TraceAPIAddress = remoteServer.URL
+	config.DatadogTraceAPIAddress = remoteServer.URL
 
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
@@ -138,7 +138,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 		flush:  flushSpansDatadog,
 	})
 
-	assert.Equal(t, server.DDTraceAddress, config.TraceAPIAddress)
+	assert.Equal(t, server.DDTraceAddress, config.DatadogTraceAPIAddress)
 
 	packet, err := ioutil.ReadAll(protobuf)
 	assert.NoError(t, err)
@@ -165,7 +165,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	config := globalConfig()
 
 	// this can be anything as long as it's not empty
-	config.TraceAPIAddress = "http://example.org"
+	config.DatadogTraceAPIAddress = "http://example.org"
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
 
@@ -179,7 +179,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 		flush:  flushSpansLightstep,
 	})
 
-	assert.Equal(t, server.DDTraceAddress, config.TraceAPIAddress)
+	assert.Equal(t, server.DDTraceAddress, config.DatadogTraceAPIAddress)
 
 	packet, err := ioutil.ReadAll(protobuf)
 	assert.NoError(t, err)

--- a/http_test.go
+++ b/http_test.go
@@ -283,7 +283,7 @@ func TestNokTraceHealthCheck(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/healthcheck/tracing", nil)
 
 	config := localConfig()
-	config.TraceAddress = ""
+	config.SsfAddress = ""
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 	HTTPAddrPort++

--- a/server.go
+++ b/server.go
@@ -126,9 +126,9 @@ type tracerSink struct {
 func NewFromConfig(conf Config) (ret Server, err error) {
 	ret.Hostname = conf.Hostname
 	ret.Tags = conf.Tags
-	ret.DDHostname = conf.APIHostname
+	ret.DDHostname = conf.DatadogAPIHostname
 	ret.DDAPIKey = conf.DatadogAPIKey
-	ret.DDTraceAddress = conf.TraceAPIAddress
+	ret.DDTraceAddress = conf.DatadogTraceAPIAddress
 	ret.traceLightstepAccessToken = conf.TraceLightstepAccessToken
 	ret.HistogramPercentiles = conf.Percentiles
 	if len(conf.Aggregates) == 0 {
@@ -272,7 +272,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	log.WithField("config", conf).Debug("Initialized server")
 
 	// Configure tracing workers and sinks
-	if len(conf.TraceAddress) > 0 && ret.tracingSinkEnabled() {
+	if len(conf.SsfAddress) > 0 && ret.tracingSinkEnabled() {
 
 		bufferSize := conf.SsfBufferSize
 		if bufferSize == 0 {
@@ -281,7 +281,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 
 		ret.TraceWorker = NewTraceWorker(ret.Statsd, bufferSize)
 
-		ret.TraceAddr, err = net.ResolveUDPAddr("udp", conf.TraceAddress)
+		ret.TraceAddr, err = net.ResolveUDPAddr("udp", conf.SsfAddress)
 		log.WithField("traceaddr", ret.TraceAddr).Info("Listening for trace spans on address")
 
 		if err == nil && ret.TraceAddr == nil {


### PR DESCRIPTION
#### Summary

The documentation in example.yaml has already been updated to use the
new names for the following configuration variables which have been
renamed. Additionally, Veneur logs a deprecation warning if the
original variables are used. However, the new names were not actually
used, so starting Veneur with the documented configuration fails.

Replace all uses of the old configuration variables everywhere with
the new ones. Add a test to ensure the server does in fact use these
variables.

  api_hostname -> datadog_api_hostname
  trace_address -> ssf_address
  trace_api_address -> datadog_trace_api_hostname

  key -> datadog_api_key (already done)

Correct the trace_api_address deprecation warning which mentioned the
  new name twice.
example.yaml: Fix a typo: diminishng -> diminishing



#### Motivation

I synchronized Bluecore's configuration with the latest example.yaml and found that the Veneur server I started did not work, because it had `""` as the Datadog API endpoint.


#### Test plan

Ran the tests. This patch works with Bluecore's config, which matches the documentation in example.yaml