### PR TITLE
Add support for Envoy and OpenTracing HTTP header formats

### DIFF
--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -18,14 +18,32 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
-// TraceIDHeader is the header for the trace id field
+// Lists the names of headers that a specification uses for representing trace information.
+type HeaderGroup struct {
+	TraceID  string
+	SpanID   string
+	ParentID string
+}
+
+var HeaderFormats = []HeaderGroup{
+	HeaderGroup{
+		TraceID:  "x-request-id",
+		SpanID:   "x-client-trace-id",
+		ParentID: "Parentid",
+	},
+	HeaderGroup{
+		TraceID:  "Trace-Id",
+		SpanID:   "Span-Id",
+		ParentID: "Parentid",
+	},
+	HeaderGroup{
+		TraceID:  "Traceid",
+		SpanID:   "Spanid",
+		ParentID: "Parentid",
+	},
+}
+
 const TraceIDHeader = "Traceid"
-
-// SpanIDHeader is the header for the span id field
-const SpanIDHeader = "Spanid"
-
-// ParentIDHeader is the header for the parent id field
-const ParentIDHeader = "Parentid"
 
 // GlobalTracer is the… global tracer!
 var GlobalTracer = Tracer{}
@@ -549,13 +567,28 @@ func (t Tracer) Extract(format interface{}, carrier interface{}) (ctx opentracin
 	}
 
 	if tm, ok := carrier.(opentracing.TextMapReader); ok {
-
 		// carrier is guaranteed to be an opentracing.TextMapReader by contract
 		// TODO support other TextMapReader implementations
-		traceID, err := strconv.ParseInt(textMapReaderGet(tm, TraceIDHeader), 10, 64)
-		spanID, err2 := strconv.ParseInt(textMapReaderGet(tm, SpanIDHeader), 10, 64)
-		parentID, err3 := strconv.ParseInt(textMapReaderGet(tm, ParentIDHeader), 10, 64)
-		if !(err == nil && err2 == nil && err3 == nil) {
+		parsedHeaders := false
+		var traceID int64
+		var spanID int64
+		var parentID int64
+		for _, headers := range HeaderFormats {
+			var err1 error
+			var err2 error
+			var err3 error
+			traceID, err1 = strconv.ParseInt(textMapReaderGet(tm, headers.TraceID), 10, 64)
+			spanID, err2 = strconv.ParseInt(textMapReaderGet(tm, headers.SpanID), 10, 64)
+			parentID, err3 = strconv.ParseInt(textMapReaderGet(tm, headers.ParentID), 10, 64)
+
+			fmt.Printf("%d ", traceID)
+
+			if err1 == nil && err2 == nil && err3 == nil {
+				parsedHeaders = true
+				break
+			}
+		}
+		if !parsedHeaders {
 			return nil, errors.New("error parsing fields from TextMapReader")
 		}
 

--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -37,6 +37,11 @@ var HeaderFormats = []HeaderGroup{
 		TraceID: "Trace-Id",
 		SpanID:  "Span-Id",
 	},
+	// Ruby format.
+	HeaderGroup{
+		TraceID: "X-Trace-Id",
+		SpanID:  "X-Span-Id",
+	},
 	// Veneur format.
 	HeaderGroup{
 		TraceID: "Traceid",
@@ -571,12 +576,10 @@ func (t Tracer) Extract(format interface{}, carrier interface{}) (ctx opentracin
 		var traceID int64
 		var spanID int64
 		for _, headers := range HeaderFormats {
-			var err1 error
-			var err2 error
-			traceID, err1 = strconv.ParseInt(textMapReaderGet(tm, headers.TraceID), 10, 64)
-			spanID, err2 = strconv.ParseInt(textMapReaderGet(tm, headers.SpanID), 10, 64)
+			traceID, _ = strconv.ParseInt(textMapReaderGet(tm, headers.TraceID), 10, 64)
+			spanID, _ = strconv.ParseInt(textMapReaderGet(tm, headers.SpanID), 10, 64)
 
-			if err1 == nil && err2 == nil {
+			if traceID != 0 && spanID != 0 {
 				parsedHeaders = true
 				break
 			}

--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -43,8 +43,6 @@ var HeaderFormats = []HeaderGroup{
 	},
 }
 
-const TraceIDHeader = "Traceid"
-
 // GlobalTracer is the… global tracer!
 var GlobalTracer = Tracer{}
 


### PR DESCRIPTION
#### Summary
When extracting a span, check for Envoy, OpenTracing, or Veneur HTTP headers (in that order). I also deleted the parent ID code from Extract.

#### Motivation
We don't have consensus on a single HTTP header format for transmitting tracing data. We need to check all of the different types we support.

#### Test plan
Unit tests.

#### Rollout/monitoring/revert plan
Not sure.

#### Questions for reviewer:
* Are there more test cases I should consider?
* Is it better to delete the parent ID extract code because it should never be used, or leave it in because we technically do have that data?