### PR TITLE
Return pointer to struct containing mutex

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -110,7 +110,7 @@ func testServerImport(t *testing.T, filename string, contentEncoding string) {
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(&s)
+	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusAccepted, w.Code, "Test server returned wrong HTTP response code")
@@ -151,7 +151,7 @@ func TestServerImportGzip(t *testing.T) {
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(&s)
+	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code, "Test server returned wrong HTTP response code")
@@ -176,7 +176,7 @@ func TestServerImportCompressedInvalid(t *testing.T) {
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(&s)
+	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
@@ -201,7 +201,7 @@ func TestServerImportUncompressedInvalid(t *testing.T) {
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(&s)
+	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
@@ -311,7 +311,7 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	defer s.Shutdown()
 	HTTPAddrPort++
 
-	handler := handleImport(&s)
+	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")

--- a/server_test.go
+++ b/server_test.go
@@ -158,7 +158,7 @@ func assertMetric(t *testing.T, metrics DDMetricsRequest, metricName string, val
 
 // setupVeneurServer creates a local server from the specified config
 // and starts listening for requests. It returns the server for inspection.
-func setupVeneurServer(t *testing.T, config Config, transport http.RoundTripper) Server {
+func setupVeneurServer(t *testing.T, config Config, transport http.RoundTripper) *Server {
 	server, err := NewFromConfig(config)
 	if transport != nil {
 		server.HTTPClient.Transport = transport
@@ -174,7 +174,7 @@ func setupVeneurServer(t *testing.T, config Config, transport http.RoundTripper)
 	server.Start()
 
 	go server.HTTPServe()
-	return server
+	return &server
 }
 
 // DDMetricsRequest represents the body of the POST request
@@ -187,7 +187,7 @@ type DDMetricsRequest struct {
 // fixture sets up a mock Datadog API server and Veneur
 type fixture struct {
 	api             *httptest.Server
-	server          Server
+	server          *Server
 	ddmetrics       chan DDMetricsRequest
 	interval        time.Duration
 	flushMaxPerBody int
@@ -199,7 +199,7 @@ func newFixture(t *testing.T, config Config) *fixture {
 
 	// Set up a remote server (the API that we're sending the data to)
 	// (e.g. Datadog)
-	f := &fixture{nil, Server{}, make(chan DDMetricsRequest, 10), interval, config.FlushMaxPerBody}
+	f := &fixture{nil, &Server{}, make(chan DDMetricsRequest, 10), interval, config.FlushMaxPerBody}
 	f.api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		zr, err := zlib.NewReader(r.Body)
 		if err != nil {


### PR DESCRIPTION
#### Summary

Because the `Server` contains a mutex, we should be returning a pointer to it, not the value itself.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 