### PR TITLE
veneur-emit: Fix address spec parsing, drop -config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * New metrics `ssf.spans.tags_per_span` and `ssf.packet_size` track the distribution of tags per span and total packet sizes, respectively.
 * Our super spiffy logo, designed by [mercedes](https://github.com/mercedes-stripe), is now included at the top of the README!
 
+## Deprecations
+* `veneur-emit` no longer supports the `-config` argument, as it's no longer possible to reliably detect which statsd host/port to connect to. The `-hostport` option now takes a URL of the same form `statsd_listen_addresses` takes to explicitly tell it what address it should send to.
+
 # 1.6.0, 2017-08-29
 
 ## Added

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -87,7 +87,7 @@ func main() {
 		config = &conf
 	}
 
-	network, addr, err := addr(passedFlags, config, hostport, *toSSF)
+	addr, network, err := addr(passedFlags, config, hostport, *toSSF)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting destination address.")
 	}

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -91,13 +91,18 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting destination address.")
 	}
-	logrus.Debugf("destination: %s", addr)
+	logrus.WithField("net", network).
+		WithField("addr", addr).
+		Debugf("destination")
 
 	if *shellCommand {
 		var conn MinimalClient
 		conn, err = statsd.New(addr)
 		if err != nil {
-			logrus.WithError(err).Fatal("Error!")
+			logrus.WithError(err).
+				WithField("addr", addr).
+				WithField("network", network).
+				Fatal("Could not create statsd client")
 		}
 
 		var status int
@@ -112,7 +117,10 @@ func main() {
 			var nconn net.Conn
 			nconn, err = net.Dial(network, addr)
 			if err != nil {
-				logrus.WithError(err).Fatal("Error!")
+				logrus.WithError(err).
+					WithField("addr", addr).
+					WithField("network", network).
+					Fatal("Could not connect")
 			}
 
 			var span *ssf.SSFSpan
@@ -129,7 +137,10 @@ func main() {
 			var conn MinimalClient
 			conn, err = statsd.New(addr)
 			if err != nil {
-				logrus.WithError(err).Fatal("Error!")
+				logrus.WithError(err).
+					WithField("addr", addr).
+					WithField("network", network).
+					Fatal("Could not create statsd client")
 			}
 
 			tags := tags(*tag)

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/Sirupsen/logrus"
 	"github.com/gogo/protobuf/proto"
+	"github.com/stripe/veneur"
 	"github.com/stripe/veneur/ssf"
 )
 
@@ -190,7 +191,17 @@ func destination(passedFlags map[string]flag.Value, hostport *string, useSSF boo
 		addr = *hostport
 	} else {
 		err = errors.New("you must specify a valid hostport")
+		return
 	}
+	address, parseErr := veneur.ResolveAddr(addr)
+	if parseErr != nil {
+		// This is fine - we can attempt to treat the
+		// host:port combination as a UDP address.
+		return
+	}
+	// Looks like we got a listener spec URL, translate that into an address:
+	network = address.Network()
+	addr = address.String()
 	return addr, network, err
 }
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -87,7 +87,7 @@ func main() {
 		config = &conf
 	}
 
-	addr, network, err := addr(passedFlags, config, hostport, *toSSF)
+	addr, network, err := destination(passedFlags, config, hostport, *toSSF)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting destination address.")
 	}
@@ -193,7 +193,7 @@ func tags(tag string) []string {
 	return tags
 }
 
