### PR TITLE
Add prefix option for veneur-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * New [configuration option](https://github.com/stripe/veneur/pull/233) `statsd_listen_addresses`, a list of URIs indicating on which ports (and protocols) veneur should listen on for statsd metrics. This deprecates both the `udp_address` and `tcp_address` settings. Thanks [antifuchs](https://github.com/antifuchs)!
 * New package `github.com/stripe/veneur/protocol`, containing a wire protocol for sending/reading SSF over a streaming connection. Thanks [antifuchs](https://github.com/antifuchs)!
+* [veneur-prometheus](https://github.com/stripe/veneur/tree/master/cmd/veneur-prometheus) now has a `-p` option for specifying a prefix for all metrics. Thanks [gphat](https://github.com/gphat)!
 
 # 1.6.0, 2017-08-29
 

--- a/cmd/veneur-prometheus/README.md
+++ b/cmd/veneur-prometheus/README.md
@@ -15,6 +15,8 @@ Usage of ./veneur-prometheus:
     	The full URL — like 'http://localhost:9090/metrics' to query for Prometheus metrics. (default "http://localhost:9090/metrics")
   -i string
     	The interval at which to query. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration). (default "10s")
+  -p string
+    	A prefix to append to any metrics emitted. Do not include a trailing period.
   -s string
     	The host and port — like '127.0.0.1:8126' — to send our metrics to. (default "127.0.0.1:8126")
 ```

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -18,6 +18,7 @@ var (
 	debug       = flag.Bool("d", false, "Enable debug mode")
 	metricsHost = flag.String("h", "http://localhost:9090/metrics", "The full URL — like 'http://localhost:9090/metrics' to query for Prometheus metrics.")
 	interval    = flag.String("i", "10s", "The interval at which to query. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration).")
+	prefix      = flag.String("p", "", "A prefix to append to any metrics emitted. Do not include a trailing period.")
 	statsHost   = flag.String("s", "127.0.0.1:8126", "The host and port — like '127.0.0.1:8126' — to send our metrics to.")
 )
 
@@ -29,7 +30,6 @@ func main() {
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	logrus.Debug("HELLO")
 
 	i, err := time.ParseDuration(*interval)
 	if err != nil {
@@ -39,6 +39,10 @@ func main() {
 	ticker := time.NewTicker(i)
 	for _ = range ticker.C {
 		collect(c)
+	}
+
+	if *prefix != "" {
+		c.Namespace = *prefix
 	}
 }
 


### PR DESCRIPTION
#### Summary
Add a `-p` option that prefixes all metrics we output with a string.

#### Motivation
Some of the things we monitor do not do any sort of metric prefixing. This causes the metrics to collide, with stuff like `process_resident_memory_bytes` to be hard to differentiate in the TSDB.

By adding a prefix we scope the metric to a namespace and all is well.

#### Test plan
Didn't, as it's a function of the DD client library.

r? @stripe/observability 