### PR TITLE
Flush the LS tracer, since Close() doesn't seem to.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.5.1, PENDING
 
+## Bugfixes
+* Flush the lightstep tracer before closing it. Thanks [gphat](https://github.com/gphat) with assist from [stangles](https://github.com/joshu-stripe)!
+
 ## Improvements
 * Better document how to configure Veneur as a DogStatsD replacement. Thanks [gphat](https://github.com/gphat) with assist from [stangles](https://github.com/stangles)!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.5.1, PENDING
+# 1.5.1, 2017-07-18
 
 ## Bugfixes
 * Flush the lightstep tracer before closing it. Thanks [gphat](https://github.com/gphat) with assist from [stangles](https://github.com/joshu-stripe)!

--- a/flusher.go
+++ b/flusher.go
@@ -784,6 +784,7 @@ func flushSpansLightstep(ctx context.Context, s *Server, tracerThunk func() open
 	for _, ssfSpan := range ssfSpans {
 		flushSpanLightstep(lightstepTracer, ssfSpan)
 	}
+	lightstep.FlushLightStepTracer(lightstepTracer)
 
 	// Confusingly, this will still get called even if the Opentracing client fails to reach the collector
 	// because we don't get access to the error if that happens.

--- a/flusher.go
+++ b/flusher.go
@@ -512,11 +512,13 @@ func (s *Server) flushTraces(ctx context.Context) {
 	})
 
 	for _, sink := range s.tracerSinks {
+		sinkFlushStart := time.Now()
 		sink.flush(span.Attach(ctx), s, sink.tracerThunk, ssfSpans)
 		tags := []string{
 			fmt.Sprintf("sink:%s", sink.name),
 			fmt.Sprintf("service:%s", trace.Service),
 		}
+		s.Statsd.TimeInMilliseconds("worker.trace.sink.flush_duration_ns", float64(time.Since(sinkFlushStart).Nanoseconds()), []string{fmt.Sprintf("sink:%s", sink.name)}, 1.0)
 
 		s.Statsd.Count("worker.trace.sink.flushed_total", int64(len(ssfSpans)), tags, 1)
 	}


### PR DESCRIPTION
#### Summary
Flush spans before we close the tracer.

#### Motivation
Based on my read of the LS tracer code, it doesn't _actually_ flush on close. This means that if you stuff a bunch of spans in really fast and call `Close()` you're dropping things.

I based this on [this code](https://github.com/lightstep/lightstep-tracer-go/blame/4b474a1c389eb591a4f4c6bcebe6f73d59ebd957/tracer.go#L37) that calls [this code](https://github.com/lightstep/lightstep-tracer-go/blame/4b474a1c389eb591a4f4c6bcebe6f73d59ebd957/tracer.go#L186) none of which calls `Flush` anywhere.

It's my theory that our recent deploy of Veneur to prod has actually broken tracing becuase we're not flushing before close.

While were here, this adds a metric that tracks the duration of each flush so we can see how much we're impacting things.

#### Test plan
Validating in QA and testing on a single prod apibox, since this is where the problem was manifested.

#### Rollout/monitoring/revert plan
Merge, make PR for this SHA in puppet-land and test a single box.

r? @stripe/observability 

