### PR TITLE
Reuse protobuf buffer to decrease memory use.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -414,3 +414,14 @@ func TestServiceCheckMessageUnescape(t *testing.T) {
 	assert.NoError(t, err, "Should have parsed correctly")
 	assert.Equal(t, "foo\nbar\nbaz\n", svcheck.Message, "Should contain newline")
 }
+
+func BenchmarkParseSSF(b *testing.B) {
+	trace := &ssf.SSFSpan{}
+
+	buff, err := proto.Marshal(trace)
+	assert.Nil(b, err)
+
+	for n := 0; n < b.N; n++ {
+		samplers.ParseSSF(buff)
+	}
+}

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -86,7 +86,9 @@ func ValidMetric(sample *UDPMetric) bool {
 
 // ParseSSF takes in a byte slice and returns:
 // an SSFSpan, slice of UDPMetrics, and an error.
-// It also validates packets before returning them.
+// It also validates packets before returning them. Note that this function
+// is not currently safe for concurrent use. If needed in the future,
+// have the caller pass in a `proto.Buffer`!
 func ParseSSF(packet []byte) (*ssf.SSFSpan, []*UDPMetric, error) {
 	sample := &ssf.SSFSpan{}
 	scratchBuff.Reset()

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -43,7 +43,9 @@ type MetricKey struct {
 	JoinedTags string `json:"tagstring"` // tags in deterministic order, joined with commas
 }
 
-// A reusable protobuf buffer, is not safe to use concurrently!
+// scratchBuff is a reusable protobuf buffer, such that repeated calls to
+// unmarshal protobuf spans don't make new buffers over and over. is not safe
+// to use concurrently!
 var scratchBuff = proto.NewBuffer(nil)
 
 // ToString returns a string representation of this MetricKey


### PR DESCRIPTION
#### Summary
Use a reusable buffer for unmarshaling spans.

#### Motivation
When inspecting the heap of a box with lots of spans, we noticed a lot of memory usage in decoding protobuf:

![screenshot 2017-08-25 08 44 54](https://user-images.githubusercontent.com/23101296/29721348-b87f7b36-8971-11e7-96b7-df65ab461a9b.png)

I did some digging and found that `proto.Buffer` [can be reused](https://github.com/gogo/protobuf/blob/6baa325bce8870eda968b8985b7d3e43d5cbd577/proto/lib.go#L303). I wrote a benchmark that — with `-benchmem` turned on — yields this:

Without buffer reuse:
`BenchmarkParseSSF-8   	 3000000	       507 ns/op	     384 B/op	       3 allocs/op`
With buffer reuse:
`BenchmarkParseSSF-8   	 3000000	       420 ns/op	     176 B/op	       2 allocs/op`

#### Test plan
Existing tests? Maybe add one that verifies two subsequent calls to `ParseSSF` don't screw anything up?

#### Rollout/monitoring/revert plan
Test out in QA

r? @aditya-stripe 

