### PR TITLE
Make the UNIX domain socket connectable by everyone

### DIFF
--- a/networking.go
+++ b/networking.go
@@ -187,6 +187,10 @@ func startSSFUnix(s *Server, addr *net.UnixAddr) <-chan struct{} {
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't listen on UNIX socket %v: %v", addr, err))
 	}
+
+	// Make the socket connectable by everyone with access to the socket pathname:
+	os.Chmod(addr.String(), 0666)
+
 	go func() {
 		conns := make(chan net.Conn)
 		go func() {

--- a/networking.go
+++ b/networking.go
@@ -189,7 +189,10 @@ func startSSFUnix(s *Server, addr *net.UnixAddr) <-chan struct{} {
 	}
 
 	// Make the socket connectable by everyone with access to the socket pathname:
-	os.Chmod(addr.String(), 0666)
+	err = os.Chmod(addr.String(), 0666)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't set permissions on %v: %v", addr, err))
+	}
 
 	go func() {
 		conns := make(chan net.Conn)

--- a/networking_test.go
+++ b/networking_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"io/ioutil"
 	"os"
@@ -62,4 +63,54 @@ func TestMultipleListeners(t *testing.T) {
 	srv3.shutdown = make(chan struct{})
 	startSSFUnix(srv3, addr)
 	close(srv3.shutdown)
+}
+
+func TestConnectUNIX(t *testing.T) {
+	srv := &Server{}
+	srv.shutdown = make(chan struct{})
+
+	dir, err := ioutil.TempDir("", "unix-listener")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	addrNet, err := ResolveAddr(fmt.Sprintf("unix://%s/socket", dir))
+	require.NoError(t, err)
+	addr, ok := addrNet.(*net.UnixAddr)
+	require.True(t, ok)
+	startSSFUnix(srv, addr)
+
+	conns := make(chan struct{})
+	for i := 0; i < 5; i++ {
+		n := i
+		go func() {
+			// Dial the server, send it invalid data, wait
+			// for it to hang up:
+			c, err := net.DialUnix("unix", nil, addr)
+			assert.NoError(t, err, "Connecting %d", n)
+			wrote, err := c.Write([]byte("foo"))
+			if !assert.NoError(t, err, "Writing to %d", n) {
+				return
+			}
+			assert.Equal(t, 3, wrote, "Writing to %d", n)
+			assert.NotNil(t, c)
+
+			n, _ = c.Read(make([]byte, 20))
+			assert.Equal(t, 0, n)
+
+			err = c.Close()
+			assert.NoError(t, err)
+
+			conns <- struct{}{}
+		}()
+	}
+	timeout := time.After(3 * time.Second)
+	for i := 0; i < 5; i++ {
+		select {
+		case <-timeout:
+			t.Fatalf("Timed out waiting for connection, %d made it", i)
+		case <-conns:
+			// pass
+		}
+	}
+	close(srv.shutdown)
 }


### PR DESCRIPTION
#### Summary

Through an oversight veneur created its unix domain socket with perms 0755, which 1) assigns useless execute permissions and 2) doesn't let anyone connect who isn't the user running veneur. Since we can't safely use `umask` (it affects the entire process, and who knows what other things are running in parallel), this change does the next-best portable thing: It chmods after `ListenUnix` returns.

This PR also fixes a regression from the previous PR, where I lost a loop around the accept loop, which meant veneur only picked up the first connection. Very oops )-:

#### Test plan

- [x] added a test for connectability
- [x] Tests pass
- [x] try this to a non-production machine


#### Rollout/monitoring/revert plan
None.

