### PR TITLE
Tag packet.spans.received_total with service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Correctly parse `Set` metrics if sent via SSF. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Return correct array of tags after parsing an SSF metric. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Don't panic if a packet doesn't have tags. Thanks [redsn0w422](https://github.com/redsn0w422)!
+* Fix a typo in the link to veneur-emit in the readme. Thanks [vasi](https://github.com/vasi)!
 
 ## Added
 * Adds [events](https://docs.datadoghq.com/guides/dogstatsd/#events-1) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks-1) to `veneur-emit`. Thanks [redsn0w422](https://github.com/redsn0w422)!
@@ -17,6 +18,7 @@
 * Refactored `veneur-emit` flag usage to make testing easier. Thanks [redsn0w422](https://github.com/redsn0w422)!
 * Minor text fixes in the README. Thanks [an-stripe](https://github.com/an-stripe)!
 * Restructured SSF parsing logic and added more tests. Thanks [redsn0w422](https://github.com/redsn0w422)!
+* Tag `packet.spans.received_total` with `service` from the span. Thanks [chimeracoder](https://github.com/chimeracoder)!
 
 # 1.5.1, 2017-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Remove support for `govendor`. Thanks [chimeracoder](https://github.com/chimeracoder)!
 * Emit GC metrics at flush time. This feature is best used with Go 1.9 as previous versions cause GC pauses when collecting this information from go. Thanks [gphat](https://github.com/gphat)!
 * Allow configuration of LightStep's reconnect period via `trace_lightstep_reconnect_period` and the maximum number of spans it will buffer via `trace_lightstep_maximum_spans`. Thanks [gphat](https://github.com/gphat)!
+* Switch to [dep](https://github.com/golang/dep/) for managing the `vendor` directory.
+* Remove support for `govendor`.
+* Added [harmonic mean](https://en.wikipedia.org/wiki/Harmonic_mean) as an optional aggregate type. Use `hmean` as an option to the `aggregates` config option to enable. Thanks [non](https://github.com/non)!
 
 ## Improvements
 * Added tests for `parseMetricSSF`. Thanks [redsn0w422](https://github.com/redsn0w422)!

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -36,10 +36,11 @@ percentiles:
 # or all of:
 # - `min`: the minimum value in the histogram during the flush period
 # - `max`: the maximum value in the histogram during the flush period
-# -	`median`: the median value in the histogram during the flush period
-# -	`avg`: the average value in the histogram during the flush period
-# -	`count`: the number of values added to the histogram during the flush period
-# -	`sum`: the sum of all values added to the histogram during the flush period
+# - `median`: the median value in the histogram during the flush period
+# - `avg`: the average value in the histogram during the flush period
+# - `count`: the number of values added to the histogram during the flush period
+# - `sum`: the sum of all values added to the histogram during the flush period
+# - `hmean`: the harmonic mean of the all the values added to the histogram during the flush period
 aggregates:
  - "min"
  - "max"

--- a/server.go
+++ b/server.go
@@ -618,7 +618,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 	}
 
 	if sample != nil {
-		s.Statsd.Incr("packet.spans.received_total", nil, .1)
+		s.Statsd.Incr("packet.spans.received_total", []string{fmt.Sprintf("service:%s", sample.Service)}, .1)
 		s.TraceWorker.TraceChan <- *sample
 	}
 }


### PR DESCRIPTION
#### Summary

Tag `packet.spans.received_total` and `packet.spans.error_total` by service name.

`packet.spans.error_total` is renamed from `packet.error_total`, because the latter is already being emitted three lines up as a separate metric altogether.


#### Motivation
https://jira.corp.stripe.com/browse/OBS-1762


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability
