### PR TITLE
Fix references to fields in backcompat code, add test

### DIFF
--- a/config_parse.go
+++ b/config_parse.go
@@ -122,7 +122,7 @@ func readConfig(r io.Reader) (c Config, err error) {
 			return
 		}
 		log.Warn("The config key `tcp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
-		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "tcp", Host: c.UdpAddress}).String())
+		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "tcp", Host: c.TcpAddress}).String())
 	}
 	c.StatsdListenAddresses = append(c.StatsdListenAddresses, moreAddrs...)
 

--- a/config_test.go
+++ b/config_test.go
@@ -41,10 +41,14 @@ func TestReadBadConfig(t *testing.T) {
 
 func TestReadConfigBackwardsCompatible(t *testing.T) {
 	// set the deprecated config options
-	const config = `api_hostname: "http://api"
+	const config = `
+api_hostname: "http://api"
 key: apikey
 trace_api_address: http://trace_api
-trace_address: trace_address:12345`
+trace_address: trace_address:12345
+udp_address: 127.0.0.1:8002
+tcp_address: 127.0.0.1:8003
+`
 	c, err := readConfig(strings.NewReader(config))
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +59,8 @@ trace_address: trace_address:12345`
 	assert.Equal(t, "apikey", c.DatadogAPIKey)
 	assert.Equal(t, "http://trace_api", c.DatadogTraceAPIAddress)
 	assert.Equal(t, "trace_address:12345", c.SsfAddress)
+	assert.Contains(t, c.StatsdListenAddresses, "udp://127.0.0.1:8002")
+	assert.Contains(t, c.StatsdListenAddresses, "tcp://127.0.0.1:8003")
 }
 
 func TestHostname(t *testing.T) {


### PR DESCRIPTION
#### Summary
Ooops, I made a mistake in the backwards compat code for tcp sockets: it used the udp socket address instead. This PR should fix that, and add a test!

#### Motivation
Bug intro'd in #233 /:


#### Test plan
Added tests to ensure this doesn't happen again (:


#### Rollout/monitoring/revert plan
Merge!

