### PR TITLE
Add dd span sink test

### DIFF
--- a/span_sink_test.go
+++ b/span_sink_test.go
@@ -1,0 +1,23 @@
+package veneur
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDatadogSpanSinkConfig(t *testing.T) {
+	// test the variables that have been renamed
+	config := Config{
+		DatadogTraceAPIAddress: "http://trace",
+	}
+	stats, _ := statsd.NewBuffered(config.StatsAddress, 1024)
+	ddSink, err := NewDatadogSpanSink(&config, stats, &http.Client{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "http://trace", ddSink.traceAddress)
+}


### PR DESCRIPTION
#### Summary
Adds a cursory test for the Datadog span sink.

#### Motivation
There wasn't one!

#### Test plan
This is just a test.

r? @stripe/observability 