### PR TITLE
Listen on streaming UNIX domain sockets

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	SentryDsn                     string    `yaml:"sentry_dsn"`
 	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
+	SsfListenAddresses            []string  `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string    `yaml:"stats_address"`
 	StatsdListenAddresses         []string  `yaml:"statsd_listen_addresses"`
 	Tags                          []string  `yaml:"tags"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -106,14 +106,14 @@ func readConfig(r io.Reader) (c Config, err error) {
 		}
 	}
 
-	var moreAddrs []string
+	var statsdAddrs []string
 	if c.UdpAddress != "" {
 		if len(c.StatsdListenAddresses) > 0 {
 			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `udp_address` are both present")
 			return
 		}
 		log.Warn("The config key `udp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
-		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
+		statsdAddrs = append(statsdAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
 	}
 
 	if c.TcpAddress != "" {
@@ -122,9 +122,20 @@ func readConfig(r io.Reader) (c Config, err error) {
 			return
 		}
 		log.Warn("The config key `tcp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
-		moreAddrs = append(moreAddrs, (&url.URL{Scheme: "tcp", Host: c.TcpAddress}).String())
+		statsdAddrs = append(statsdAddrs, (&url.URL{Scheme: "tcp", Host: c.TcpAddress}).String())
 	}
-	c.StatsdListenAddresses = append(c.StatsdListenAddresses, moreAddrs...)
+	c.StatsdListenAddresses = append(c.StatsdListenAddresses, statsdAddrs...)
+
+	var ssfAddrs []string
+	if c.SsfAddress != "" {
+		if len(c.SsfListenAddresses) > 0 {
+			err = fmt.Errorf("`ssf_listen_addresses` and deprecated parameter `ssf_address` are both present")
+			return
+		}
+		log.Warn("The config key `ssf_address` is deprecated and replaced with entries in `ssf_listen_addresses` and will be removed in 2.0!")
+		ssfAddrs = append(statsdAddrs, (&url.URL{Scheme: "udp", Host: c.SsfAddress}).String())
+	}
+	c.SsfListenAddresses = append(c.SsfListenAddresses, ssfAddrs...)
 
 	return c, nil
 }

--- a/config_parse.go
+++ b/config_parse.go
@@ -133,7 +133,7 @@ func readConfig(r io.Reader) (c Config, err error) {
 			return
 		}
 		log.Warn("The config key `ssf_address` is deprecated and replaced with entries in `ssf_listen_addresses` and will be removed in 2.0!")
-		ssfAddrs = append(statsdAddrs, (&url.URL{Scheme: "udp", Host: c.SsfAddress}).String())
+		ssfAddrs = append(ssfAddrs, (&url.URL{Scheme: "udp", Host: c.SsfAddress}).String())
 	}
 	c.SsfListenAddresses = append(c.SsfListenAddresses, ssfAddrs...)
 

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -80,7 +80,18 @@ forward_address: "http://veneur.example.com"
 
 # SSF
 # The address on which we will listen for SSF packets via UDP
-ssf_address: "127.0.0.1:8128"
+# This option is DEPRECATED. Use ssf_listen_addresses instead.
+ssf_address: ""
+
+# The addresses on which to listen for SSF data. As with
+# statsd_listen_addresses, these are formatted as URLs, with schemes
+# corresponding to valid "network" arguments on
+# https://golang.org/pkg/net/#Listen. Currently, only UDP and Unix
+# domain sockets are supported.
+# This option supersedes the "ssf_address" option.
+ssf_listen_addresses:
+  - udp://localhost:8128
+  - unix:///tmp/veneur-ssf.sock
 
 # TRACING
 # The address on which we will listen for UDP trace data
@@ -110,12 +121,12 @@ statsd_listen_addresses:
 
 # The address on which to listen for metrics sent to this instance over UDP,
 # leave empty to disable.
-# This option is DEPRECATED, use statsd_listen_addresses instead.
-udp_address: "localhost:8126"
+# This option is DEPRECATED. Use statsd_listen_addresses instead.
+udp_address: ""
 
 # The address on which to listen for metrics sent to this instance over TCP,
 # leave empty to disable.
-# This option is DEPRECATED; use statsd_listen_addresses instead.
+# This option is DEPRECATED. Use statsd_listen_addresses instead.
 tcp_address: ""
 
 # == SINKS ==

--- a/config_test.go
+++ b/config_test.go
@@ -61,6 +61,7 @@ tcp_address: 127.0.0.1:8003
 	assert.Equal(t, "trace_address:12345", c.SsfAddress)
 	assert.Contains(t, c.StatsdListenAddresses, "udp://127.0.0.1:8002")
 	assert.Contains(t, c.StatsdListenAddresses, "tcp://127.0.0.1:8003")
+	assert.Contains(t, c.SsfListenAddresses, "udp://trace_address:12345")
 }
 
 func TestHostname(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -64,6 +64,21 @@ tcp_address: 127.0.0.1:8003
 	assert.Contains(t, c.SsfListenAddresses, "udp://trace_address:12345")
 }
 