-func addr(passedFlags map[string]flag.Value, conf *veneur.Config, hostport *string, useSSF bool) (addr string, network string, err error) {
+func destination(passedFlags map[string]flag.Value, conf *veneur.Config, hostport *string, useSSF bool) (addr string, network string, err error) {
 	network = "udp"
 	if conf != nil && !useSSF && len(conf.StatsdListenAddresses) > 0 {
 		addrStr := conf.StatsdListenAddresses[0]

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/veneur"
 )
 
 var (
@@ -222,7 +221,7 @@ func TestHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testHostport := "host:port"
 	testFlag["hostport"] = newValue(testHostport)
-	addr, network, err := destination(testFlag, nil, &testHostport, false)
+	addr, network, err := destination(testFlag, &testHostport, false)
 	if addr != testHostport || network != "udp" || err != nil {
 		t.Errorf("Did not return hostport: %q/%q", network, addr)
 	}
@@ -230,26 +229,15 @@ func TestHostport(t *testing.T) {
 
 func TestNilHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, network, err := destination(testFlag, nil, nil, false)
+	addr, network, err := destination(testFlag, nil, false)
 	if addr != "" || network != "udp" || err == nil {
 		t.Error("Did not check for valid hostport.")
 	}
 }
 
-func TestConfig(t *testing.T) {
-	testFlag := make(map[string]flag.Value)
-	fakeConfig := &veneur.Config{}
-	fakeConfig.StatsdListenAddresses = []string{"udp://127.0.0.1:8200"}
-	testFlag["f"] = newValue("/pay/conf/veneur.yaml")
-	addr, network, err := destination(testFlag, fakeConfig, nil, false)
-	if addr != "127.0.0.1:8200" || network != "udp" || err != nil {
-		t.Errorf("Did not use config file for hostname and port: %q/%q", network, addr)
-	}
-}
-
 func TestNoAddr(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, network, err := destination(testFlag, nil, nil, false)
+	addr, network, err := destination(testFlag, nil, false)
 	if addr != "" || network != "udp" || err == nil {
 		t.Error("Returned non-empty address with no flags.")
 	}

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -222,7 +222,7 @@ func TestHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testHostport := "host:port"
 	testFlag["hostport"] = newValue(testHostport)
-	addr, network, err := addr(testFlag, nil, &testHostport, false)
+	addr, network, err := destination(testFlag, nil, &testHostport, false)
 	if addr != testHostport || network != "udp" || err != nil {
 		t.Errorf("Did not return hostport: %q/%q", network, addr)
 	}
@@ -230,7 +230,7 @@ func TestHostport(t *testing.T) {
 
 func TestNilHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, network, err := addr(testFlag, nil, nil, false)
+	addr, network, err := destination(testFlag, nil, nil, false)
 	if addr != "" || network != "udp" || err == nil {
 		t.Error("Did not check for valid hostport.")
 	}
@@ -241,7 +241,7 @@ func TestConfig(t *testing.T) {
 	fakeConfig := &veneur.Config{}
 	fakeConfig.StatsdListenAddresses = []string{"udp://127.0.0.1:8200"}
 	testFlag["f"] = newValue("/pay/conf/veneur.yaml")
-	addr, network, err := addr(testFlag, fakeConfig, nil, false)
+	addr, network, err := destination(testFlag, fakeConfig, nil, false)
 	if addr != "127.0.0.1:8200" || network != "udp" || err != nil {
 		t.Errorf("Did not use config file for hostname and port: %q/%q", network, addr)
 	}
@@ -249,7 +249,7 @@ func TestConfig(t *testing.T) {
 
 func TestNoAddr(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	addr, network, err := addr(testFlag, nil, nil, false)
+	addr, network, err := destination(testFlag, nil, nil, false)
 	if addr != "" || network != "udp" || err == nil {
 		t.Error("Returned non-empty address with no flags.")
 	}

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -219,12 +219,22 @@ func TestBadCalls(t *testing.T) {
 
 func TestHostport(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	testHostport := "host:port"
+	testHostport := "127.0.0.1:8200"
 	testFlag["hostport"] = newValue(testHostport)
 	addr, network, err := destination(testFlag, &testHostport, false)
-	if addr != testHostport || network != "udp" || err != nil {
-		t.Errorf("Did not return hostport: %q/%q", network, addr)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:8200", addr)
+	assert.Equal(t, "udp", network)
+}
+
+func TestHostportAsURL(t *testing.T) {
+	testFlag := make(map[string]flag.Value)
+	testHostport := "tcp://127.0.0.1:8200"
+	testFlag["hostport"] = newValue(testHostport)
+	addr, network, err := destination(testFlag, &testHostport, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:8200", addr)
+	assert.Equal(t, "tcp", network)
 }
 
 func TestNilHostport(t *testing.T) {


### PR DESCRIPTION
#### Summary
This change fixes the way veneur-emit parses host:port specs, and gets it ready for the new world in which `statsd_listening_addresses` are a thing by dropping `-config` and by giving `-hostport` the (backwards-compatible!) ability to understand these same listening URLs. It also improves some debug/fatal logging to make diagnosis of these config problems easier.

#### Motivation
As noted in #257, `-config` has lost a lot of utility / correctness, so we should remove it.

Also, `veneur-emit` was unusable due to the host:port destructuring bug.


#### Test plan
Adjusted tests and added a new one to validate that backwards compat is still working.


#### Rollout/monitoring/revert plan
We can just merge this and roll it out. We're not using `-config`, and the `-hostport` argument is backwards compatible.
