### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+Contributing to Veneur
+=================
+
+Thanks for contributing to Veneur!
+
+This is a short document letting you know what you can expect when submitting a patch.
+
+### Code Review
+
+All pull requests will be reviewed by someone on Stripe's Observability team. At present, those users are:
+
+* aditya-stripe (aka chimeracoder)
+* kiran-stripe
+* joshu-stripe
+* krisreeves-stripe
+* asf-stripe
+* cory-stripe (aka gphat)
+
+There's no need to pick a reviewer; if you submit a pull request, we'll see it and figure out who should review it.
+
+If your pull request involves large or sensitive changes, it will probably need to be reviewed by either Aditya Mukerjee (chimeracoder || aditya-stripe) or Cory Watson (cory-stripe || gphat).
+
+For larger changes, there may be a delay in reviewing/merging if Aditya or Cory is unavailable, or if we need to complete merge some other related work first as a prerequisite. If you have any questions along the way, though, feel free to ask on the thread, and we'll be happy to help out.
+
+### Help us help you!
+
+We highly recommend [allowing edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) (ie, us) to your branch. Since Veneur is actively developed, there's a good chance that other pull requests will have been merged in between when you submit a pull request and when we approve it. Allowing us to edit your branch means that we can rebase and fix any merge conflicts for you.


### PR DESCRIPTION
#### Summary

Adds a simple CONTRIBUTING.md file, so contributors will know what to expect. See also: https://help.github.com/articles/setting-guidelines-for-repository-contributors/


This doesn't change the current process at all; it just documents the current, implicit one.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe 
cc @stripe/observability 
