### PR TITLE
Add Go 1.9 stable to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.8
+  - 1.9
   - tip
 
 install:
@@ -11,10 +12,10 @@ install:
   - rm protoc-3.1.0-linux-x86_64.zip
   # After 1.9 hits stable, replace this link
   # It is only used for gofmt
-  - wget https://storage.googleapis.com/golang/go1.9rc1.linux-amd64.tar.gz
-  - tar -C /tmp -xvf go1.9rc1.linux-amd64.tar.gz go/bin/gofmt
+  - wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+  - tar -C /tmp -xvf go1.9.linux-amd64.tar.gz go/bin/gofmt
   - sudo mv /tmp/go/bin/gofmt /usr/bin/gofmt
-  - rm go1.9rc1.linux-amd64.tar.gz
+  - rm go1.9.linux-amd64.tar.gz
 
 before_script:
   - go get -u github.com/ChimeraCoder/gojson/gojson


### PR DESCRIPTION
#### Summary

Add 1.9 to the Travis CI build matrix.



We're already using `golang:1.9` in our Docker image, though that gets cached until each machine is rebuilt. We have three options to switch to the latest release: pin to `1.9.0`, pin to a specific hash, or pin to `latest` (which always pulls in the latest updates, as you know, since you wrote that code). The last one doesn't sound like a particularly good idea for our uses here, but I don't feel strongly between the others.


#### Motivation

[Go 1.9 was released yesterday!](https://blog.golang.org/go1.9)



r? @cory-stripe 
