### PR TITLE
Add ssf.packet_size and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * New [configuration option](https://github.com/stripe/veneur/pull/233) `statsd_listen_addresses`, a list of URIs indicating on which ports (and protocols) veneur should listen on for statsd metrics. This deprecates both the `udp_address` and `tcp_address` settings. Thanks [antifuchs](https://github.com/antifuchs)!
 * New package `github.com/stripe/veneur/protocol`, containing a wire protocol for sending/reading SSF over a streaming connection. Thanks [antifuchs](https://github.com/antifuchs)!
 * [veneur-prometheus](https://github.com/stripe/veneur/tree/master/cmd/veneur-prometheus) now has a `-p` option for specifying a prefix for all metrics. Thanks [gphat](https://github.com/gphat)!
+* New metrics `ssf.spans.tags_per_span` and `ssf.packet_size` track the distribution of tags per span and total packet sizes, respectively.
 
 # 1.6.0, 2017-08-29
 

--- a/server.go
+++ b/server.go
@@ -508,6 +508,8 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		return
 	}
 
+	s.Statsd.Histogram("ssf.packet_size", float64(len(packet)), nil, .1)
+
 	msg, err := samplers.ParseSSF(packet)
 	if err != nil {
 		reason := fmt.Sprintf("reason:%s", err.Error())
@@ -555,7 +557,7 @@ func (s *Server) handleSSF(msg *samplers.Message, tags []string) {
 	tags = append([]string{fmt.Sprintf("service:%s", span.Service)}, tags...)
 
 	s.Statsd.Incr("ssf.spans.received_total", tags, .1)
-	s.Statsd.Histogram("ssf.spans.tags", float64(len(span.Tags)), tags, .1)
+	s.Statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
 	s.SpanWorker.SpanChan <- *span
 }
 


### PR DESCRIPTION
#### Summary

* Add `ssf.packet_size`, so we know how close we are to bumping up against the MTU
* Includes entry for #253


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @cory-stripe 
cc @stripe/observability 