### PR TITLE
Use AddHook to avoid data race in tests

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -58,7 +58,7 @@ func NewProxyFromConfig(conf ProxyConfig) (p Proxy, err error) {
 	}
 	p.Hostname = hostname
 
-	log.Hooks.Add(sentryHook{
+	log.AddHook(sentryHook{
 		c:        p.Sentry,
 		hostname: hostname,
 		lv: []logrus.Level{

--- a/server.go
+++ b/server.go
@@ -185,7 +185,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	// condition in logrus discussed here:
 	// https://github.com/sirupsen/logrus/issues/295
 	if _, ok := log.Hooks[logrus.FatalLevel]; !ok {
-		log.Hooks.Add(sentryHook{
+		log.AddHook(sentryHook{
 			c:        ret.Sentry,
 			hostname: ret.Hostname,
 			lv: []logrus.Level{


### PR DESCRIPTION
#### Summary

This only manifests in tests, but we should avoid it. Could have sworn I fixed it on a different branch, but looks like I didn't.


#### Motivation
```
=== RUN   TestAllowStaticServices

==================

WARNING: DATA RACE

Write at 0x00c4200110e0 by goroutine 220:

  runtime.mapassign_fast32()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/runtime/hashmap_fast.go:422 +0x0

  github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus.LevelHooks.Add()

      /home/travis/gopath/src/github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus/hooks.go:20 +0x1a0

  github.com/stripe/veneur.NewProxyFromConfig()

      /home/travis/gopath/src/github.com/stripe/veneur/proxy.go:61 +0x1ce

  github.com/stripe/veneur.TestAllowStaticServices()

      /home/travis/gopath/src/github.com/stripe/veneur/proxy_test.go:103 +0x16f

  testing.tRunner()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:746 +0x16c

Previous read at 0x00c4200110e0 by goroutine 80:

  runtime.mapaccess1_fast32()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/runtime/hashmap_fast.go:12 +0x0

  github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus.LevelHooks.Fire()

      /home/travis/gopath/src/github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus/hooks.go:27 +0x50

  github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus.Entry.log()

      /home/travis/gopath/src/github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus/entry.go:98 +0x1ee

  github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus.(*Entry).Debug()

      /home/travis/gopath/src/github.com/stripe/veneur/vendor/github.com/Sirupsen/logrus/entry.go:134 +0x116

  github.com/stripe/veneur/plugins/s3.(*S3Plugin).Flush()

      /home/travis/gopath/src/github.com/stripe/veneur/plugins/s3/s3.go:55 +0x80e

  github.com/stripe/veneur.(*Server).FlushGlobal.func1()

      /home/travis/gopath/src/github.com/stripe/veneur/flusher.go:68 +0x2de

Goroutine 220 (running) created at:

  testing.(*T).Run()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:789 +0x568

  testing.runTests.func1()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:1004 +0xa7

  testing.tRunner()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:746 +0x16c

  testing.runTests()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:1002 +0x521

  testing.(*M).Run()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:921 +0x206

  github.com/stripe/veneur.TestMain()

      /home/travis/gopath/src/github.com/stripe/veneur/server_test.go:43 +0x13d

  main.main()

      github.com/stripe/veneur/_test/_testmain.go:224 +0x1cd

Goroutine 80 (running) created at:

  github.com/stripe/veneur.(*Server).FlushGlobal()

      /home/travis/gopath/src/github.com/stripe/veneur/flusher.go:65 +0x400

  github.com/stripe/veneur.(*Server).Flush()

      /home/travis/gopath/src/github.com/stripe/veneur/flusher.go:38 +0x1aa

  github.com/stripe/veneur.TestGlobalServerS3PluginFlush()

      /home/travis/gopath/src/github.com/stripe/veneur/plugin_test.go:168 +0xa09

  testing.tRunner()

      /home/travis/.gimme/versions/go1.9.linux.amd64/src/testing/testing.go:746 +0x16c

==================
```


#### Test plan
https://travis-ci.org/stripe/veneur/jobs/277405540


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @asf-stripe 