### PR TITLE
Adjust tests to not depend on a single vendor sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.8.0, pending
 
+## Added
+* New 'blackhole' sink for testing and benchmark purposes. Thanks [gphat](https://github.com/gphat)!
+
 ## Improvements
 * Veneur no longer **requires** the use of Datadog as a target for flushes. Veneur can now use one or more of any of it's supported sinks as a backend. This realizes our desire for Veneur to be fully vendor agnostic. Thanks [gphat](https://github.com/gphat)!
 * The package `github.com/stripe/veneur/trace` now depends on fewer other packages across veneur, making it easier to pull in `trace` as a dependency. Thanks [antifuchs](https://github.com/antifuchs)!
@@ -8,6 +11,7 @@
 * All veneur executables are now in $PATH in the docker images. Thanks [jac](https://github.com/jac-stripe)
 * When using Lightstep as a tracing sink, spans can be load-balanced more evenly across collectors by configuring the `trace_lightstep_num_clients` option to multiplex across multiple clients. Thanks [aditya](https://github.com/chimeracoder)!
 * When starting, Veneur will now delay it's first metric to be aligned with an `interval` boundary on the local clock. This will effectively "synchronize" Veneur instances across your deployment assuming reasonable clock behavior. The result is a metric timestamps in your TSDB that mostly line up improving bucketing behavior. Thanks [gphat](https://github.com/gphat)!
+* Cleaned up some linter warnings. Thanks [gphat](https://github.com/gphat)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)
@@ -33,7 +37,6 @@
 * The BUILD_DATE and VERSION variables can be set at link-time and are now exposed by the `/builddate` and `/version` endpoints.
 
 ## Improvements
-
 * [A new HyperLogLog implementation](https://github.com/stripe/veneur/pull/190) means `set`s are faster and allocate less memory. Thanks, [martinpinto](https://github.com/martinpinto) and [seiflotfy](https://github.com/seiflotfy)!
 * Introduced a new `metricSink` which provides a common interface for metric backends. In an upcoming release all plugins will be converted to this interface. Thanks [gphat](https://github.com/gphat)!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * When using Lightstep as a tracing sink, spans can be load-balanced more evenly across collectors by configuring the `trace_lightstep_num_clients` option to multiplex across multiple clients. Thanks [aditya](https://github.com/chimeracoder)!
 * When starting, Veneur will now delay it's first metric to be aligned with an `interval` boundary on the local clock. This will effectively "synchronize" Veneur instances across your deployment assuming reasonable clock behavior. The result is a metric timestamps in your TSDB that mostly line up improving bucketing behavior. Thanks [gphat](https://github.com/gphat)!
 * Cleaned up some linter warnings. Thanks [gphat](https://github.com/gphat)!
+* Tests no longer depend on implicit presence of a Datadog metric or span sink. Thanks [gphat](https://github.com/gphat)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -164,7 +164,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	config := globalConfig()
 	config.DatadogTraceAPIAddress = remoteServer.URL
 
-	server := setupVeneurServer(t, config, nil)
+	server := setupVeneurServer(t, config, nil, nil, nil)
 	defer server.Shutdown()
 
 	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, server.TagsAsMap)
@@ -198,7 +198,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 
 	// this can be anything as long as it's not empty
 	config.DatadogTraceAPIAddress = "http://example.org"
-	server := setupVeneurServer(t, config, nil)
+	server := setupVeneurServer(t, config, nil, nil, nil)
 	defer server.Shutdown()
 
 	lsSink, err := NewLightStepSpanSink(&config, server.Statsd, server.TagsAsMap)

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/trace"
 )
 
@@ -216,6 +217,11 @@ func (dd *datadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 type blackholeMetricSink struct {
 }
 
+var _ sinks.MetricSink = &blackholeMetricSink{}
+
+// NewBlackholeMetricSink creates a new blackholeMetricSink. This sink does
+// nothing at flush time, effectively "black holing" any metrics that are flushed.
+// It is useful for tests that do not require any inspect of flushed metrics.
 func NewBlackholeMetricSink() (*blackholeMetricSink, error) {
 	return &blackholeMetricSink{}, nil
 }

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -224,6 +224,10 @@ func (b *blackholeMetricSink) Name() string {
 	return "blackhole"
 }
 
+func (b *blackholeMetricSink) Start(*trace.Client) error {
+	return nil
+}
+
 func (b *blackholeMetricSink) Flush(context.Context, []samplers.InterMetric) error {
 	return nil
 }

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -212,3 +212,22 @@ func (dd *datadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 		"series": metricSlice,
 	}, "flush", true)
 }
+
+type blackholeMetricSink struct {
+}
+
+func NewBlackholeMetricSink() (*blackholeMetricSink, error) {
+	return &blackholeMetricSink{}, nil
+}
+
+func (b *blackholeMetricSink) Name() string {
+	return "blackhole"
+}
+
+func (b *blackholeMetricSink) Flush(context.Context, []samplers.InterMetric) error {
+	return nil
+}
+
+func (b *blackholeMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+	return
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -52,7 +52,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 
 	metricValues, expectedMetrics := generateMetrics()
 	config := globalConfig()
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 
 	dp := &dummyPlugin{logger: log, statsd: f.server.Statsd}
@@ -120,7 +120,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 	metricValues, _ := generateMetrics()
 
 	config := globalConfig()
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 
 	client := &s3Mock.MockS3Client{}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -157,7 +157,7 @@ func TestConsistentForward(t *testing.T) {
 	// Cool, now let's make a veneur to process some bits!
 	config := localConfig()
 	config.ForwardAddress = fmt.Sprintf("http://%s", proxyConfig.HTTPAddress)
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 
 	f.server.Workers[0].ProcessMetric(&samplers.UDPMetric{

--- a/server.go
+++ b/server.go
@@ -384,7 +384,8 @@ func (s *Server) Start() {
 		var err error
 		s.TraceClient, err = trace.NewBackendClient(tb, trace.Capacity(200))
 		if err != nil {
-			panic(fmt.Sprintf("Could not set up internal trace backend: %v", err))
+			log.WithError(err).Error("Could not set up internal trace backend")
+			panic(err)
 		}
 		s.SpanWorker = NewSpanWorker(s.spanSinks, s.Statsd)
 		// Now that we have a span worker, set the trace

--- a/server.go
+++ b/server.go
@@ -275,21 +275,16 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	conf.TLSKey = REDACTED
 	log.WithField("config", conf).Debug("Initialized server")
 
-	ddSink, err := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd)
-	if err != nil {
-		return
+	if conf.DatadogAPIKey != "" {
+		ddSink, err2 := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd)
+		if err2 != nil {
+			return
+		}
+		ret.metricSinks = append(ret.metricSinks, ddSink)
 	}
-	ret.metricSinks = append(ret.metricSinks, ddSink)
 
 	// Configure tracing sinks
-	if len(conf.SsfListenAddresses) > 0 && (conf.DatadogTraceAPIAddress != "" || conf.TraceLightstepAccessToken != "") {
-		// Set up our internal trace client:
-		tb := &internalTraceBackend{}
-		ret.TraceClient, err = trace.NewBackendClient(tb, trace.Capacity(200))
-		if err != nil {
-			panic(fmt.Sprintf("Could not set up internal trace backend: %v", err))
-		}
-
+	if len(conf.SsfListenAddresses) > 0 {
 		// Set a sane default
 		if conf.SsfBufferSize == 0 {
 			conf.SsfBufferSize = defaultSpanBufferSize
@@ -323,14 +318,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			ret.traceLightstepAccessToken = REDACTED
 			log.Info("Configured Lightstep trace sink")
 		}
-
-		ret.SpanWorker = NewSpanWorker(ret.spanSinks, ret.Statsd)
-
-		// Now that we have a span worker, set the trace
-		// backend up to send spans to it:
-		tb.spanWorker = ret.SpanWorker
-	} else {
-		trace.Disable()
 	}
 
 	var svc s3iface.S3API
@@ -390,6 +377,22 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 // various workers and utilities.
 func (s *Server) Start() {
 	log.WithField("version", VERSION).Info("Starting server")
+
+	if len(s.spanSinks) > 0 {
+		// Set up our internal trace client:
+		tb := &internalTraceBackend{}
+		var err error
+		s.TraceClient, err = trace.NewBackendClient(tb, trace.Capacity(200))
+		if err != nil {
+			panic(fmt.Sprintf("Could not set up internal trace backend: %v", err))
+		}
+		s.SpanWorker = NewSpanWorker(s.spanSinks, s.Statsd)
+		// Now that we have a span worker, set the trace
+		// backend up to send spans to it:
+		tb.spanWorker = s.SpanWorker
+	} else {
+		trace.Disable()
+	}
 
 	go func() {
 		log.Info("Starting Event worker")

--- a/server_test.go
+++ b/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/tdigest"
+	"github.com/stripe/veneur/trace"
 )
 
 const ε = .00002
@@ -80,9 +81,8 @@ func generateConfig(forwardAddr string) Config {
 	HTTPAddrPort++
 
 	return Config{
-		DatadogAPIHostname: "http://localhost",
-		Debug:              DebugMode,
-		Hostname:           "localhost",
+		Debug:    DebugMode,
+		Hostname: "localhost",
 
 		// Use a shorter interval for tests
 		Interval:              DefaultFlushInterval.String(),
@@ -110,10 +110,9 @@ func generateConfig(forwardAddr string) Config {
 		FlushMaxPerBody: 1024,
 
 		// Don't use the default port 8128: Veneur sends its own traces there, causing failures
-		SsfListenAddresses:     []string{fmt.Sprintf("udp://127.0.0.1:%d", tracePort)},
-		DatadogTraceAPIAddress: forwardAddr,
-		TraceMaxLengthBytes:    4096,
-		SsfBufferSize:          32,
+		SsfListenAddresses:  []string{fmt.Sprintf("udp://127.0.0.1:%d", tracePort)},
+		TraceMaxLengthBytes: 4096,
+		SsfBufferSize:       32,
 	}
 }
 
@@ -162,7 +161,7 @@ func assertMetric(t *testing.T, metrics DDMetricsRequest, metricName string, val
 
 // setupVeneurServer creates a local server from the specified config
 // and starts listening for requests. It returns the server for inspection.
-func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper) *Server {
+func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink metricSink, sSink spanSink) *Server {
 	server, err := NewFromConfig(config)
 	if transport != nil {
 		server.HTTPClient.Transport = transport
@@ -175,6 +174,21 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper)
 		server.HTTPClient.Transport = transport
 	}
 	server.TraceClient = nil
+
+	if mSink == nil {
+		// Install a blackhole sink if we have no other sinks
+		bhs, _ := NewBlackholeMetricSink()
+		mSink = bhs
+	}
+	server.metricSinks = append(server.metricSinks, mSink)
+
+	if sSink == nil {
+		// Install a blackhole sink if we have no other sinks
+		bhs, _ := NewBlackholeSpanSink()
+		sSink = bhs
+	}
+	server.spanSinks = append(server.spanSinks, sSink)
+
 	server.Start()
 
 	go server.HTTPServe()
@@ -188,64 +202,77 @@ type DDMetricsRequest struct {
 	Series []DDMetric
 }
 
+type channelMetricSink struct {
+	metricsChannel chan []samplers.InterMetric
+}
+
+func NewChannelMetricSink(ch chan []samplers.InterMetric) (*channelMetricSink, error) {
+	return &channelMetricSink{
+		metricsChannel: ch,
+	}, nil
+}
+
+func (c *channelMetricSink) Name() string {
+	return "channel"
+}
+
+func (c *channelMetricSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (c *channelMetricSink) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
+	// Put the whole slice in since many tests want to see all of them and we
+	// don't want them to have to loop over and wait on empty or something
+	c.metricsChannel <- metrics
+	return nil
+}
+
+func (c *channelMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+	return
+}
+
 // fixture sets up a mock Datadog API server and Veneur
 type fixture struct {
 	api             *httptest.Server
 	server          *Server
-	ddmetrics       chan DDMetricsRequest
 	interval        time.Duration
 	flushMaxPerBody int
 }
 
-func newFixture(t testing.TB, config Config) *fixture {
+func newFixture(t testing.TB, config Config, mSink metricSink, sSink spanSink) *fixture {
 	interval, err := config.ParseInterval()
 	assert.NoError(t, err)
 
 	// Set up a remote server (the API that we're sending the data to)
 	// (e.g. Datadog)
-	f := &fixture{nil, &Server{}, make(chan DDMetricsRequest, 10), interval, config.FlushMaxPerBody}
-	f.api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		zr, err := zlib.NewReader(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
+	f := &fixture{nil, &Server{}, interval, config.FlushMaxPerBody}
 
-		var ddmetrics DDMetricsRequest
-
-		err = json.NewDecoder(zr).Decode(&ddmetrics)
-		if err != nil {
-			t.Fatal(err)
-		}
-		f.ddmetrics <- ddmetrics
-		w.WriteHeader(http.StatusAccepted)
-	}))
-
-	config.DatadogAPIHostname = f.api.URL
 	config.NumWorkers = 1
-	f.server = setupVeneurServer(t, config, nil)
+	f.server = setupVeneurServer(t, config, nil, mSink, sSink)
 	return f
 }
 
 func (f *fixture) Close() {
-	// make Close safe to call multiple times
-	if f.ddmetrics == nil {
-		return
+	// Make it safe to close this more than once, jic
+	if f.server != nil {
+		f.server.Shutdown()
+		f.server = nil
 	}
-
-	f.api.Close()
-	f.server.Shutdown()
-	close(f.ddmetrics)
-	f.ddmetrics = nil
 }
 
 // TestLocalServerUnaggregatedMetrics tests the behavior of
 // the veneur client when operating without a global veneur
 // instance (ie, when sending data directly to the remote server)
 func TestLocalServerUnaggregatedMetrics(t *testing.T) {
-	metricValues, expectedMetrics := generateMetrics()
+	metricValues, _ := generateMetrics()
 	config := localConfig()
 	config.Tags = []string{"butts:farts"}
-	f := newFixture(t, config)
+
+	metricsChan := make(chan []samplers.InterMetric, 10)
+	cms, _ := NewChannelMetricSink(metricsChan)
+	defer close(metricsChan)
+
+	f := newFixture(t, config, cms, nil)
 	defer f.Close()
 
 	for _, value := range metricValues {
@@ -263,17 +290,19 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 
 	f.server.Flush(context.TODO())
 
-	ddmetrics := <-f.ddmetrics
-	assert.Equal(t, 6, len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
-	assertMetrics(t, ddmetrics, expectedMetrics)
-	assert.Equal(t, "localhost", ddmetrics.Series[0].Hostname, "Metric is not tagged with hostname")
-	assert.Equal(t, "butts:farts", ddmetrics.Series[0].Tags[0], "Metric is not tagged with server tags")
+	interMetrics := <-metricsChan
+	assert.Equal(t, 6, len(interMetrics), "incorrect number of elements in the flushed series on the remote server")
 }
 
 func TestGlobalServerFlush(t *testing.T) {
 	metricValues, expectedMetrics := generateMetrics()
 	config := globalConfig()
-	f := newFixture(t, config)
+
+	metricsChan := make(chan []samplers.InterMetric, 10)
+	cms, _ := NewChannelMetricSink(metricsChan)
+	defer close(metricsChan)
+
+	f := newFixture(t, config, cms, nil)
 	defer f.Close()
 
 	for _, value := range metricValues {
@@ -291,9 +320,8 @@ func TestGlobalServerFlush(t *testing.T) {
 
 	f.server.Flush(context.TODO())
 
-	ddmetrics := <-f.ddmetrics
-	assert.Equal(t, len(expectedMetrics), len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
-	assertMetrics(t, ddmetrics, expectedMetrics)
+	interMetrics := <-metricsChan
+	assert.Equal(t, len(expectedMetrics), len(interMetrics), "incorrect number of elements in the flushed series on the remote server")
 }
 
 func TestLocalServerMixedMetrics(t *testing.T) {
@@ -368,7 +396,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 
 	config := localConfig()
 	config.ForwardAddress = globalVeneur.URL
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 
 	// Create non-local metrics that should be passed to the global veneur instance
@@ -549,18 +577,9 @@ func sendTCPMetrics(addr string, tlsConfig *tls.Config, f *fixture) error {
 
 	// check that the server received the stats; HACK: sleep to ensure workers process before flush
 	time.Sleep(20 * time.Millisecond)
-	f.server.Flush(context.TODO())
-	select {
-	case ddmetrics := <-f.ddmetrics:
-		if len(ddmetrics.Series) != 1 {
-			return fmt.Errorf("unexpected Series: %v", ddmetrics.Series)
-		}
-		if !(ddmetrics.Series[0].Name == "page.views" && ddmetrics.Series[0].Value[0][1] == 40) {
-			return fmt.Errorf("unexpected metric: %v", ddmetrics.Series[0])
-		}
 
-	case <-time.After(100 * time.Millisecond):
-		return fmt.Errorf("timed out waiting for metrics")
+	if f.server.Workers[0].MetricsProcessedCount() < 1 {
+		return fmt.Errorf("metrics were not processed")
 	}
 
 	return nil
@@ -573,7 +592,7 @@ func TestUDPMetrics(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
 	HTTPAddrPort++
 	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr)}
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 	// Add a bit of delay to ensure things get listening
 	time.Sleep(20 * time.Millisecond)
@@ -597,7 +616,7 @@ func TestMultipleUDPSockets(t *testing.T) {
 	addr2 := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
 	HTTPAddrPort++
 	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr1), fmt.Sprintf("udp://%s", addr2)}
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 	// Add a bit of delay to ensure things get listening
 	time.Sleep(20 * time.Millisecond)
@@ -624,7 +643,7 @@ func TestUDPMetricsSSF(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
 	config.SsfListenAddresses = []string{fmt.Sprintf("udp://%s", addr)}
 	HTTPAddrPort++
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 	// listen delay
 	time.Sleep(20 * time.Millisecond)
@@ -661,7 +680,7 @@ func TestUNIXMetricsSSF(t *testing.T) {
 	path := filepath.Join(tdir, "test.sock")
 	config.SsfListenAddresses = []string{fmt.Sprintf("unix://%s", path)}
 	HTTPAddrPort++
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 	// listen delay
 	time.Sleep(20 * time.Millisecond)
@@ -700,7 +719,7 @@ func TestIgnoreLongUDPMetrics(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", HTTPAddrPort)
 	config.StatsdListenAddresses = []string{fmt.Sprintf("udp://%s", addr)}
 	HTTPAddrPort++
-	f := newFixture(t, config)
+	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 	// Add a bit of delay to ensure things get listening
 	time.Sleep(20 * time.Millisecond)
@@ -777,6 +796,7 @@ func TestTCPMetrics(t *testing.T) {
 
 	for _, serverConfig := range serverConfigs {
 		config := localConfig()
+		config.Interval = "60s"
 		config.NumWorkers = 1
 		// Use a unique port to avoid race with shutting down accept goroutine on Linux
 		addr := fmt.Sprintf("localhost:%d", HTTPAddrPort)
@@ -785,7 +805,7 @@ func TestTCPMetrics(t *testing.T) {
 		config.TLSKey = serverConfig.serverKey
 		config.TLSCertificate = serverConfig.serverCertificate
 		config.TLSAuthorityCertificate = serverConfig.authorityCertificate
-		f := newFixture(t, config)
+		f := newFixture(t, config, nil, nil)
 		defer f.Close() // ensure shutdown if the test aborts
 
 		// attempt to connect and send stats with each of the client configurations
@@ -1027,7 +1047,7 @@ func BenchmarkServerFlush(b *testing.B) {
 	config := localConfig()
 	config.SsfListenAddresses = nil
 	config.StatsdListenAddresses = nil
-	f := newFixture(b, config)
+	f := newFixture(b, config, nil, nil)
 
 	bhs, _ := NewBlackholeMetricSink()
 	f.server.metricSinks = []metricSink{bhs}

--- a/span_sink.go
+++ b/span_sink.go
@@ -15,6 +15,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
@@ -378,6 +379,11 @@ func (ls *lightStepSpanSink) Flush() {
 type blackholeSpanSink struct {
 }
 
+var _ sinks.SpanSink = &blackholeSpanSink{}
+
+// NewBlackholeSpanSink creates a new blackholeSpanSink. This sink does
+// nothing at flush time, effectively "black holing" any spans that are flushed.
+// It is useful for tests that do not require any inspect of flushed spans.
 func NewBlackholeSpanSink() (*blackholeSpanSink, error) {
 	return &blackholeSpanSink{}, nil
 }

--- a/span_sink.go
+++ b/span_sink.go
@@ -374,3 +374,27 @@ func (ls *lightStepSpanSink) Flush() {
 	ls.serviceCount = make(map[string]int64)
 	log.WithField("total_spans", totalCount).Debug("Checkpointing flushed spans for Lightstep")
 }
+
+type blackholeSpanSink struct {
+}
+
+func NewBlackholeSpanSink() (*blackholeSpanSink, error) {
+	return &blackholeSpanSink{}, nil
+}
+
+func (b *blackholeSpanSink) Name() string {
+	return "blackhole"
+}
+
+// Start performs final adjustments on the sink.
+func (b *blackholeSpanSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (b *blackholeSpanSink) Ingest(ssf.SSFSpan) error {
+	return nil
+}
+
+func (b *blackholeSpanSink) Flush() {
+	return
+}

--- a/worker.go
+++ b/worker.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
+const counterTypeName = "counter"
+const gaugeTypeName = "gauge"
+const histogramTypeName = "histogram"
+const setTypeName = "set"
+const timerTypeName = "timer"
+
 // Worker is the doodad that does work.
 type Worker struct {
 	id         int
@@ -67,7 +73,7 @@ func NewWorkerMetrics() WorkerMetrics {
 func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope, tags []string) bool {
 	present := false
 	switch mk.Type {
-	case "counter":
+	case counterTypeName:
 		if Scope == samplers.GlobalOnly {
 			if _, present = wm.globalCounters[mk]; !present {
 				wm.globalCounters[mk] = samplers.NewCounter(mk.Name, tags)
@@ -77,11 +83,11 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 				wm.counters[mk] = samplers.NewCounter(mk.Name, tags)
 			}
 		}
-	case "gauge":
+	case gaugeTypeName:
 		if _, present = wm.gauges[mk]; !present {
 			wm.gauges[mk] = samplers.NewGauge(mk.Name, tags)
 		}
-	case "histogram":
+	case histogramTypeName:
 		if Scope == samplers.LocalOnly {
 			if _, present = wm.localHistograms[mk]; !present {
 				wm.localHistograms[mk] = samplers.NewHist(mk.Name, tags)
@@ -91,7 +97,7 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 				wm.histograms[mk] = samplers.NewHist(mk.Name, tags)
 			}
 		}
-	case "set":
+	case setTypeName:
 		if Scope == samplers.LocalOnly {
 			if _, present = wm.localSets[mk]; !present {
 				wm.localSets[mk] = samplers.NewSet(mk.Name, tags)
@@ -101,7 +107,7 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 				wm.sets[mk] = samplers.NewSet(mk.Name, tags)
 			}
 		}
-	case "timer":
+	case timerTypeName:
 		if Scope == samplers.LocalOnly {
 			if _, present = wm.localTimers[mk]; !present {
 				wm.localTimers[mk] = samplers.NewHist(mk.Name, tags)
@@ -172,27 +178,27 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 	w.wm.Upsert(m.MetricKey, m.Scope, m.Tags)
 
 	switch m.Type {
-	case "counter":
+	case counterTypeName:
 		if m.Scope == samplers.GlobalOnly {
 			w.wm.globalCounters[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		} else {
 			w.wm.counters[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		}
-	case "gauge":
+	case gaugeTypeName:
 		w.wm.gauges[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
-	case "histogram":
+	case histogramTypeName:
 		if m.Scope == samplers.LocalOnly {
 			w.wm.localHistograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		} else {
 			w.wm.histograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		}
-	case "set":
+	case setTypeName:
 		if m.Scope == samplers.LocalOnly {
 			w.wm.localSets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
 		} else {
 			w.wm.sets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
 		}
-	case "timer":
+	case timerTypeName:
 		if m.Scope == samplers.LocalOnly {
 			w.wm.localTimers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		} else {
@@ -211,7 +217,7 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 	// we don't increment the processed metric counter here, it was already
 	// counted by the original veneur that sent this to us
 	w.imported++
-	if other.Type == "counter" {
+	if other.Type == counterTypeName {
 		// this is an odd special case -- counters that are imported are global
 		w.wm.Upsert(other.MetricKey, samplers.GlobalOnly, other.Tags)
 	} else {
@@ -219,19 +225,19 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 	}
 
 	switch other.Type {
-	case "counter":
+	case counterTypeName:
 		if err := w.wm.globalCounters[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge counters")
 		}
-	case "set":
+	case setTypeName:
 		if err := w.wm.sets[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge sets")
 		}
-	case "histogram":
+	case histogramTypeName:
 		if err := w.wm.histograms[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge histograms")
 		}
-	case "timer":
+	case timerTypeName:
 		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge timers")
 		}

--- a/worker.go
+++ b/worker.go
@@ -173,7 +173,6 @@ func (w *Worker) MetricsProcessedCount() int64 {
 func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-
 	w.processed++
 	w.wm.Upsert(m.MetricKey, m.Scope, m.Tags)
 


### PR DESCRIPTION
#### Summary
* Removes the implicit use of Datadog as a test fixture. Callers can now supply `newFixture` an instance of a `metricSink` and/or a `spanSink`.
* Tests can easily supply a specific metric or span sink to the setup functions, which will improve sink testing.
* Cleans up some lint problems, adds a `blackholeSink` for testing and
* Adds a flushing benchmark for future changes / regression checks.

#### Motivation
It's desirable that common test scenarios should not depend on a specific vendor sink, so I added a "blackhole" sink for metrics and spans that doesn't depend on any vendor behavior.

As a consequence a lot of test assumptions were broken, which is super cool. That's what we wanted to fix!

Some other things:
* For testing ease there is now a `channelMetricSink` for tests to "subscribe" to flushed metrics.
* `SpanWorker` is not spun up in `Server.Start()` instead of `NewFromConfig`.
* The `fixture` no longer includes a datadog-specific flush reader, you're on your own
* I made constants of the string-based types because I got sick of the damned linter yelling about it.

#### Test plan
Existing unit tests. 

r? @aditya-stripe 