### PR TITLE
Unify statsd socket config, allow listening on multiple addresses

### DIFF
--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -222,16 +222,16 @@ func TestHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testHostport := "host:port"
 	testFlag["hostport"] = newValue(testHostport)
-	addr, err := addr(testFlag, nil, &testHostport)
-	if addr != testHostport || err != nil {
-		t.Error("Did not return hostport.")
+	addr, network, err := addr(testFlag, nil, &testHostport, false)
+	if addr != testHostport || network != "udp" || err != nil {
+		t.Errorf("Did not return hostport: %q/%q", network, addr)
 	}
 }
 
 func TestNilHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, err := addr(testFlag, nil, nil)
-	if addr != "" || err == nil {
+	addr, network, err := addr(testFlag, nil, nil, false)
+	if addr != "" || network != "udp" || err == nil {
 		t.Error("Did not check for valid hostport.")
 	}
 }
@@ -239,18 +239,18 @@ func TestNilHostport(t *testing.T) {
 func TestConfig(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	fakeConfig := &veneur.Config{}
-	fakeConfig.UdpAddress = "testudp"
+	fakeConfig.StatsdListenAddresses = []string{"udp://127.0.0.1:8200"}
 	testFlag["f"] = newValue("/pay/conf/veneur.yaml")
-	addr, err := addr(testFlag, fakeConfig, nil)
-	if addr != "testudp" || err != nil {
-		t.Error("Did not use config file for hostname and port.")
+	addr, network, err := addr(testFlag, fakeConfig, nil, false)
+	if addr != "127.0.0.1:8200" || network != "udp" || err != nil {
+		t.Errorf("Did not use config file for hostname and port: %q/%q", network, addr)
 	}
 }
 
 func TestNoAddr(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, err := addr(testFlag, nil, nil)
-	if addr != "" || err == nil {
+	addr, network, err := addr(testFlag, nil, nil, false)
+	if addr != "" || network != "udp" || err == nil {
 		t.Error("Returned non-empty address with no flags.")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
 	StatsAddress                  string    `yaml:"stats_address"`
+	StatsdListenAddresses         []string  `yaml:"statsd_listen_addresses"`
 	Tags                          []string  `yaml:"tags"`
 	TcpAddress                    string    `yaml:"tcp_address"`
 	TLSAuthorityCertificate       string    `yaml:"tls_authority_certificate"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -1,8 +1,10 @@
 package veneur
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"time"
 
@@ -103,6 +105,26 @@ func readConfig(r io.Reader) (c Config, err error) {
 			c.SsfAddress = c.TraceAddress
 		}
 	}
+
+	var moreAddrs []string
+	if c.UdpAddress != "" {
+		if len(c.StatsdListenAddresses) > 0 {
+			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `udp_address` are both present")
+			return
+		}
+		log.Warn("The config key `udp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
+		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
+	}
+
+	if c.TcpAddress != "" {
+		if len(c.StatsdListenAddresses) > 0 {
+			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `tcp_address` are both present")
+			return
+		}
+		log.Warn("The config key `tcp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
+		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "tcp", Host: c.UdpAddress}).String())
+	}
+	c.StatsdListenAddresses = append(c.StatsdListenAddresses, moreAddrs...)
 
 	return c, nil
 }

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -70,14 +70,6 @@ hostname: foobar
 # If true and hostname is "" or absent, don't add the host tag
 omit_empty_hostname: false
 
-# The address on which to listen for metrics sent to this instance over UDP,
-# leave empty to disable.
-udp_address: "localhost:8126"
-
-# The address on which to listen for metrics sent to this instance over TCP,
-# leave empty to disable.
-tcp_address: ""
-
 # The address on which to listen for HTTP imports and/or healthchecks.
 #http_address: "einhorn@0"
 http_address: "localhost:8127"
@@ -104,6 +96,27 @@ tls_certificate: ""
 
 # Authority certificate: requires clients to be authenticated
 tls_authority_certificate: ""
+
+# == STATSD ==
+
+# The addresses on which to listen for statsd metrics. These are
+# formatted as URLs, with schemes corresponding to valid "network"
+# arguments on https://golang.org/pkg/net/#Listen. Currently, only udp
+# and tcp (including IPv4 and 6-only) schemes are supported.
+# This option supersedes the "udp_address" and "tcp_address" options.
+statsd_listen_addresses:
+ - udp://localhost:8126
+ - tcp://localhost:8126
+
+# The address on which to listen for metrics sent to this instance over UDP,
+# leave empty to disable.
+# This option is DEPRECATED, use statsd_listen_addresses instead.
+udp_address: "localhost:8126"
+
+# The address on which to listen for metrics sent to this instance over TCP,
+# leave empty to disable.
+# This option is DEPRECATED; use statsd_listen_addresses instead.
+tcp_address: ""
 
 # == SINKS ==
 

--- a/networking.go
+++ b/networking.go
@@ -1,0 +1,128 @@
+package veneur
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// ResolveAddr takes a URL-style listen address specification,
+// resolves it and returns a net.Addr that corresponds to the
+// string. If any error (in URL decoding, destructuring or resolving)
+// occurs, ResolveAddr returns the respective error.
+//
+// Valid address examples are:
+//   udp6://127.0.0.1:8000
+//   unix:///tmp/foo.sock
+//   tcp://127.0.0.1:9002
+func ResolveAddr(str string) (net.Addr, error) {
+	u, err := url.Parse(str)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "unix", "unixgram", "unixpacket":
+		addr, err := net.ResolveUnixAddr(u.Scheme, u.Path)
+		if err != nil {
+			return nil, err
+		}
+		return addr, nil
+	case "tcp6", "tcp4", "tcp":
+		addr, err := net.ResolveTCPAddr(u.Scheme, u.Host)
+		if err != nil {
+			return nil, err
+		}
+		return addr, nil
+	case "udp6", "udp4", "udp":
+		addr, err := net.ResolveUDPAddr(u.Scheme, u.Host)
+		if err != nil {
+			return nil, err
+		}
+		return addr, nil
+	}
+	return nil, fmt.Errorf("unknown address family %q on address %q", u.Scheme, u.String())
+}
+
+// StartStatsd spawns a goroutine that listens for metrics in statsd
+// format on the address a. As this is a setup routine, if any error
+// occurs, it panics.
+func StartStatsd(s *Server, a net.Addr, packetPool *sync.Pool) {
+	switch addr := a.(type) {
+	case *net.UDPAddr:
+		startStatsdUDP(s, addr, packetPool)
+	case *net.TCPAddr:
+		startStatsdTCP(s, addr, packetPool)
+	default:
+		panic(fmt.Sprintf("Can't listen on %v: only TCP and UDP are supported", a))
+	}
+}
+
+func startStatsdUDP(s *Server, addr *net.UDPAddr, packetPool *sync.Pool) {
+	for i := 0; i < s.numReaders; i++ {
+		go func() {
+			defer func() {
+				ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+			}()
+			// each goroutine gets its own socket
+			// if the sockets support SO_REUSEPORT, then this will cause the
+			// kernel to distribute datagrams across them, for better read
+			// performance
+			sock, err := NewSocket(addr, s.RcvbufBytes, s.numReaders != 1)
+			if err != nil {
+				// if any goroutine fails to create the socket, we can't really
+				// recover, so we just blow up
+				// this probably indicates a systemic issue, eg lack of
+				// SO_REUSEPORT support
+				panic(fmt.Sprintf("couldn't listen on UDP socket %v: %v", addr, err))
+			}
+			log.WithField("address", addr).Info("Listening for statsd metrics on UDP socket")
+			s.ReadMetricSocket(sock, packetPool)
+		}()
+	}
+}
+
+func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) {
+	var listener net.Listener
+	var err error
+
+	listener, err = net.ListenTCP("tcp", addr)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't listen on TCP socket %v: %v", addr, err))
+	}
+
+	go func() {
+		<-s.shutdown
+		// TODO: the socket is in use until there are no goroutines blocked in Accept
+		// we should wait until the accepting goroutine exits
+		err := listener.Close()
+		if err != nil {
+			log.WithError(err).Warn("Ignoring error closing TCP listener")
+		}
+	}()
+
+	mode := "unencrypted"
+	if s.tlsConfig != nil {
+		// wrap the listener with TLS
+		listener = tls.NewListener(listener, s.tlsConfig)
+		if s.tlsConfig.ClientAuth == tls.RequireAndVerifyClientCert {
+			mode = "authenticated"
+		} else {
+			mode = "encrypted"
+		}
+	}
+
+	log.WithFields(logrus.Fields{
+		"address": addr, "mode": mode,
+	}).Info("Listening for statsd metrics on TCP socket")
+
+	go func() {
+		defer func() {
+			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+		}()
+		s.ReadTCPSocket(listener)
+	}()
+}

