### PR TITLE
Restructure SSF parsing in the sampler

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -116,7 +116,8 @@ func TestParseSSFInvalidTraceValidMetric(t *testing.T) {
 		}
 
 		span, err := msg.TraceSpan()
-		assert.Equal(t, samplers.ErrInvalidTrace, err)
+		_, isInvalid := err.(*samplers.InvalidTrace)
+		assert.True(t, isInvalid)
 		assert.Nil(t, span)
 	}
 }

--- a/regression_test.go
+++ b/regression_test.go
@@ -32,11 +32,17 @@ func TestTagNameSetNameNotSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Eror when marshalling sample")
 
-	newSample, metrics, errSSF := samplers.ParseSSF(buf)
-	assert.Equal(t, sample.Tags["name"], newSample.Name, "Name via Tag did not propogate")
-	assert.Zero(t, len(metrics))
-	assert.NoError(t, errSSF)
-	assert.Empty(t, newSample.Tags["name"])
+	msg, errSSF := samplers.ParseSSF(buf)
+	assert.NoError(t, err)
+	if assert.NotNil(t, msg) {
+		newSample, err := msg.TraceSpan()
+		assert.NoError(t, err)
+		if assert.NotNil(t, newSample) {
+			assert.Equal(t, sample.Tags["name"], newSample.Name, "Name via Tag did not propogate")
+			assert.NoError(t, errSSF)
+			assert.Empty(t, newSample.Tags["name"])
+		}
+	}
 }
 
 // Tests that setting a tag "Name" and span.Name won't change
@@ -51,11 +57,17 @@ func TestTagNameSetNameSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Error when marshalling sample")
 
-	newSample, metrics, errSSF := samplers.ParseSSF(buf)
-	assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
-	assert.Zero(t, len(metrics))
-	assert.NoError(t, errSSF)
-	assert.NotEmpty(t, newSample.Tags["name"])
+	msg, errSSF := samplers.ParseSSF(buf)
+	assert.NoError(t, err)
+	if assert.NotNil(t, msg) {
+		newSample, err := msg.TraceSpan()
+		assert.NoError(t, err)
+		if assert.NotNil(t, newSample) {
+			assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
+			assert.NoError(t, errSSF)
+			assert.NotEmpty(t, newSample.Tags["name"])
+		}
+	}
 }
 
 func TestNoTagName(t *testing.T) {
@@ -65,10 +77,16 @@ func TestNoTagName(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err)
 
-	newSample, metrics, errSSF := samplers.ParseSSF(buf)
-	assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
-	assert.Zero(t, len(metrics))
-	assert.NoError(t, errSSF)
+	msg, errSSF := samplers.ParseSSF(buf)
+	assert.NoError(t, err)
+	if assert.NotNil(t, msg) {
+		newSample, err := msg.TraceSpan()
+		assert.NoError(t, err)
+		if assert.NotNil(t, newSample) {
+			assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
+			assert.NoError(t, errSSF)
+		}
+	}
 }
 
 func TestOperation(t *testing.T) {
@@ -80,8 +98,14 @@ func TestOperation(t *testing.T) {
 	packet, err := ioutil.ReadAll(pb)
 	assert.NoError(t, err)
 
-	sample, metrics, errSSF := samplers.ParseSSF(packet)
+	msg, errSSF := samplers.ParseSSF(packet)
 	assert.NoError(t, errSSF)
-	assert.Zero(t, len(metrics))
-	assert.NotNil(t, sample)
+	if assert.NotNil(t, msg) {
+		sample, errSSF := msg.TraceSpan()
+		assert.NoError(t, err)
+		if assert.NotNil(t, sample) {
+			assert.NoError(t, errSSF)
+			assert.NotNil(t, sample)
+		}
+	}
 }

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -90,10 +90,8 @@ func (e *InvalidTrace) Error() string {
 }
 
 // TraceSpan checks if an SSF message is a valid trace. If so, it
-// normalizes the span in-place (infers a Name from a "name" tag, sets
-// Tags if none were given), and returns a pointer to that original
-// span. If the span is not a valid trace, TraceSpan returns nil and
-// an *InvalidTrace error type.
+// returns a pointer to that original span. If the span is not a valid
+// trace, TraceSpan returns nil and an *InvalidTrace error type.
 //
 // The span returned from TraceSpan does contain the (unparsed) metric
 // samples contained in the span. Note also that since the data

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -43,11 +44,6 @@ type MetricKey struct {
 	JoinedTags string `json:"tagstring"` // tags in deterministic order, joined with commas
 }
 
-// scratchBuff is a reusable protobuf buffer, such that repeated calls to
-// unmarshal protobuf spans don't make new buffers over and over. is not safe
-// to use concurrently!
-var scratchBuff = proto.NewBuffer(nil)
-
 // ToString returns a string representation of this MetricKey
 func (m *MetricKey) String() string {
 	var buff bytes.Buffer
@@ -65,11 +61,6 @@ func ValidTrace(sample *ssf.SSFSpan) bool {
 	ret = ret && sample.TraceId != 0
 	ret = ret && sample.StartTimestamp != 0
 	ret = ret && sample.EndTimestamp != 0
-
-	if sample.Tags == nil {
-		sample.Tags = make(map[string]string, 0)
-	}
-
 	return ret
 }
 
@@ -78,52 +69,127 @@ func ValidMetric(sample *UDPMetric) bool {
 	ret := true
 	ret = ret && sample.Name != ""
 	ret = ret && sample.Value != nil
-	if sample.SampleRate == 0 {
-		sample.SampleRate = 1
-	}
 	return ret
 }
 
-// ParseSSF takes in a byte slice and returns:
-// an SSFSpan, slice of UDPMetrics, and an error.
-// It also validates packets before returning them. Note that this function
-// is not currently safe for concurrent use. If needed in the future,
-// have the caller pass in a `proto.Buffer`!
-func ParseSSF(packet []byte) (*ssf.SSFSpan, []*UDPMetric, error) {
-	sample := &ssf.SSFSpan{}
-	scratchBuff.Reset()
+// A Message struct represents a parsed SSF message. It encapsulates
+// an ssf.SSFSpan object, which can contain a trace span and/or a set
+// of metrics.
+type Message struct {
+	span *ssf.SSFSpan
+}
+
+type errInvalidTrace string
+
+// ErrInvalidTrace indicates that an SSF span was invalid.
+const ErrInvalidTrace errInvalidTrace = "span did not validate"
+
+func (e errInvalidTrace) Error() string {
+	return string(e)
+}
+
+// TraceSpan checks if an SSF message is a valid trace. If so, it
+// normalizes the span in-place (infers a Name from a "name" tag, sets
+// Tags if none were given), and returns that span.  If the span is
+// not a valid trace, TraceSpan returns a nil span and
+// ErrInvalidTrace.
+//
+// The span returned from TraceSpan does contain the (unparsed) metric
+// samples contained in the span.
+func (m *Message) TraceSpan() (*ssf.SSFSpan, error) {
+	if !ValidTrace(m.span) {
+		return nil, ErrInvalidTrace
+	}
+	return m.span, nil
+}
+
+// Metrics examines an SSF message, parses and returns any
+// metrics contained inside. If any parse error occurs in processing
+// any of the metrics, ExtractMetrics collects them into the error
+// type InvalidMetrics and returns this error alongside any valid
+// metrics that could be parsed.
+func (m *Message) Metrics() ([]*UDPMetric, error) {
+	span := m.span
+	invalid := []*ssf.SSFSample{}
+	metrics := make([]*UDPMetric, 0)
+	for _, metricPacket := range span.Metrics {
+		metric, err := ParseMetricSSF(metricPacket)
+		if err != nil || !ValidMetric(metric) {
+			invalid = append(invalid, metricPacket)
+			continue
+		}
+		metrics = append(metrics, metric)
+	}
+	if len(invalid) != 0 {
+		return metrics, &invalidMetrics{invalid}
+	}
+	return metrics, nil
+}
+
+var pbufPool = sync.Pool{
+	New: func() interface{} {
+		return proto.NewBuffer(nil)
+	},
+}
+
+// ParseSSF takes in a byte slice and returns: a normalized SSFSpan
+// and an error if any errors in parsing the SSF packet occur.
+func ParseSSF(packet []byte) (*Message, error) {
+	span := &ssf.SSFSpan{}
+	scratchBuff := pbufPool.Get().(*proto.Buffer)
+	defer func() {
+		scratchBuff.Reset()
+		pbufPool.Put(scratchBuff)
+	}()
 	scratchBuff.SetBuf(packet)
-	err := scratchBuff.Unmarshal(sample)
+	err := scratchBuff.Unmarshal(span)
 
 	if err != nil {
-		return nil, nil, errors.New("unmarshal")
+		return nil, err
 	}
 
-	metrics := make([]*UDPMetric, 0)
-	for _, metricPacket := range sample.Metrics {
-		metric, err := ParseMetricSSF(metricPacket)
-		if err != nil {
-			return nil, nil, errors.New("parse")
-		}
-		if ValidMetric(metric) {
-			metrics = append(metrics, metric)
-		}
+	// Normalize the span:
+	if span.Tags == nil {
+		span.Tags = make(map[string]string, 0)
 	}
-
-	if !ValidTrace(sample) {
-		sample = nil
-	} else if sample.Name == "" {
+	if span.Name == "" {
 		// Even though incoming packets should have Name set,
 		// this allows Veneur to be backwards-compatible.
-		for k, v := range sample.Tags {
+		for k, v := range span.Tags {
 			if k == "name" {
-				sample.Name = v
+				span.Name = v
 			}
 		}
-		delete(sample.Tags, "name")
+		delete(span.Tags, "name")
 	}
 
-	return sample, metrics, nil
+	// Normalize metrics on the span:
+	for _, sample := range span.Metrics {
+		if sample.SampleRate == 0 {
+			sample.SampleRate = 1
+		}
+	}
+	return &Message{span}, nil
+}
+
+// InvalidMetrics is an error type returned if any metric could not be parsed.
+type InvalidMetrics interface {
+	error
+
+	// Samples returns any samples that couldn't be parsed or validated.
+	Samples() []*ssf.SSFSample
+}
+
+type invalidMetrics struct {
+	samples []*ssf.SSFSample
+}
+
+func (err *invalidMetrics) Error() string {
+	return fmt.Sprintf("parse errors on %d metrics", len(err.samples))
+}
+
+func (err *invalidMetrics) Samples() []*ssf.SSFSample {
+	return err.samples
 }
 
 // ParseMetricSSF converts an incoming SSF packet to a Metric.

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -151,7 +151,7 @@ func ParseSSF(packet []byte) (*Message, error) {
 
 	// Normalize the span:
 	if span.Tags == nil {
-		span.Tags = make(map[string]string, 0)
+		span.Tags = map[string]string{}
 	}
 	if span.Name == "" {
 		// Even though incoming packets should have Name set,

--- a/server.go
+++ b/server.go
@@ -544,7 +544,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 
 	span, err := msg.TraceSpan()
 	if err != nil {
-		if err != samplers.ErrInvalidTrace {
+		if _, ok := err.(*samplers.InvalidTrace); !ok {
 			log.WithError(err).Warn("Unexpected error extracting trace span from SSF Message")
 		}
 		return

--- a/server.go
+++ b/server.go
@@ -539,7 +539,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		}
 	}
 	for _, metric := range metrics {
-		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- *metric
+		s.Workers[metric.Digest%uint32(len(s.Workers))].PacketChan <- metric
 	}
 
 	span, err := msg.TraceSpan()


### PR DESCRIPTION
#### Summary
This PR cleans up the responsibilities of the `ParseSSF` function to really be just that, parsing (and a bit of normalizing).

Some more detailed list of changes:
- Break `ParseSSF` into three functional pieces: `ParseSSF`, then two methods `.Metrics` and `.TraceSpan`, which each return meaningful errors
- Replace the static scratch buffer with a pool of buffers for parsing, making the parse function data-race-safe(r?)
- Make `ValidMetric` and `ValidSpan` not in-place modify the span (which should make them data-race-safer too)

#### Motivation
The ParseSSF function did three jobs, and returned unclear error states for problems on each. Now, it only does one (parsing the SSF protobuf message) job, returning an opaque struct with methods that perform the metric and trace span extraction.

These methods return clearer errors now, which should help SSF-reading code to better understand what's going on.

#### Test plan

Adjusted tests.

#### Rollout/monitoring/revert plan

None (:

