### PR TITLE
Add events and service checks to veneur-emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 * Correctly parse `Set` metrics if sent via SSF. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Return correct array of tags after parsing an SSF metric. Thanks [redsn0w422](https://github.com/redsn0w422)!
 
+## Added
+* Adds [events](https://docs.datadoghq.com/guides/dogstatsd/#events-1) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks-1) to `veneur-emit`. Thanks [redsn0w422](https://github.com/redsn0w422)!
+
 ## Improvements
 * Added tests for `parseMetricSSF`. Thanks [redsn0w422](https://github.com/redsn0w422)!
+* Refactored `veneur-emit` flag usage to make testing easier. Thanks [redsn0w422](https://github.com/redsn0w422)!
 
 # 1.5.1, 2017-07-18
 

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -10,21 +10,55 @@ Some common use cases:
 `veneur-emit` can read an existing veneur [config file](https://github.com/stripe/veneur#configuration). If that's not convenient, you can specify it's configuration options directly.
 
 ```
-Usage of ./veneur-emit:
+Usage of veneur-emit:
   -count int
-    	Report a 'count' metric. Value must be an integer.
+       Report a 'count' metric. Value must be an integer.
   -debug
-    	Turns on debug messages.
+       Turns on debug messages.
+  -e_aggr_key string
+       Add an aggregation key to group event with others with same key.
+  -e_alert_type string
+       Alert type must be 'error', 'warning', 'info', or 'success'. (default "info")
+  -e_event_tags string
+       Tag(s) for event, comma separated. Ex: 'service:airflow,host_type:qa'
+  -e_hostname string
+       Hostname for the event.
+  -e_priority string
+       Priority of event. Must be 'low' or 'normal'. (default "normal")
+  -e_source_type string
+       Add source type to the event.
+  -e_text string
+       Text of event. Insert line breaks with an esaped slash (\\n) *
+  -e_time string
+       Add timestamp to the event. Default is the current Unix epoch timestamp.
+  -e_title string
+       Title of event. Ex: 'An exception occurred' *
   -f string
-    	The Veneur config file to read for settings.
+       The Veneur config file to read for settings.
   -gauge float
-    	Report a 'gauge' metric. Value must be float64.
+       Report a 'gauge' metric. Value must be float64.
   -hostport string
-    	Hostname and port of destination. Must be used if config file is not present.
+       Hostname and port of destination. Must be used if config file is not present.
+  -mode string
+       Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'. (default "metric")
   -name string
-    	Name of metric to report. Ex: daemontools.service.starts
+       Name of metric to report. Ex: 'daemontools.service.starts'
+  -sc_hostname string
+       Add hostname to the event.
+  -sc_msg string
+       Message describing state of current state of service check.
+  -sc_name string
+       Service check name. *
+  -sc_status string
+       Integer corresponding to check status. (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)*
+  -sc_tags string
+       Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'
+  -sc_time string
+       Add timestamp to check. Default is current Unix epoch timestamp.
+  -ssf
+       Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)
   -tag string
-    	Tag(s) for metric, comma separated. Ex: service:airflow
+       Tag(s) for metric, comma separated. Ex: 'service:airflow'
   -timing duration
-    	Report a 'timing' metric. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration). (default -10ns)
+       Report a 'timing' metric. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration).
 ```

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -230,7 +230,6 @@ func sendSpan(conn MinimalConn, span *ssf.SSFSpan) error {
 	return nil
 }
 
-// TODO: validity checking? or just fire and forget
 func buildEventPacket(passedFlags map[string]flag.Value) (bytes.Buffer, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("_e")

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -249,7 +249,8 @@ func buildEventPacket(passedFlags map[string]flag.Value) (bytes.Buffer, error) {
 	buffer.WriteString(passedFlags["e_title"].String())
 	buffer.WriteString("|")
 
-	buffer.WriteString(passedFlags["e_text"].String())
+	text := strings.Replace(passedFlags["e_text"].String(), "\n", "\\n", -1)
+	buffer.WriteString(text)
 
 	if passedFlags["e_time"] != nil {
 		buffer.WriteString(fmt.Sprintf("|d:%s", passedFlags["e_time"].String()))

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -224,11 +224,8 @@ func buildEventPacket(passedFlags map[string]bool) (bytes.Buffer, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("_e")
 
-	if !passedFlags["e_title"] {
-		return bytes.Buffer{}, errors.New("missing event title")
-	}
-	if !passedFlags["e_text"] {
-		return bytes.Buffer{}, errors.New("missing event text")
+	if !passedFlags["e_title"] || !passedFlags["e_text"] {
+		return bytes.Buffer{}, errors.New("missing event title or text")
 	}
 
 	buffer.WriteString(fmt.Sprintf("{%d,%d}", len(*eTitle), len(*eText)))

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -286,11 +286,11 @@ func buildSCPacket(passedFlags map[string]flag.Value) (bytes.Buffer, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("_sc")
 
-	if passedFlags["sc_name"] != nil {
+	if passedFlags["sc_name"] == nil {
 		return bytes.Buffer{}, errors.New("missing service check name")
 	}
 
-	if passedFlags["sc_status"] != nil {
+	if passedFlags["sc_status"] == nil {
 		return bytes.Buffer{}, errors.New("missing service check status")
 	}
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -20,18 +20,34 @@ var (
 	configFile = flag.String("f", "", "The Veneur config file to read for settings.")
 	hostport   = flag.String("hostport", "", "Hostname and port of destination. Must be used if config file is not present.")
 	mode       = flag.String("mode", "metric", "Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'.")
+	debug      = flag.Bool("debug", false, "Turns on debug messages.")
 
 	// Metric flags
-	name   = flag.String("name", "", "Name of metric to report. Ex: daemontools.service.starts")
+	name   = flag.String("name", "", "Name of metric to report. Ex: 'daemontools.service.starts'")
 	gauge  = flag.Float64("gauge", 0, "Report a 'gauge' metric. Value must be float64.")
 	timing = flag.Duration("timing", 0*time.Millisecond, "Report a 'timing' metric. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration).")
 	count  = flag.Int64("count", 0, "Report a 'count' metric. Value must be an integer.")
-	tag    = flag.String("tag", "", "Tag(s) for metric, comma separated. Ex: service:airflow")
-	debug  = flag.Bool("debug", false, "Turns on debug messages.")
+	tag    = flag.String("tag", "", "Tag(s) for metric, comma separated. Ex: 'service:airflow'")
 	toSSF  = flag.Bool("ssf", false, "Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)")
 
 	// Event flags
+	// TODO: what should flags be called?
+	eTitle      = flag.String("e_title", "", "Title of event. Ex: 'An exception occurred' *")
+	eText       = flag.String("e_text", "", "Text of event. Insert line breaks with an esaped slash (\\\\n) *")
+	eHostname   = flag.String("e_hostname", "", "Hostname for the event.")
+	eAggrKey    = flag.String("e_aggr_key", "", "Add an aggregation key to group event with others with same key.")
+	ePriority   = flag.String("e_priority", "normal", "Priority of event. Must be 'low' or 'normal'.")
+	eSourceType = flag.String("e_source_type", "", "Add source type to the event.")
+	eAlertType  = flag.String("e_alert_type", "info", "Alert type must be 'error', 'warning', 'info', or 'success'.")
+	eTag        = flag.String("e_event_tags", "", "Tag(s) for event, comma separated. Ex: 'service:airflow,host_type:qa'")
+
 	// Service check flags
+	scName      = flag.String("sc_name", "", "Service check name. *")
+	scStatus    = flag.String("sc_status", "", "Integer corresponding to check status. (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)*")
+	scTimestamp = flag.String("sc_time", "", "Add timestamp to check. Default is current Unix epoch timestamp.")
+	scHostname  = flag.String("sc_hostname", "", "Add hostname to the event.")
+	scTags      = flag.String("sc_tags", "", "Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'")
+	scMsg       = flag.String("sc_msg", "", "Message describing state of current state of service check.")
 )
 
 // MinimalClient represents the functions that we call on Clients in veneur-emit.

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -287,7 +287,7 @@ func TestBadSendSpan(t *testing.T) {
 
 func TestBuildEventPacketError(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	pkt, err := buildEventPacket(testFlag)
+	_, err := buildEventPacket(testFlag)
 	assert.NotNil(t, err, "Did not catch error.")
 }
 

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -339,15 +339,16 @@ func TestBuildEventPacket(t *testing.T) {
 		assert.True(t, strings.HasPrefix(pkt.String(), "_e"))
 	})
 
-	// TODO: check this test
 	t.Run("newline", func(t *testing.T) {
 		testFlag["e_title"] = newValue("An exception occurred")
-		testFlag["e_text"] = newValue("Cannot parse JSON request:\\n{'foo': 'bar'}")
+		testFlag["e_text"] = newValue("Cannot parse JSON request:\n{'foo': 'bar'}")
 		testFlag["e_priority"] = newValue("low")
 		testFlag["e_event_tags"] = newValue("err_type:bad_request")
 
-		_, err := buildEventPacket(testFlag)
+		pkt, err := buildEventPacket(testFlag)
 		assert.Nil(t, err, "Returned non-nil error.")
+
+		assert.Contains(t, pkt.String(), "\\n", "Did not parse newline.")
 	})
 
 	t.Run("all", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR adds [events](https://docs.datadoghq.com/guides/dogstatsd/#events-1) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks-1) to `veneur-emit`. It also refactors a lot of existing `veneur-emit` code to use flags differently, to make testing much easier.


#### Motivation
We want to use `veneur-emit` to emit events and service checks.


#### Test plan
There are updated tests in `main_test.go` that test both `buildEventPacket` and `buildSCPacket`, as well as other tests to make sure the refactored flag usage works as intended.


#### Rollout/monitoring/revert plan
Puppet the world!

r? @cory-stripe 