### PR TITLE
Add a harmonic mean (hmean) aggregator.

### DIFF
--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -53,12 +53,12 @@ type HistogramAggregates struct {
 }
 
 var aggregates = [...]string{
-	AggregateMin:     "min",
-	AggregateMax:     "max",
-	AggregateMedian:  "median",
-	AggregateAverage: "avg",
-	AggregateCount:   "count",
-	AggregateSum:     "sum",
+	AggregateMin:          "min",
+	AggregateMax:          "max",
+	AggregateMedian:       "median",
+	AggregateAverage:      "avg",
+	AggregateCount:        "count",
+	AggregateSum:          "sum",
 	AggregateHarmonicMean: "hmean",
 }
 
@@ -248,10 +248,10 @@ type Histo struct {
 	// we separate them because they're easy to aggregate on the backend without
 	// loss of granularity, and having host-local information on them might be
 	// useful
-	LocalWeight float64
-	LocalMin    float64
-	LocalMax    float64
-	LocalSum    float64
+	LocalWeight        float64
+	LocalMin           float64
+	LocalMax           float64
+	LocalSum           float64
 	LocalReciprocalSum float64
 }
 

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -245,7 +245,7 @@ func TestHisto(t *testing.T) {
 	assert.Len(t, m8.Tags, 1, "Tag count")
 	assert.Equal(t, "a:b", m8.Tags[0], "First tag")
 	// The counter returns an array with a single tuple of timestamp,value
-	expected := float64(5.0 / ((1.0/5) + (1.0/10) + (1.0/15) + (1.0/20) + (1.0/25)))
+	expected := float64(5.0 / ((1.0 / 5) + (1.0 / 10) + (1.0 / 15) + (1.0 / 20) + (1.0 / 25)))
 	assert.Equal(t, expected, m8.Value[0][1], "Value")
 
 	// And the percentile
@@ -328,7 +328,7 @@ func TestHistoHMeanOnly(t *testing.T) {
 	assert.Len(t, m5.Tags, 1, "Tag count")
 	assert.Equal(t, "a:b", m5.Tags[0], "First tag")
 	// The counter returns an array with a single tuple of timestamp,value
-	expected := float64(5.0 / ((1.0/5) + (1.0/10) + (1.0/15) + (1.0/20) + (1.0/25)))
+	expected := float64(5.0 / ((1.0 / 5) + (1.0 / 10) + (1.0 / 15) + (1.0 / 20) + (1.0 / 25)))
 	assert.Equal(t, expected, m5.Value[0][1], "Value")
 }
 


### PR DESCRIPTION
#### Summary

This adds one more field to the histogram (LocalReciprocalSum), which
parallels the existing LocalSum value.

#### Motivation

The [harmonic mean](https://en.wikipedia.org/wiki/Harmonic_mean) is often used to take the average of values which are weights. It is less affected by large outlier values than the usual arithmetic mean.

#### Test plan

I mirrored the existing testing for the AggregateAverage metric.

#### Rollout/monitoring/revert plan

This commit can be reverted if it causes problems.
