### PR TITLE
Bumps version of Go to 1.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.9.1
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build


### PR DESCRIPTION
#### Summary
Bumps our dependency from go-1.9 to go-1.9.1

#### Test plan
No tests added.
