### PR TITLE
Unify statsd socket config, allow listening on multiple addresses

### DIFF
--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -222,16 +222,16 @@ func TestHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testHostport := "host:port"
 	testFlag["hostport"] = newValue(testHostport)
-	addr, err := addr(testFlag, nil, &testHostport)
-	if addr != testHostport || err != nil {
-		t.Error("Did not return hostport.")
+	addr, network, err := addr(testFlag, nil, &testHostport, false)
+	if addr != testHostport || network != "udp" || err != nil {
+		t.Errorf("Did not return hostport: %q/%q", network, addr)
 	}
 }
 
 func TestNilHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, err := addr(testFlag, nil, nil)
-	if addr != "" || err == nil {
+	addr, network, err := addr(testFlag, nil, nil, false)
+	if addr != "" || network != "udp" || err == nil {
 		t.Error("Did not check for valid hostport.")
 	}
 }
@@ -239,18 +239,18 @@ func TestNilHostport(t *testing.T) {
 func TestConfig(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	fakeConfig := &veneur.Config{}
-	fakeConfig.UdpAddress = "testudp"
+	fakeConfig.StatsdListenAddresses = []string{"udp://localhost:8200"}
 	testFlag["f"] = newValue("/pay/conf/veneur.yaml")
-	addr, err := addr(testFlag, fakeConfig, nil)
-	if addr != "testudp" || err != nil {
-		t.Error("Did not use config file for hostname and port.")
+	addr, network, err := addr(testFlag, fakeConfig, nil, false)
+	if addr != "localhost:8200" || network != "udp" || err != nil {
+		t.Error("Did not use config file for hostname and port: %q/%q", network, addr)
 	}
 }
 
 func TestNoAddr(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, err := addr(testFlag, nil, nil)
-	if addr != "" || err == nil {
+	addr, network, err := addr(testFlag, nil, nil, false)
+	if addr != "" || network != "udp" || err == nil {
 		t.Error("Returned non-empty address with no flags.")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
 	StatsAddress                  string    `yaml:"stats_address"`
+	StatsdListenAddresses         []string  `yaml:"statsd_listen_addresses"`
 	Tags                          []string  `yaml:"tags"`
 	TcpAddress                    string    `yaml:"tcp_address"`
 	TLSAuthorityCertificate       string    `yaml:"tls_authority_certificate"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -1,8 +1,10 @@
 package veneur
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"time"
 
@@ -91,6 +93,17 @@ func readConfig(r io.Reader) (c Config, err error) {
 			c.SsfAddress = c.TraceAddress
 		}
 	}
+
+	var moreAddrs []string
+	if c.UdpAddress != "" {
+		if len(c.StatsdListenAddresses) > 0 {
+			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `udp_address` are both present")
+			return
+		}
+		log.Warn("The config key `udp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
+		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
+	}
+	c.StatsdListenAddresses = append(c.StatsdListenAddresses, moreAddrs...)
 
 	return c, nil
 }

--- a/config_parse.go
+++ b/config_parse.go
@@ -103,6 +103,15 @@ func readConfig(r io.Reader) (c Config, err error) {
 		log.Warn("The config key `udp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
 		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
 	}
+
+	if c.TcpAddress != "" {
+		if len(c.StatsdListenAddresses) > 0 {
+			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `tcp_address` are both present")
+			return
+		}
+		log.Warn("The config key `tcp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
+		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "tcp", Host: c.UdpAddress}).String())
+	}
 	c.StatsdListenAddresses = append(c.StatsdListenAddresses, moreAddrs...)
 
 	return c, nil

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -70,14 +70,6 @@ hostname: foobar
 # If true and hostname is "" or absent, don't add the host tag
 omit_empty_hostname: false
 
-# The address on which to listen for metrics sent to this instance over UDP,
-# leave empty to disable.
-udp_address: "localhost:8126"
-
-# The address on which to listen for metrics sent to this instance over TCP,
-# leave empty to disable.
-tcp_address: ""
-
 # The address on which to listen for HTTP imports and/or healthchecks.
 #http_address: "einhorn@0"
 http_address: "localhost:8127"
@@ -104,6 +96,27 @@ tls_certificate: ""
 
 # Authority certificate: requires clients to be authenticated
 tls_authority_certificate: ""
+
+# == STATSD ==
+
+# The addresses on which to listen for statsd metrics. These are
+# formatted as URLs, with schemes corresponding to valid "network"
+# arguments on https://golang.org/pkg/net/#Listen. Currently, only udp
+# and tcp (including IPv4 and 6-only) schemes are supported.
+# This option supersedes the "udp_address" and "tcp_address" options.
+statsd_listen_addresses:
+ - udp://localhost:8126
+ - tcp://localhost:8126
+
+# The address on which to listen for metrics sent to this instance over UDP,
+# leave empty to disable.
+# This option is DEPRECATED, use statsd_listen_addresses instead.
+udp_address: "localhost:8126"
+
+# The address on which to listen for metrics sent to this instance over TCP,
+# leave empty to disable.
+# This option is DEPRECATED, use statsd_listen_addresses instead.
+tcp_address: ""
 
 # == SINKS ==
 

--- a/networking.go
+++ b/networking.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
+	"sync"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/Sirupsen/logrus"
 )
 
 // ListeningAddr implements the net.Addr interface and gets
@@ -18,8 +20,9 @@ import (
 //   - unix:///tmp/foo.sock
 //   - tcp://127.0.0.1:9002
 type ListeningAddr struct {
-	address string
-	network string
+	address     string
+	network     string
+	startStatsd StatsdStarter
 }
 
 var _ net.Addr = &ListeningAddr{}
@@ -32,24 +35,77 @@ func (a *ListeningAddr) String() string {
 	return a.address
 }
 
-func (a *ListeningAddr) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var addrStr string
-	if err := unmarshal(&addrStr); err != nil {
-		return err
-	}
-
-	u, err := url.Parse(addrStr)
-	if err != nil {
-		return fmt.Errorf("couldn't parse listening address %q: %v", addrStr, err)
-	}
+func (a *ListeningAddr) FromURL(u *url.URL) error {
 	switch u.Scheme {
-	case "unix", "unixpacket", "unixgram":
+	case "unix":
 		a.address = u.Path
-	case "tcp6", "tcp4", "tcp", "udp6", "udp4", "udp":
+	case "unixgram", "unixpacket":
+		a.address = u.Path
+	case "tcp6", "tcp4", "tcp":
 		a.address = u.Host
+	case "udp6", "udp4", "udp":
+		a.address = u.Host
+		a.startStatsd = startStatsdUDP
 	default:
-		return fmt.Errorf("unknown address family %q on address %q", u.Scheme, addrStr)
+		return fmt.Errorf("unknown address family %q on address %q", u.Scheme, u.String())
 	}
 	a.network = u.Scheme
 	return nil
+}
+
+func (a ListeningAddr) StartStatsd(s *Server, packetPool *sync.Pool) {
+	if a.startStatsd == nil {
+		log.WithFields(logrus.Fields{
+			"address": a.address,
+			"network": a.network,
+		}).Fatal("I do not know how to listen for statsd packets on this kind of socket")
+	}
+	a.startStatsd(s, a, packetPool)
+}
+
+func (a ListeningAddr) Resolve() (net.Addr, error) {
+	switch {
+	case strings.HasPrefix(a.network, "udp"):
+		return net.ResolveUDPAddr(a.network, a.address)
+	case strings.HasPrefix(a.network, "tcp"):
+		return net.ResolveTCPAddr(a.network, a.address)
+	case strings.HasPrefix(a.network, "unix"):
+		return net.ResolveUnixAddr(a.network, a.address)
+	}
+	return nil, fmt.Errorf("can't tell how to resolve address for network %q", a.network)
+}
+
+// StatsdStarter is a function (to be called in a goroutine) that will
+// loop forever and read statsd packets from a socket that it creates
+// from the address passed.  Errors in listening are fatal, so the
+// function is expected to either loop forever, handling its own
+// errors, or trigger a fatal error.
+type StatsdStarter func(s *Server, addr ListeningAddr, packetPool *sync.Pool)
+
+func startStatsdUDP(s *Server, laddr ListeningAddr, packetPool *sync.Pool) {
+	addr, err := net.ResolveUDPAddr(laddr.Network(), laddr.String())
+	if err != nil {
+		log.WithError(err).WithField("address", addr.String()).Fatal("Couldn't resolve UDP listening address")
+	}
+	for i := 0; i < s.numReaders; i++ {
+		go func() {
+			defer func() {
+				ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+			}()
+			// each goroutine gets its own socket
+			// if the sockets support SO_REUSEPORT, then this will cause the
+			// kernel to distribute datagrams across them, for better read
+			// performance
+			sock, err := NewSocket(addr, s.RcvbufBytes, s.numReaders != 1)
+			if err != nil {
+				// if any goroutine fails to create the socket, we can't really
+				// recover, so we just blow up
+				// this probably indicates a systemic issue, eg lack of
+				// SO_REUSEPORT support
+				log.WithError(err).Fatal("Error listening for UDP metrics")
+			}
+			log.WithField("address", addr).Info("Listening for UDP metrics")
+			s.ReadMetricSocket(sock, packetPool)
+		}()
+	}
 }

--- a/networking.go
+++ b/networking.go
@@ -1,0 +1,55 @@
+package veneur
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// ListeningAddr implements the net.Addr interface and gets
+// deserialized from the YAML config file by interpreting it as a URL,
+// where the Scheme corresponds to the "net" argument to net.Listen,
+// and the host&port or path are the "laddr" arg.
+//
+// Valid address examples are:
+//   - udp6://127.0.0.1:8000
+//   - unix:///tmp/foo.sock
+//   - tcp://127.0.0.1:9002
+type ListeningAddr struct {
+	address string
+	network string
+}
+
+var _ net.Addr = &ListeningAddr{}
+
+func (a *ListeningAddr) Network() string {
+	return a.network
+}
+
+func (a *ListeningAddr) String() string {
+	return a.address
+}
+
+func (a *ListeningAddr) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var addrStr string
+	if err := unmarshal(&addrStr); err != nil {
+		return err
+	}
+
+	u, err := url.Parse(addrStr)
+	if err != nil {
+		return fmt.Errorf("couldn't parse listening address %q: %v", addrStr, err)
+	}
+	switch u.Scheme {
+	case "unix", "unixpacket", "unixgram":
+		a.address = u.Path
+	case "tcp6", "tcp4", "tcp", "udp6", "udp4", "udp":
+		a.address = u.Host
+	default:
+		return fmt.Errorf("unknown address family %q on address %q", u.Scheme, addrStr)
+	}
+	a.network = u.Scheme
+	return nil
+}

--- a/networking_test.go
+++ b/networking_test.go
@@ -1,0 +1,37 @@
+package veneur
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenAddr(t *testing.T) {
+	tests := []struct {
+		input   string
+		network string
+		laddr   string
+	}{
+		{"udp://127.0.0.1:8200", "udp", "127.0.0.1:8200"},
+		{"tcp://:8200", "tcp", ":8200"},
+		{"tcp6://[::1]:8200", "tcp6", "[::1]:8200"},
+		{"unix:///tmp/foo.sock", "unix", "/tmp/foo.sock"},
+		{"unixgram:///tmp/foo.sock", "unixgram", "/tmp/foo.sock"},
+		{"unixpacket:///tmp/foo.sock", "unixpacket", "/tmp/foo.sock"},
+	}
+	for _, test := range tests {
+		var addr ListeningAddr
+		u, err := url.Parse(test.input)
+		if !assert.NoError(t, err) {
+			continue
+		}
+
+		err = addr.FromURL(u)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		assert.Equal(t, test.network, addr.Network())
+		assert.Equal(t, test.laddr, addr.String(), "Address %#v not correct", addr)
+	}
+}


### PR DESCRIPTION
#### Summary
This changes veneur's config handling to support an array of statsd socket addresses (given as URLs), rather than having a single `udp_socket` and optional `tcp_socket`. 

This allows us to better dispatch per-protocol/socket-type handling of behavior (fewer special-cased branches to support the TCP socket), allows users to configure veneur to listen on multiple ports, and sets us up for success in fixing #199 (-:

#### Motivation
This is lead-up work to tackling #199: I would like to get most of our networking strategy in a reasonable shape before introducing another socket family*protocol combination.


#### Test plan

Adjusted unit tests, they all pass!


#### Rollout/monitoring/revert plan

Some considerations: 

* This comes with a backwards-compatible config change, so we'll have to update docs/examples.
* Before rolling this to our infra, we should update our config files to use `statsd_listen_address` instead of `udp_socket`