--- a/networking_test.go
+++ b/networking_test.go
@@ -1,0 +1,30 @@
+package veneur
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenAddr(t *testing.T) {
+	tests := []struct {
+		input   string
+		network string
+		laddr   string
+	}{
+		{"udp://127.0.0.1:8200", "udp", "127.0.0.1:8200"},
+		{"tcp://:8200", "tcp", ":8200"},
+		{"tcp6://[::1]:8200", "tcp", "[::1]:8200"},
+		{"unix:///tmp/foo.sock", "unix", "/tmp/foo.sock"},
+		{"unixgram:///tmp/foo.sock", "unixgram", "/tmp/foo.sock"},
+		{"unixpacket:///tmp/foo.sock", "unixpacket", "/tmp/foo.sock"},
+	}
+	for _, test := range tests {
+		addr, err := ResolveAddr(test.input)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		assert.Equal(t, test.network, addr.Network())
+		assert.Equal(t, test.laddr, addr.String(), "Address %#v not correct", addr)
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+
 	"math/rand"
 	"net"
 	"net/http"
@@ -81,17 +82,17 @@ func generateConfig(forwardAddr string) Config {
 		Hostname:           "localhost",
 
 		// Use a shorter interval for tests
-		Interval:            DefaultFlushInterval.String(),
-		Key:                 "",
-		MetricMaxLength:     4096,
-		Percentiles:         []float64{.5, .75, .99},
-		Aggregates:          []string{"min", "max", "count"},
-		ReadBufferSizeBytes: 2097152,
-		UdpAddress:          fmt.Sprintf("localhost:%d", metricsPort),
-		HTTPAddress:         fmt.Sprintf("localhost:%d", port),
-		ForwardAddress:      forwardAddr,
-		NumWorkers:          4,
-		FlushFile:           "",
+		Interval:              DefaultFlushInterval.String(),
+		Key:                   "",
+		MetricMaxLength:       4096,
+		Percentiles:           []float64{.5, .75, .99},
+		Aggregates:            []string{"min", "max", "count"},
+		ReadBufferSizeBytes:   2097152,
+		StatsdListenAddresses: []string{fmt.Sprintf("udp://localhost:%d", metricsPort)},
+		HTTPAddress:           fmt.Sprintf("localhost:%d", port),
+		ForwardAddress:        forwardAddr,
+		NumWorkers:            4,
+		FlushFile:             "",
 
 		// Use only one reader, so that we can run tests
 		// on platforms which do not support SO_REUSEPORT
@@ -661,13 +662,13 @@ func readTestKeysCerts() (map[string]string, error) {
 func TestTCPConfig(t *testing.T) {
 	config := localConfig()
 
-	config.TcpAddress = " invalid:invalid"
+	config.StatsdListenAddresses = []string{"tcp://invalid:invalid"}
 	_, err := NewFromConfig(config)
 	if err == nil {
 		t.Error("invalid TCP address is a config error")
 	}
 
-	config.TcpAddress = "localhost:8129"
+	config.StatsdListenAddresses = []string{"tcp://localhost:8129"}
 	config.TLSKey = "somekey"
 	config.TLSCertificate = ""
 	_, err = NewFromConfig(config)
@@ -688,12 +689,9 @@ func TestTCPConfig(t *testing.T) {
 
 	config.TLSKey = pems["serverkey.pem"]
 	config.TLSCertificate = pems["servercert.pem"]
-	s, err := NewFromConfig(config)
+	_, err = NewFromConfig(config)
 	if err != nil {
 		t.Error("expected valid config")
-	}
-	if s.TCPAddr == nil || s.TCPAddr.Port != 8129 {
-		t.Error("TCPAddr not set correctly:", s.TCPAddr)
 	}
 }
 
@@ -744,14 +742,15 @@ func TestUDPMetrics(t *testing.T) {
 	config := localConfig()
 	config.NumWorkers = 1
 	config.Interval = "60s"
-	config.UdpAddress = fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
+	addr := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
 	HTTPAddrPort++
+	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr)}
 	f := newFixture(t, config)
 	defer f.Close()
 	// Add a bit of delay to ensure things get listening
 	time.Sleep(20 * time.Millisecond)
 
-	conn, err := net.Dial("udp", config.UdpAddress)
+	conn, err := net.Dial("udp", addr)
 	assert.NoError(t, err)
 	defer conn.Close()
 
@@ -759,6 +758,35 @@ func TestUDPMetrics(t *testing.T) {
 	// Add a bit of delay to ensure things get processed
 	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, int64(1), f.server.Workers[0].MetricsProcessedCount(), "worker processed metric")
+}
+
+func TestMultipleUDPSockets(t *testing.T) {
+	config := localConfig()
+	config.NumWorkers = 1
+	config.Interval = "60s"
+	addr1 := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
+	HTTPAddrPort++
+	addr2 := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
+	HTTPAddrPort++
+	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr1), fmt.Sprintf("udp://%s", addr2)}
+	f := newFixture(t, config)
+	defer f.Close()
+	// Add a bit of delay to ensure things get listening
+	time.Sleep(20 * time.Millisecond)
+
+	conn, err := net.Dial("udp", addr1)
+	assert.NoError(t, err)
+	defer conn.Close()
+	conn.Write([]byte("foo.bar:1|c|#baz:gorch"))
+
+	conn2, err := net.Dial("udp", addr2)
+	assert.NoError(t, err)
+	defer conn2.Close()
+	conn2.Write([]byte("foo.bar:1|c|#baz:gorch"))
+
+	// Add a bit of delay to ensure things get processed
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, int64(2), f.server.Workers[0].MetricsProcessedCount(), "worker processed metric")
 }
 
 func TestUDPMetricsSSF(t *testing.T) {
@@ -798,14 +826,15 @@ func TestIgnoreLongUDPMetrics(t *testing.T) {
 	config.NumWorkers = 1
 	config.MetricMaxLength = 31
 	config.Interval = "60s"
-	config.UdpAddress = fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
+	addr := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
+	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr)}
 	HTTPAddrPort++
 	f := newFixture(t, config)
 	defer f.Close()
 	// Add a bit of delay to ensure things get listening
 	time.Sleep(20 * time.Millisecond)
 
