### PR TITLE
[wip] start maintaining an internal count of time series produced per metric

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -425,6 +425,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 			jsonMetrics = append(jsonMetrics, jm)
 		}
 	}
+	// TODO (kiran) export the cardinalityCount.ExportSets()
 	s.Statsd.TimeInMilliseconds("forward.duration_ns", float64(time.Since(exportStart).Nanoseconds()), []string{"part:export"}, 1.0)
 
 	s.Statsd.Gauge("forward.post_metrics_total", float64(len(jsonMetrics)), nil, 1.0)

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -108,7 +108,7 @@ func (cc *CardinalityCount) Export() {
 }
 
 // Combine merges cardinality count structs exported from locals
-func (cc *CardinalityCount) Combine(other []byte) {
+func (cc *CardinalityCount) Combine(other []byte) error {
 	// TODO: deserialize `other`
 	var otherCC CardinalityCount
 	for name, hll := range otherCC.MetricCardinality {
@@ -118,6 +118,7 @@ func (cc *CardinalityCount) Combine(other []byte) {
 			cc.MetricCardinality[name] = hll
 		}
 	}
+	return nil
 }
 
 // Flush emits the names + cardinality of the top TEN in the map

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -100,9 +100,10 @@ func TestCardinalityMerge(t *testing.T) {
 	assert.Equal(t, uint64(100), cc.MetricCardinality["abc"].Count(), "counts did not match")
 	assert.Equal(t, uint64(150), cc.MetricCardinality["cde"].Count(), "counts did not match")
 
-	jm, err := cc.Export()
+	jsonMetrics, err := cc.ExportSets()
 	assert.NoError(t, err, "should have exported successfully")
-	assert.NotNil(t, jm, "Need a value")
+	assert.NotEmpty(t, jsonMetrics, "should have returned a value")
+	assert.NotNil(t, jsonMetrics[0], "Need a value")
 
 	cc2 := NewCardinalityCount()
 	for i := 0; i < 50; i++ {
@@ -112,7 +113,10 @@ func TestCardinalityMerge(t *testing.T) {
 		cc2.Sample("cde", strconv.Itoa(rand.Int()))
 	}
 
-	assert.NoError(t, cc2.Combine(jm.Value), "should have combined successfully")
+	for _, jm := range jsonMetrics {
+		assert.NoError(t, cc2.Combine(jm.Value), "should have combined successfully")
+	}
+
 	// // HLLs are approximate, and we've seen error of +-1 here in the past, so
 	// // we're giving the test some room for error to reduce flakes
 	receivedCount := int(cc2.MetricCardinality["abc"].Count())

--- a/worker.go
+++ b/worker.go
@@ -240,6 +240,10 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge timers")
 		}
+	case "cardinalitycount":
+		if err := w.wm.cardinality.Combine(other.Value); err != nil {
+			log.WithError(err).Error("Could not merge cardinality")
+		}
 	default:
 		log.WithField("type", other.Type).Error("Unknown metric type for importing")
 	}

--- a/worker.go
+++ b/worker.go
@@ -36,6 +36,9 @@ type WorkerMetrics struct {
 	sets       map[samplers.MetricKey]*samplers.Set
 	timers     map[samplers.MetricKey]*samplers.Histo
 
+	// metametrics -- these store information about the metrics themselves
+	cardinality *samplers.CardinalityCount
+
 	// this is for counters which are globally aggregated
 	globalCounters map[samplers.MetricKey]*samplers.Counter
 
@@ -54,6 +57,7 @@ func NewWorkerMetrics() WorkerMetrics {
 		histograms:      make(map[samplers.MetricKey]*samplers.Histo),
 		sets:            make(map[samplers.MetricKey]*samplers.Set),
 		timers:          make(map[samplers.MetricKey]*samplers.Histo),
+		cardinality:     samplers.NewCardinalityCount(),
 		localHistograms: make(map[samplers.MetricKey]*samplers.Histo),
 		localSets:       make(map[samplers.MetricKey]*samplers.Set),
 		localTimers:     make(map[samplers.MetricKey]*samplers.Histo),
@@ -200,6 +204,8 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 	default:
 		log.WithField("type", m.Type).Error("Unknown metric type for processing")
 	}
+	// record the metric's cardinality
+	w.wm.cardinality.Sample(m.MetricKey.Name, m.MetricKey.JoinedTags)
 }
 
 // ImportMetric receives a metric from another veneur instance

--- a/worker.go
+++ b/worker.go
@@ -240,7 +240,7 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge timers")
 		}
-	case "cardinalitycount":
+	case samplers.CardinalityCountType:
 		if err := w.wm.cardinality.Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge cardinality")
 		}

--- a/worker_test.go
+++ b/worker_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, log)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -52,7 +52,7 @@ func TestWorkerLocal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, log)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo", 1.0)
 	testset.Sample("bar", 1.0)
@@ -82,7 +82,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerImportCardinality(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, log)
 
 	cc := samplers.NewCardinalityCount()
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Maintain an internal count of time series produced by metric, which we then flush out to sinks.

Still to do:
- [ ] Ensure that the memory consumption is within bounds (and tune the precision)
- [ ] Determine the cardinality width of each type of metric and ensure that we account for this correctly
- [ ] Determine whether we'd only want to flush the top k highest metrics to Datadog

#### Motivation
<!-- Why are you making this change? -->
This lays down the groundwork for a few features:
- automatic cardinality management! (We could catch high-card metrics earlier!)
- this is now feasible because of the hyperloglogplus upgrade (https://github.com/stripe/veneur/pull/190)

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
- [ ] Automated tests

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
deploy veneur
