### PR TITLE
Restructure SSF Parsing Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bugfixes
 * Correctly parse `Set` metrics if sent via SSF. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Return correct array of tags after parsing an SSF metric. Thanks [redsn0w422](https://github.com/redsn0w422)!
+* Don't panic if a packet doesn't have tags. Thanks [redsn0w422](https://github.com/redsn0w422)!
 
 ## Added
 * Adds [events](https://docs.datadoghq.com/guides/dogstatsd/#events-1) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks-1) to `veneur-emit`. Thanks [redsn0w422](https://github.com/redsn0w422)!
@@ -13,6 +14,7 @@
 * Added tests for `parseMetricSSF`. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Refactored `veneur-emit` flag usage to make testing easier. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Minor text fixes in the README. Thanks [an-stripe](https://github.com/an-stripe)!
+* Restructured SSF parsing logic and added more tests. Thanks [redsn0w422](https://github.com/redsn0w422)!
 
 # 1.5.1, 2017-07-18
 

--- a/flusher.go
+++ b/flusher.go
@@ -503,6 +503,10 @@ func (s *Server) flushTraces(ctx context.Context) {
 				s.Statsd.Incr("worker.trace.sink.timestamp_error", []string{timeErr}, 1)
 			}
 
+			if ssfSpan.Tags == nil {
+				ssfSpan.Tags = make(map[string]string)
+			}
+
 			// this will overwrite tags already present on the span
 			for _, tag := range tags {
 				ssfSpan.Tags[tag[0]] = tag[1]

--- a/parser_test.go
+++ b/parser_test.go
@@ -23,6 +23,34 @@ func freshSSFMetric() *ssf.SSFSample {
 	}
 }
 
+func TestValidMetric(t *testing.T) {
+	metric := freshSSFMetric()
+
+	m, _ := samplers.ParseMetricSSF(metric)
+	assert.True(t, samplers.ValidMetric(m))
+
+	metric.Name = ""
+	m, _ = samplers.ParseMetricSSF(metric)
+	assert.False(t, samplers.ValidMetric(m))
+
+	metric.SampleRate = 0
+	m, _ = samplers.ParseMetricSSF(metric)
+	assert.False(t, samplers.ValidMetric(m))
+	assert.Equal(t, float32(1), m.SampleRate)
+}
+
+func TestValidTrace(t *testing.T) {
+	trace := &ssf.SSFSpan{}
+	assert.False(t, samplers.ValidTrace(trace))
+	assert.NotNil(t, trace.Tags)
+
+	trace.Id = 1
+	trace.TraceId = 1
+	trace.StartTimestamp = 1
+	trace.EndTimestamp = 5
+	assert.True(t, samplers.ValidTrace(trace))
+}
+
 func TestParserSSF(t *testing.T) {
 	standardMetric := freshSSFMetric()
 	m, _ := samplers.ParseMetricSSF(standardMetric)

--- a/parser_test.go
+++ b/parser_test.go
@@ -70,7 +70,7 @@ func TestParseSSFEmpty(t *testing.T) {
 
 	sample, metrics, err := samplers.ParseSSF(buff)
 	assert.Nil(t, sample)
-	assert.Nil(t, metrics)
+	assert.Zero(t, len(metrics))
 	assert.Nil(t, err)
 }
 

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -79,12 +79,6 @@ func ValidMetric(sample UDPMetric) bool {
 	return ret
 }
 
-// ErrSSFUnmarshal is returned by ParseSSF when the packet can't be unmarshaled.
-var ErrSSFUnmarshal = errors.New("Unmarshal trace")
-
-// ErrParseMetricSSF is returned by ParseSSF when a metric packet can't be parsed.
-var ErrParseMetricSSF = errors.New("ParseMetricSSF on metric")
-
 // ParseSSF takes in a byte slice and returns:
 // an SSFSpan, slice of UDPMetrics, and an error.
 // It also validates packets before returning them.
@@ -92,14 +86,14 @@ func ParseSSF(packet []byte) (*ssf.SSFSpan, []*UDPMetric, error) {
 	sample := &ssf.SSFSpan{}
 	err := proto.Unmarshal(packet, sample)
 	if err != nil {
-		return nil, nil, ErrSSFUnmarshal
+		return nil, nil, errors.New("unmarshal")
 	}
 
 	metrics := make([]*UDPMetric, 0)
 	for _, metricPacket := range sample.Metrics {
 		metric, err := ParseMetricSSF(metricPacket)
 		if err != nil {
-			return nil, nil, ErrParseMetricSSF
+			return nil, nil, errors.New("parse")
 		}
 		if ValidMetric(*metric) {
 			metrics = append(metrics, metric)

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -54,7 +54,7 @@ func (m *MetricKey) String() string {
 
 // ValidTrace takes in an SSF span and determines if it is valid or not.
 // It also makes sure the Tags is non-nil, since we use it later.
-func ValidTrace(sample ssf.SSFSpan) bool {
+func ValidTrace(sample *ssf.SSFSpan) bool {
 	ret := true
 	ret = ret && sample.Id != 0
 	ret = ret && sample.TraceId != 0
@@ -69,7 +69,7 @@ func ValidTrace(sample ssf.SSFSpan) bool {
 }
 
 // ValidMetric takes in an SSF sample and determines if it is valid or not.
-func ValidMetric(sample UDPMetric) bool {
+func ValidMetric(sample *UDPMetric) bool {
 	ret := true
 	ret = ret && sample.Name != ""
 	ret = ret && sample.Value != nil
@@ -95,12 +95,12 @@ func ParseSSF(packet []byte) (*ssf.SSFSpan, []*UDPMetric, error) {
 		if err != nil {
 			return nil, nil, errors.New("parse")
 		}
-		if ValidMetric(*metric) {
+		if ValidMetric(metric) {
 			metrics = append(metrics, metric)
 		}
 	}
 
-	if !ValidTrace(*sample) {
+	if !ValidTrace(sample) {
 		sample = nil
 	}
 

--- a/server.go
+++ b/server.go
@@ -547,8 +547,8 @@ func (s *Server) HandleTracePacket(packet []byte) {
 	}
 
 	sample, metrics, err := samplers.ParseSSF(packet)
-	reason := fmt.Sprintf("reason:%s", err.Error())
 	if err != nil {
+		reason := fmt.Sprintf("reason:%s", err.Error())
 		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:ssf_metric", reason}, 1.0)
 		log.WithError(err).Warn("ParseSSF")
 		return

--- a/server.go
+++ b/server.go
@@ -547,17 +547,10 @@ func (s *Server) HandleTracePacket(packet []byte) {
 	}
 
 	sample, metrics, err := samplers.ParseSSF(packet)
-	if err == samplers.ErrSSFUnmarshal {
-		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:trace", "reason:unmarshal"}, 1.0)
-		log.WithError(err).Warn("Trace unmarshaling error")
-		return
-	} else if err == samplers.ErrParseMetricSSF {
-		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:ssf_metric", "reason:parse"}, 1.0)
-		log.WithError(err).Warn("ParseMetricSSF error")
-		return
-	} else if err != nil {
-		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:ssf_metric", "reason:unknown"}, 1.0)
-		log.WithError(err).Warn("Unknown error ASDF")
+	reason := fmt.Sprintf("reason:%s", err.Error())
+	if err != nil {
+		s.Statsd.Count("packet.error_total", 1, []string{"packet_type:ssf_metric", reason}, 1.0)
+		log.WithError(err).Warn("ParseSSF")
 		return
 	}
 


### PR DESCRIPTION
#### Summary
This PR:
1. Adds an explicit bug fix in the flusher, that would occur if we wanted to flush an SSF metric packet without tags.
2. Moves validity checking of SSF metrics and traces to the parser, instead of the server. `ValidTrace` now also addresses the same bug as 1. 
3. Moves parsing of an SSF packet to `parser.go` as opposed to the server.

TODO: 
- [x] Write tests for `ParseSSF` (new function in `parser.go`).


#### Motivation
Bug fix, and it makes more sense for the parsing logic to be in `parser.go` than in `server.go`. 


#### Test plan
Tests coming soon.


#### Rollout/monitoring/revert plan
Puppet!

r? @cory-stripe 