+func TestReadSSFConfigBackwardsCompatible(t *testing.T) {
+	// set the deprecated config options
+	const config = `
+trace_api_address: http://trace_api
+ssf_address: trace_address:12345
+`
+	c, err := readConfig(strings.NewReader(config))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// they should get copied to the new config options
+	assert.Equal(t, c.SsfListenAddresses, []string{"udp://trace_address:12345"})
+}
+
 func TestHostname(t *testing.T) {
 	const hostnameConfig = "hostname: foo"
 	r := strings.NewReader(hostnameConfig)

--- a/http_test.go
+++ b/http_test.go
@@ -283,7 +283,7 @@ func TestNokTraceHealthCheck(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/healthcheck/tracing", nil)
 
 	config := localConfig()
-	config.SsfAddress = ""
+	config.SsfListenAddresses = []string{}
 	s := setupVeneurServer(t, config, nil)
 	defer s.Shutdown()
 	HTTPAddrPort++

--- a/networking.go
+++ b/networking.go
@@ -156,7 +156,7 @@ func startSSFUDP(s *Server, addr *net.UDPAddr, tracePool *sync.Pool) {
 		defer func() {
 			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
 		}()
-		s.ReadTraceSocket(listener, tracePool)
+		s.ReadSSFPacketSocket(listener, tracePool)
 	}()
 }
 

--- a/networking.go
+++ b/networking.go
@@ -181,7 +181,7 @@ func startSSFUnix(s *Server, addr *net.UnixAddr) {
 					log.WithError(err).Fatal("Unix accept failed")
 				}
 			}
-			go s.ReadTraceStream(conn)
+			go s.ReadSSFStreamSocket(conn)
 		}
 	}()
 }

--- a/networking.go
+++ b/networking.go
@@ -126,3 +126,34 @@ func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) {
 		s.ReadTCPSocket(listener)
 	}()
 }
+
+func StartSSF(s *Server, a net.Addr, tracePool *sync.Pool) {
+	switch addr := a.(type) {
+	case *net.UDPAddr:
+		startSSFUDP(s, addr, tracePool)
+	default:
+		panic(fmt.Sprintf("Can't listen for SSF on %v: only UDP is supported", a))
+	}
+	log.WithFields(logrus.Fields{
+		"address": a.String(),
+		"network": a.Network(),
+	}).Info("Listening for SSF traces")
+}
+
+func startSSFUDP(s *Server, addr *net.UDPAddr, tracePool *sync.Pool) {
+	// if we want to use multiple readers, make reuseport a parameter, like ReadMetricSocket.
+	listener, err := NewSocket(addr, s.RcvbufBytes, false)
+	if err != nil {
+		// if any goroutine fails to create the socket, we can't really
+		// recover, so we just blow up
+		// this probably indicates a systemic issue, eg lack of
+		// SO_REUSEPORT support
+		panic(fmt.Sprintf("couldn't listen on UDP socket %v: %v", addr, err))
+	}
+	go func() {
+		defer func() {
+			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+		}()
+		s.ReadTraceSocket(listener, tracePool)
+	}()
+}

--- a/server.go
+++ b/server.go
@@ -620,9 +620,10 @@ func (s *Server) ReadSSFPacketSocket(serverConn net.PacketConn, packetPool *sync
 	}
 }
 
-// ReadTraceStream reads a streaming connection in framed wire
-// format. See package github.com/stripe/veneur/protocol for details.
-func (s *Server) ReadTraceStream(serverConn net.Conn) {
+// ReadSSFStreamSocket reads a streaming connection in framed wire format
+// off a streaming socket. See package
+// github.com/stripe/veneur/protocol for details.
+func (s *Server) ReadSSFStreamSocket(serverConn net.Conn) {
 	defer func() {
 		serverConn.Close()
 	}()
@@ -653,6 +654,7 @@ func (s *Server) ReadTraceStream(serverConn net.Conn) {
 				1.0)
 			continue
 		}
+		// TODO: don't use statsd for this metric, use an in-memory counter.
 		s.Statsd.Incr("ssf.received_total", tags, .1)
 		s.handleSSF(msg, tags)
 	}

