### PR TITLE
Revamp Metric Handling

### DIFF
--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -34,7 +34,7 @@ func main() {
 		logrus.WithError(err).Fatal("Could not initialize proxy")
 	}
 	defer func() {
-		veneur.ConsumePanic(proxy.Sentry, proxy.Statsd, proxy.Hostname, recover())
+		veneur.ConsumePanic(proxy.Sentry, proxy.Recorder, proxy.Hostname, recover())
 	}()
 	proxy.Start()
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -60,7 +60,7 @@ func main() {
 		logrus.WithError(e).Fatal("Could not initialize server")
 	}
 	defer func() {
-		veneur.ConsumePanic(server.Sentry, server.Statsd, server.Hostname, recover())
+		veneur.ConsumePanic(server.Sentry, server.Recorder, server.Hostname, recover())
 	}()
 	server.Start()
 

--- a/networking.go
+++ b/networking.go
@@ -65,7 +65,7 @@ func startStatsdUDP(s *Server, addr *net.UDPAddr, packetPool *sync.Pool) {
 	for i := 0; i < s.numReaders; i++ {
 		go func() {
 			defer func() {
-				ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+				ConsumePanic(s.Sentry, s.Recorder, s.Hostname, recover())
 			}()
 			// each goroutine gets its own socket
 			// if the sockets support SO_REUSEPORT, then this will cause the
@@ -121,7 +121,7 @@ func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) {
 
 	go func() {
 		defer func() {
-			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+			ConsumePanic(s.Sentry, s.Recorder, s.Hostname, recover())
 		}()
 		s.ReadTCPSocket(listener)
 	}()

--- a/proxy.go
+++ b/proxy.go
@@ -42,6 +42,7 @@ type Proxy struct {
 	HTTPAddr               string
 	HTTPClient             *http.Client
 	Statsd                 *statsd.Client
+	Recorder               *Recorder
 	AcceptingForwards      bool
 	AcceptingTraces        bool
 
@@ -72,11 +73,12 @@ func NewProxyFromConfig(conf ProxyConfig) (p Proxy, err error) {
 	// TODO Timeout?
 	p.HTTPClient = &http.Client{}
 
-	p.Statsd, err = statsd.NewBuffered(conf.StatsAddress, 1024)
+	p.Recorder, err = NewProxyRecorder(conf)
 	if err != nil {
 		log.WithError(err).Error("Failed to create stats instance")
 		return
 	}
+	p.Statsd = p.Recorder.Statsd
 	p.Statsd.Namespace = "veneur_proxy."
 
 	p.enableProfiling = conf.EnableProfiling
@@ -172,7 +174,7 @@ func (p *Proxy) Start() {
 	if p.usingConsul {
 		go func() {
 			defer func() {
-				ConsumePanic(p.Sentry, p.Statsd, p.Hostname, recover())
+				ConsumePanic(p.Sentry, p.Recorder, p.Hostname, recover())
 			}()
 			ticker := time.NewTicker(p.ConsulInterval)
 			for range ticker.C {

--- a/recorder.go
+++ b/recorder.go
@@ -19,6 +19,7 @@ const sentryErrorsTotal = "sentry.errors_total"
 const flushPluginErrorsTotal = "flush.plugins.%s.error_total"
 const flushPluginDuration = "flush.plugins.%s.total_duration_ns"
 const packetsSpanCount = "packet.spans.received_total"
+const totalSpansFlushedMetricKey = "worker.spans_flushed_total"
 const workerSpanFlushDuration = "worker.span.flush_duration_ns"
 const workerSpanIngestErrorTotal = "worker.span.ingest_error_total"
 
@@ -125,14 +126,17 @@ func (r *Recorder) SentryErrorCount() {
 	r.Statsd.Count(sentryErrorsTotal, 1, nil, 1.0)
 }
 
-func (r *Recorder) SpanPacketsProcessedCount(spans int64) {
-	r.Statsd.Count(packetsSpanCount, spans, nil, 1.0)
+// SpanPacketsProcessedCount tracks the number of span packets processed.
+func (r *Recorder) SpanPacketsProcessedCount(spans int64, service string) {
+	r.Statsd.Count(packetsSpanCount, spans, []string{fmt.Sprintf("service:%s", service)}, 1)
 }
 
+// WorkerSpanIngestErrorTotal tracks the number of spans that failed sink ingest.
 func (r *Recorder) WorkerSpanIngestErrorTotal(sink string) {
 	r.Statsd.Incr(workerSpanIngestErrorTotal, []string{fmt.Sprintf("sink:%s", sink)}, 1.0)
 }
 
+// WorkerSpanFlushDuration tracks the duration of span sink flushes.
 func (r *Recorder) WorkerSpanFlushDuration(start time.Time, sink string) {
 	r.Statsd.TimeInMilliseconds(workerSpanFlushDuration, float64(time.Since(start).Nanoseconds()), []string{fmt.Sprintf("sink:%s", sink)}, 1.0)
 }

--- a/recorder.go
+++ b/recorder.go
@@ -1,0 +1,122 @@
+package veneur
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+const workerMetricsFlushedTotal = "worker.metrics_flushed_total"
+const flushDuration = "flush.total_duration_ns"
+const flushPostTotal = "flush.post_metrics_total"
+const memHeapAlloc = "mem.heap_alloc_bytes"
+const memGCNumber = "gc.number"
+const memGCPauseTotal = "gc.pause_total_ns"
+const sentryErrorsTotal = "sentry.errors_total"
+const flushPluginErrorsTotal = "flush.plugins.%s.error_total"
+const flushPluginDuration = "flush.plugins.%s.total_duration_ns"
+
+// Recorder is a type-safe interface for emitting metrics.
+type Recorder struct {
+	Statsd *statsd.Client
+}
+
+// NewRecorder makes a new Recorder instance from a Config.
+func NewRecorder(conf Config) (*Recorder, error) {
+	statsd, err := statsd.NewBuffered(conf.StatsAddress, 1024)
+	if err != nil {
+		return nil, err
+	}
+	statsd.Namespace = "veneur."
+	statsd.Tags = append(conf.Tags, "veneurlocalonly")
+
+	return &Recorder{
+		Statsd: statsd,
+	}, nil
+}
+
+// NewProxyRecorder makes a new Recorder instance from a ProxyConfig.
+func NewProxyRecorder(conf ProxyConfig) (*Recorder, error) {
+	statsd, err := statsd.NewBuffered(conf.StatsAddress, 1024)
+	if err != nil {
+		return nil, err
+	}
+	statsd.Namespace = "veneur."
+
+	return &Recorder{
+		Statsd: statsd,
+	}, nil
+}
+
+// DurationSinceStart is a convenience method for getting a duration in
+// nanoseconds given a start time.
+func DurationSinceStart(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds())
+}
+
+// LocalMetricsFlushCounts reports the counts of
+// Counters, Gauges, LocalHistograms, LocalSets, and LocalTimers
+// as metrics. These are shared by both global and local flush operations.
+// It does *not* report the totalHistograms, totalSets, or totalTimers
+// because those are only performed by the global veneur instance.
+// It also does not report the total metrics posted, because on the local veneur,
+// that should happen *after* the flush-forward operation.
+func (r *Recorder) LocalMetricsFlushCounts(ms metricsSummary) {
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalCounters), []string{"metric_type:counter"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalGauges), []string{"metric_type:gauge"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalLocalHistograms), []string{"metric_type:local_histogram"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalLocalSets), []string{"metric_type:local_set"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalLocalTimers), []string{"metric_type:local_timer"}, 1.0)
+}
+
+// GlobalMetricsFlushCounts reports the counts of
+// globalCounters, totalHistograms, totalSets, and totalTimers,
+// which are the three metrics reported *only* by the global
+// veneur instance.
+func (r *Recorder) GlobalMetricsFlushCounts(ms metricsSummary) {
+	// we only report these lengths in FlushGlobal
+	// since if we're the global veneur instance responsible for flushing them
+	// this avoids double-counting problems where a local veneur reports
+	// histograms that it received, and then a global veneur reports them
+	// again
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalGlobalCounters), []string{"metric_type:global_counter"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalHistograms), []string{"metric_type:histogram"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalSets), []string{"metric_type:set"}, 1.0)
+	r.Statsd.Count(workerMetricsFlushedTotal, int64(ms.totalTimers), []string{"metric_type:timer"}, 1.0)
+}
+
+// FlushDuration tracks the duration of a flush operation, with a part tag.
+func (r *Recorder) FlushDuration(start time.Time, part string) {
+	r.Statsd.TimeInMilliseconds(flushDuration, DurationSinceStart(start), []string{fmt.Sprintf("part:%s", part)}, 1.0)
+}
+
+// FlushMetricCount tracks the number of metrics posted.
+func (r *Recorder) FlushMetricCount(count int) {
+	r.Statsd.Gauge(flushPostTotal, float64(count), nil, 1.0)
+}
+
+// GCStats tracks various Go GC metrics.
+func (r *Recorder) GCStats(mem *runtime.MemStats) {
+	r.Statsd.Gauge(memHeapAlloc, float64(mem.HeapAlloc), nil, 1.0)
+	r.Statsd.Gauge(memGCNumber, float64(mem.NumGC), nil, 1.0)
+	r.Statsd.Gauge(memGCPauseTotal, float64(mem.PauseTotalNs), nil, 1.0)
+}
+
+// PluginFlushDuration tracks the duration of a plugin's flush, tagged by the
+// plugin's name.
+func (r *Recorder) PluginFlushDuration(start time.Time, plugin string) {
+	r.Statsd.TimeInMilliseconds(fmt.Sprintf(flushPluginDuration, plugin), DurationSinceStart(start), nil, 1.0)
+}
+
+// PluginFlushErrorCount tracks the number of errors a plugin encounters,
+// tagged by the plugin's name.
+func (r *Recorder) PluginFlushErrorCount(plugin string) {
+	r.Statsd.Count(fmt.Sprintf(flushPluginErrorsTotal, plugin), 1, nil, 1.0)
+}
+
+// SentryErrorCount tracks the number of errors sent to Sentry.
+func (r *Recorder) SentryErrorCount() {
+	r.Statsd.Count(sentryErrorsTotal, 1, nil, 1.0)
+}

--- a/sentry.go
+++ b/sentry.go
@@ -3,7 +3,6 @@ package veneur
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
 )
@@ -11,7 +10,7 @@ import (
 // ConsumePanic is intended to be called inside a deferred function when recovering
 // from a panic. It accepts the value of recover() as its only argument,
 // and reports the panic to Sentry, prints the stack,  and then repanics (to ensure your program terminates)
-func ConsumePanic(sentry *raven.Client, stats *statsd.Client, hostname string, err interface{}) {
+func ConsumePanic(sentry *raven.Client, recorder *Recorder, hostname string, err interface{}) {
 	if err == nil {
 		return
 	}
@@ -39,7 +38,7 @@ func ConsumePanic(sentry *raven.Client, stats *statsd.Client, hostname string, e
 		}
 
 		_, ch := sentry.Capture(&p, nil)
-		stats.Count("sentry.errors_total", 1, nil, 1.0)
+		recorder.SentryErrorCount()
 
 		// we don't want the program to terminate before reporting to sentry
 		<-ch

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -14,14 +14,14 @@ func consumeAndCatchPanic(s *Server) (result interface{}) {
 	defer func() {
 		result = recover()
 	}()
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, "panic")
+	ConsumePanic(s.Sentry, s.Recorder, s.Hostname, "panic")
 	return
 }
 
 func TestConsumePanicWithoutSentry(t *testing.T) {
 	s := &Server{}
 	// does nothing
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, nil)
+	ConsumePanic(s.Sentry, s.Recorder, s.Hostname, nil)
 
 	recovered := consumeAndCatchPanic(s)
 	if recovered != "panic" {
@@ -39,7 +39,12 @@ func (t *fakeSentryTransport) Send(url string, authHeader string, packet *raven.
 }
 
 func TestConsumePanicWithSentry(t *testing.T) {
-	s := &Server{}
+	config := localConfig()
+	HTTPAddrPort++
+	f := newFixture(t, config)
+	defer f.Close()
+	s := f.server
+
 	var err error
 	s.Sentry, err = raven.NewClient("", nil)
 	if err != nil {
@@ -49,7 +54,7 @@ func TestConsumePanicWithSentry(t *testing.T) {
 	s.Sentry.Transport = fakeTransport
 
 	// nil does nothing
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, nil)
+	ConsumePanic(s.Sentry, s.Recorder, s.Hostname, nil)
 	if len(fakeTransport.packets) != 0 {
 		t.Error("ConsumePanic(nil) should not send data:", fakeTransport.packets)
 	}
@@ -61,6 +66,8 @@ func TestConsumePanicWithSentry(t *testing.T) {
 	if len(fakeTransport.packets) != 1 {
 		t.Error("expected 1 packet:", fakeTransport.packets)
 	}
+
+	f.Close()
 }
 
 func TestHookWithoutSentry(t *testing.T) {


### PR DESCRIPTION
#### Summary
Make a `Recorder` which exports public methods for recording metrics within Veneur.

#### Motivation
I'd like to improve the shit out of our metrics. Here's how this does that:
* puts them in one place (avoiding naming convention problems, renaming metrics issued in different places with different tags, etc
* gives them a type signature (what tags must be in place, float or int, etc)
* makes testing easier
* make sampling, etc easier as there is on place to change
* makes the future spanification of all this easier since they are in one place

If you need a new metric, you add a new method. If you want to change a metric you can easily find it's calls sites. If you want to emit a metric you are forced to look over all the existing ones and maybe find a better one to use. :)

#### Test plan
This PR is to iterate on the idea. I plucked out a few metrics and used the `Recorder` for them. I didn't do them all to keep the PR reasonable in size.

r? @aditya-stripe 