### PR TITLE
Veneur-emit time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.5.3, pending
+
+## Added
+* Veneur-emit can now time any shell command and emit its duration as a Timing metric. Thanks [redsn0w422](https://github.com/redsn0w422)!
+
 # 1.5.2, 2017-08-15
 
 ## Bugfixes

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -97,7 +97,7 @@ func main() {
 			logrus.WithError(err).Fatal("Error!")
 		}
 
-		err := timeCommand(conn, passedFlags)
+		err = timeCommand(conn, passedFlags)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error timing command.")
 		}

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -28,7 +28,7 @@ var (
 	mode         = flag.String("mode", "metric", "Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'.")
 	debug        = flag.Bool("debug", false, "Turns on debug messages.")
 	command      = flag.String("command", "", "Command to time. This will exec 'command', time it, and emit a timer metric.")
-	shellCommand = flag.Bool("shellCommand", false, "Turns on timeCommand mode. TODO")
+	shellCommand = flag.Bool("shellCommand", false, "Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.")
 
 	// Metric flags
 	name   = flag.String("name", "", "Name of metric to report. Ex: 'daemontools.service.starts'")

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -198,7 +198,7 @@ func addr(passedFlags map[string]flag.Value, conf *veneur.Config, hostport *stri
 }
 
 func timeCommand(client MinimalClient, command []string, name string, tags []string) (int, error) {
-	logrus.Debugf("Timing '%s'...", command)
+	logrus.Debugf("Timing %q...", command)
 	cmd := exec.Command(command[0], command[1:]...)
 	exitStatus := 0
 	start := time.Now()
@@ -214,7 +214,7 @@ func timeCommand(client MinimalClient, command []string, name string, tags []str
 	elapsed := time.Since(start)
 	exitTag := fmt.Sprintf("exit_status:%d", exitStatus)
 	tags = append(tags, exitTag)
-	logrus.Debugf("'%s' took %s", command, elapsed)
+	logrus.Debugf("%q took %s", command, elapsed)
 	err = client.Timing(name, elapsed, tags, 1)
 	return exitStatus, err
 }

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -213,8 +213,8 @@ func timeCommand(client MinimalClient, passedFlags map[string]flag.Value) error 
 		myTags = make([]string, 0)
 	}
 	logrus.Debugf("%s took %s", command, elapsed)
-	client.Timing(passedFlags["name"].String(), elapsed, myTags, 1)
-	return nil
+	err := client.Timing(passedFlags["name"].String(), elapsed, myTags, 1)
+	return err
 }
 
 func bareMetric(name string, tags string) *ssf.SSFSample {

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -101,7 +101,7 @@ func main() {
 		}
 
 		var status int
-		status, err = timeCommand(conn, flag.Args(), passedFlags["name"].String(), tags(*tag))
+		status, err = timeCommand(conn, flag.Args(), *name, tags(*tag))
 		if err != nil {
 			logrus.WithError(err).Fatal("Error timing command.")
 		}

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -93,6 +93,36 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestTimeCommand(t *testing.T) {
+	client := &fakeClient{}
+	resetMap(calledFunctions)
+	testFlag := make(map[string]flag.Value)
+	testFlag["command"] = newValue("echo hello")
+	testFlag["name"] = newValue("test.timing")
+
+	t.Run("basic", func(t *testing.T) {
+		err := timeCommand(client, testFlag)
+
+		assert.NoError(t, err, "timeCommand had an error")
+		assert.True(t, calledFunctions["timing"], "timeCommand did not call Timing")
+	})
+
+	t.Run("badCall", func(t *testing.T) {
+		badCall = true
+		defer func() {
+			badCall = false
+		}()
+		err := timeCommand(client, testFlag)
+		assert.Error(t, err, "timeCommand did not throw error.")
+	})
+
+	t.Run("withTags", func(t *testing.T) {
+		testFlag["tag"] = newValue("tag1:value1")
+		err := timeCommand(client, testFlag)
+		assert.NoError(t, err, "timeCommand had an error")
+	})
+}
+
 func TestGauge(t *testing.T) {
 	client := &fakeClient{}
 	resetMap(calledFunctions)

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -101,10 +101,11 @@ func TestTimeCommand(t *testing.T) {
 	testFlag["name"] = newValue("test.timing")
 
 	t.Run("basic", func(t *testing.T) {
-		err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, testFlag)
 
 		assert.NoError(t, err, "timeCommand had an error")
 		assert.True(t, calledFunctions["timing"], "timeCommand did not call Timing")
+		assert.Zero(t, st)
 	})
 
 	t.Run("badCall", func(t *testing.T) {
@@ -112,14 +113,16 @@ func TestTimeCommand(t *testing.T) {
 		defer func() {
 			badCall = false
 		}()
-		err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, testFlag)
 		assert.Error(t, err, "timeCommand did not throw error.")
+		assert.Zero(t, st)
 	})
 
 	t.Run("withTags", func(t *testing.T) {
 		testFlag["tag"] = newValue("tag1:value1")
-		err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, testFlag)
 		assert.NoError(t, err, "timeCommand had an error")
+		assert.Zero(t, st)
 	})
 }
 

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -124,6 +124,12 @@ func TestTimeCommand(t *testing.T) {
 		assert.NoError(t, err, "timeCommand had an error")
 		assert.Zero(t, st)
 	})
+
+	t.Run("badCall", func(t *testing.T) {
+		testFlag["command"] = newValue("cat x")
+		st, _ := timeCommand(client, testFlag)
+		assert.NotZero(t, st)
+	})
 }
 
 func TestGauge(t *testing.T) {

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -99,9 +99,11 @@ func TestTimeCommand(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["command"] = newValue("echo hello")
 	testFlag["name"] = newValue("test.timing")
+	command := "echo hello"
+	name := "test.timing"
 
 	t.Run("basic", func(t *testing.T) {
-		st, err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, command, name, []string{})
 
 		assert.NoError(t, err, "timeCommand had an error")
 		assert.True(t, calledFunctions["timing"], "timeCommand did not call Timing")
@@ -113,22 +115,22 @@ func TestTimeCommand(t *testing.T) {
 		defer func() {
 			badCall = false
 		}()
-		st, err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, command, name, []string{})
 		assert.Error(t, err, "timeCommand did not throw error.")
 		assert.Zero(t, st)
 	})
 
 	t.Run("withTags", func(t *testing.T) {
-		testFlag["tag"] = newValue("tag1:value1")
-		st, err := timeCommand(client, testFlag)
+		st, err := timeCommand(client, command, name, []string{"tag1:value1"})
 		assert.NoError(t, err, "timeCommand had an error")
 		assert.Zero(t, st)
 	})
 
 	t.Run("badCall", func(t *testing.T) {
-		testFlag["command"] = newValue("cat x")
-		st, _ := timeCommand(client, testFlag)
+		command = "cat x"
+		st, err := timeCommand(client, command, name, []string{"tag1:value1"})
 		assert.NotZero(t, st)
+		assert.NoError(t, err)
 	})
 }
 

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -99,7 +99,7 @@ func TestTimeCommand(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["command"] = newValue("echo hello")
 	testFlag["name"] = newValue("test.timing")
-	command := "echo hello"
+	command := []string{"echo", "hello"}
 	name := "test.timing"
 
 	t.Run("basic", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestTimeCommand(t *testing.T) {
 	})
 
 	t.Run("badCall", func(t *testing.T) {
-		command = "cat x"
+		command = []string{"cat", "x"}
 		st, err := timeCommand(client, command, name, []string{"tag1:value1"})
 		assert.NotZero(t, st)
 		assert.NoError(t, err)


### PR DESCRIPTION
#### Summary
This PR adds a `-command` flag to `veneur-emit`. If you pass a command to `-command`, `veneur-emit` will:
1. Skip/ignore any metrics by flag;
2. Execute the command passed in;
3. Report the runtime of that executable as a Timing metric. 


#### Motivation
A lot of use cases of `veneur-emit` involve a shell script, where the user would get the time, run some program, get the time again, calculate the difference, and then send the elapsed time as a Timing metric via `veneur-emit`. This PR makes it easier to do so.


#### Test plan
I added tests for `timeCommand`. 


#### Rollout/monitoring/revert plan
Puppet!

r? @cory-stripe 

TODO: 
- [x] Do we care about the exit status of the executable?
We do - `veneur-emit` will grab the exit status and put it on the Timing metric as a tag: `exit_status:0`, for example.

- [x] `cmd.Start()` & `cmd.Wait()` OR `cmd.Run()`?
`cmd.Run()` gets the job done, for now.

- [x] Do we want to have a timeout on the executable?
Too many edge cases for a timeout, so if the user wishes, they can add a timeout to the command passed to `veneur-emit`.

- [x] Do we want the user to be able to send other metrics as well, or should we skip that entirely?
Skip metrics. Calling `veneur-emit` is trivial, and if they want to send other metrics, they can just call it repeatedly.

- [ ] ~Support sending the Timing via SSF?~
SSF does not (yet) support Timing metrics.