--- a/server.go
+++ b/server.go
@@ -587,8 +587,8 @@ func (s *Server) ReadMetricSocket(serverConn net.PacketConn, packetPool *sync.Po
 	}
 }
 
-// ReadTraceSocket listens for available packets to handle.
-func (s *Server) ReadTraceSocket(serverConn net.PacketConn, packetPool *sync.Pool) {
+// ReadSSFPacketSocket reads SSF packets off a packet connection.
+func (s *Server) ReadSSFPacketSocket(serverConn net.PacketConn, packetPool *sync.Pool) {
 	// TODO This is duplicated from ReadMetricSocket and feels like it could be it's
 	// own function?
 	p := packetPool.Get().([]byte)

--- a/server.go
+++ b/server.go
@@ -499,6 +499,7 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 // HandleTracePacket accepts an incoming packet as bytes and sends it to the
 // appropriate worker.
 func (s *Server) HandleTracePacket(packet []byte) {
+	// TODO: don't use statsd for this in favor of an in-memory counter
 	s.Statsd.Incr("ssf.received_total", nil, .1)
 	// Unlike metrics, protobuf shouldn't have an issue with 0-length packets
 	if len(packet) == 0 {

--- a/server_test.go
+++ b/server_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/protocol"
@@ -877,6 +877,17 @@ func TestNewFromServerConfigRenamedVariables(t *testing.T) {
 	assert.Equal(t, 99, addr.Port)
 }
 
+// This is necessary until we can import
+// github.com/sirupsen/logrus/test - it's currently failing due to dep
+// insisting on pulling the repo in with its capitalized name.
+//
+// TODO: Revisit once https://github.com/golang/dep/issues/433 is fixed
+func nullLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+	return logger
+}
+
 // BenchmarkSendSSFUNIX sends b.N metrics to veneur and waits until
 // all of them have been read (not processed).
 func BenchmarkSendSSFUNIX(b *testing.B) {
@@ -902,8 +913,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Simulate a metrics worker:
-	logger, _ := test.NewNullLogger()
-	w := NewWorker(0, nil, logger)
+	w := NewWorker(0, nil, nullLogger())
 	s.Workers = []*Worker{w}
 	go func() {
 	}()
@@ -978,8 +988,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	require.NoError(b, err)
 
 	// Simulate a metrics worker:
-	logger, _ := test.NewNullLogger()
-	w := NewWorker(0, nil, logger)
+	w := NewWorker(0, nil, nullLogger())
 	s.Workers = []*Worker{w}
 
 	go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -1015,7 +1015,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 			conn.Write(packet)
 		}
 	}()
-	go s.ReadTraceSocket(l, pool)
+	go s.ReadSSFPacketSocket(l, pool)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/server_test.go
+++ b/server_test.go
@@ -943,7 +943,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 	}()
 	sConn, err := l.Accept()
 	require.NoError(b, err)
-	go s.ReadTraceStream(sConn)
+	go s.ReadSSFStreamSocket(sConn)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/server_test.go
+++ b/server_test.go
@@ -647,6 +647,7 @@ func TestUNIXMetricsSSF(t *testing.T) {
 	config.Interval = "60s"
 	path := filepath.Join(tdir, "test.sock")
 	config.SsfListenAddresses = []string{fmt.Sprintf("unix://%s", path)}
+	HTTPAddrPort++
 	f := newFixture(t, config)
 	defer f.Close()
 	// listen delay


### PR DESCRIPTION
#### Summary
This PR adds functionality to listen for framed SSF messages on a UNIX domain socket, using the framed SSF reader from #244. Some additional things to make that listener work:

* make `protocol.ReadSSF` return `io.EOF` if it encounters an EOF at frame boundaries (EOFs otherwise are considered framing errors).
* change metrics emitted from SSF handling to `ssf.*` from `packet.*` (since they're no longer packets), but tag them with `ssf_format:packet` or `ssf_format:framed`

#### Motivation

This will let us buffer SSF data in clients, have less overhead in sending stuff, larger messages, and possibly fewer dropped packets in general.

#### Test plan

Added a test for reading SSF from the UNIX domain socket.

#### Rollout/monitoring/revert plan

This PR changes the names of SSF packet metrics-as-processed  to `ssf.*` from `packet.*`, so things graphing / monitoring metrics will have to be adjusted. I didn't do a double-writing scheme because these are still fairly new.