-	conn, err := net.Dial("udp", config.UdpAddress)
+	conn, err := net.Dial("udp", addr)
 	assert.NoError(t, err)
 	defer conn.Close()
 
@@ -879,8 +908,9 @@ func TestTCPMetrics(t *testing.T) {
 		config := localConfig()
 		config.NumWorkers = 1
 		// Use a unique port to avoid race with shutting down accept goroutine on Linux
-		config.TcpAddress = fmt.Sprintf("localhost:%d", HTTPAddrPort)
+		addr := fmt.Sprintf("localhost:%d", HTTPAddrPort)
 		HTTPAddrPort++
+		config.StatsdListenAddresses = []string{fmt.Sprintf("tcp://%s", addr)}
 		config.TLSKey = serverConfig.serverKey
 		config.TLSCertificate = serverConfig.serverCertificate
 		config.TLSAuthorityCertificate = serverConfig.authorityCertificate
@@ -890,7 +920,7 @@ func TestTCPMetrics(t *testing.T) {
 		// attempt to connect and send stats with each of the client configurations
 		for i, clientConfig := range clientConfigs {
 			expectedSuccess := serverConfig.expectedConnectResults[i]
-			err := sendTCPMetrics(config.TcpAddress, clientConfig.tlsConfig, f)
+			err := sendTCPMetrics(addr, clientConfig.tlsConfig, f)
 			if err != nil {
 				if expectedSuccess {
 					t.Errorf("server config: '%s' client config: '%s' failed: %s",


### PR DESCRIPTION
#### Summary
This changes veneur's config handling to support an array of statsd socket addresses (given as URLs), rather than having a single `udp_socket` and optional `tcp_socket`. 

This allows us to better dispatch per-protocol/socket-type handling of behavior (fewer special-cased branches to support the TCP socket), allows users to configure veneur to listen on multiple ports, and sets us up for success in fixing #199 (-:

(This is a re-vived #231)

#### Motivation
This is lead-up work to tackling #199: I would like to get most of our networking strategy in a reasonable shape before introducing another socket family*protocol combination.


#### Test plan

Adjusted unit tests, they all pass!


#### Rollout/monitoring/revert plan

Some considerations: 

* This comes with a backwards-compatible config change, so we'll have to update docs/examples.
* Before rolling this to our infra, we should update our config files to use `statsd_listen_address` instead of `udp_socket`

