### PR TITLE
Fix bugs with SSF parsing & add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.5.2, pending
+
+## Bugfixes
+* Correctly parse `Set` metrics if sent via SSF. Thanks [redsn0w422](https://github.com/redsn0w422)!
+* Return correct array of tags after parsing an SSF metric. Thanks [redsn0w422](https://github.com/redsn0w422)!
+
+## Improvements
+* Added tests for `parseMetricSSF`. Thanks [redsn0w422](https://github.com/redsn0w422)!
+
 # 1.5.1, 2017-07-18
 
 ## Bugfixes

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,7 +3,6 @@ package veneur
 import (
 	"testing"
 
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/ssf"
@@ -27,7 +26,6 @@ func freshSSFMetric() *ssf.SSFSample {
 func TestParserSSF(t *testing.T) {
 	standardMetric := freshSSFMetric()
 	m, _ := samplers.ParseMetricSSF(standardMetric)
-	fmt.Printf("%v\n", m)
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, standardMetric.Name, m.Name, "Name")
 	assert.Equal(t, float64(standardMetric.Value), m.Value, "Value")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -78,7 +78,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 		ret.Value = float64(metric.Value)
 	}
 	ret.SampleRate = metric.SampleRate
-	tempTags := make([]string, len(metric.Tags))
+	tempTags := make([]string, 0)
 	for key, value := range metric.Tags {
 		if key == "veneurlocalonly" {
 			// delete the tag from the list

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -92,6 +92,9 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 			tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
 		}
 	}
+	if len(tempTags) == 0 {
+		tempTags = append(tempTags, ":")
+	}
 	sort.Strings(tempTags)
 	ret.Tags = tempTags
 	ret.JoinedTags = strings.Join(tempTags, ",")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -92,9 +92,6 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 			tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
 		}
 	}
-	if len(tempTags) == 0 {
-		tempTags = append(tempTags, ":")
-	}
 	sort.Strings(tempTags)
 	ret.Tags = tempTags
 	ret.JoinedTags = strings.Join(tempTags, ",")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -72,7 +72,11 @@ func ParseMetricSSF(metric *ssf.SSFSample) (*UDPMetric, error) {
 		return nil, invalidMetricTypeError
 	}
 	h.Write([]byte(ret.Type))
-	ret.Value = float64(metric.Value)
+	if metric.Metric == ssf.SSFSample_SET {
+		ret.Value = metric.Message
+	} else {
+		ret.Value = float64(metric.Value)
+	}
 	ret.SampleRate = metric.SampleRate
 	tempTags := make([]string, len(metric.Tags))
 	for key, value := range metric.Tags {

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestCounterEmpty(t *testing.T) {
-
 	c := NewCounter("a.b.c", []string{"a:b"})
 	c.Sample(1, 1.0)
 
@@ -32,7 +31,6 @@ func TestCounterEmpty(t *testing.T) {
 }
 
 func TestCounterRate(t *testing.T) {
-
 	c := NewCounter("a.b.c", []string{"a:b"})
 
 	c.Sample(5, 1.0)
@@ -43,7 +41,6 @@ func TestCounterRate(t *testing.T) {
 }
 
 func TestCounterSampleRate(t *testing.T) {
-
 	c := NewCounter("a.b.c", []string{"a:b"})
 
 	c.Sample(5, 0.5)
@@ -80,7 +77,6 @@ func TestCounterMerge(t *testing.T) {
 }
 
 func TestGauge(t *testing.T) {
-
 	g := NewGauge("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", g.Name, "Name")
@@ -253,7 +249,6 @@ func TestHisto(t *testing.T) {
 }
 
 func TestHistoAvgOnly(t *testing.T) {
-
 	h := NewHist("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", h.Name, "Name")
@@ -290,7 +285,6 @@ func TestHistoAvgOnly(t *testing.T) {
 }
 
 func TestHistoSampleRate(t *testing.T) {
-
 	h := NewHist("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", h.Name, "Name")

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -151,7 +151,6 @@ func TestSetMerge(t *testing.T) {
 }
 
 func TestHisto(t *testing.T) {
-
 	h := NewHist("a.b.c", []string{"a:b"})
 
 	assert.Equal(t, "a.b.c", h.Name, "Name")


### PR DESCRIPTION
#### Summary
- Fixed bug that would crash Veneur if the SSF metric was a `set`
- Fixed bug that caused the tags returned by `parseMetricSSF` to be double-length
- Added tests for `parseMetricSSF` 
- Fixed formatting


#### Motivation
Bug fixes, and a lack of tests.


#### Test plan
Tests found in `parser_test.go` are updated.


#### Rollout/monitoring/revert plan
Puppet the world!

r? @cory-stripe 