### PR TITLE
Allow non-networked `trace.Client`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 * Veneur no longer **requires** the use of Datadog as a target for flushes. Veneur can now use one or more of any of it's supported sinks as a backend. This realizes our desire for Veneur to be fully vendor agnostic. Thanks [gphat](https://github.com/gphat)!
 * The package `github.com/stripe/veneur/trace` now depends on fewer other packages across veneur, making it easier to pull in `trace` as a dependency. Thanks [antifuchs](https://github.com/antifuchs)!
+* A veneur server with tracing enabled now submits traces and spans concerning its own operation to itself internally without sending them over UDP. Thanks [antifuchs](https://github.com/antifuchs)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -62,6 +62,13 @@ func main() {
 	defer func() {
 		veneur.ConsumePanic(server.Sentry, server.Statsd, server.Hostname, recover())
 	}()
+
+	if server.TraceClient != nil {
+		if trace.DefaultClient != nil {
+			trace.DefaultClient.Close()
+		}
+		trace.DefaultClient = server.TraceClient
+	}
 	server.Start()
 
 	if conf.HTTPAddress != "" {

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -167,7 +167,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
 
-	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, server.TagsAsMap)
+	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, nil, server.TagsAsMap)
 
 	server.spanSinks = append(server.spanSinks, ddSink)
 
@@ -200,7 +200,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
 
-	lsSink, err := NewLightStepSpanSink(&config, server.Statsd, server.TagsAsMap)
+	lsSink, err := NewLightStepSpanSink(&config, server.Statsd, nil, server.TagsAsMap)
 	server.spanSinks = append(server.spanSinks, lsSink)
 
 	packet, err := ioutil.ReadAll(protobuf)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -169,6 +169,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 
 	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, nil, server.TagsAsMap)
 
+	server.TraceClient = nil
 	server.spanSinks = append(server.spanSinks, ddSink)
 
 	packet, err := ioutil.ReadAll(protobuf)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -167,7 +167,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
 
-	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, nil, server.TagsAsMap)
+	ddSink, err := NewDatadogSpanSink(&config, server.Statsd, server.HTTPClient, server.TagsAsMap)
 
 	server.TraceClient = nil
 	server.spanSinks = append(server.spanSinks, ddSink)
@@ -201,7 +201,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	server := setupVeneurServer(t, config, nil)
 	defer server.Shutdown()
 
-	lsSink, err := NewLightStepSpanSink(&config, server.Statsd, nil, server.TagsAsMap)
+	lsSink, err := NewLightStepSpanSink(&config, server.Statsd, server.TagsAsMap)
 	server.spanSinks = append(server.spanSinks, lsSink)
 
 	packet, err := ioutil.ReadAll(protobuf)

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -35,6 +35,7 @@ type datadogMetricSink struct {
 	statsd          *statsd.Client
 	tags            []string
 	interval        float64
+	traceClient     *trace.Client
 }
 
 // DDMetric is a data structure that represents the JSON that Datadog
@@ -50,7 +51,7 @@ type DDMetric struct {
 }
 
 // NewDatadogMetricSink creates a new Datadog sink for trace spans.
-func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Client, stats *statsd.Client) (*datadogMetricSink, error) {
+func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Client, stats *statsd.Client, traceClient *trace.Client) (*datadogMetricSink, error) {
 	return &datadogMetricSink{
 		HTTPClient:      httpClient,
 		statsd:          stats,
@@ -60,6 +61,7 @@ func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Cli
 		tags:            config.Tags,
 		ddHostname:      config.DatadogAPIHostname,
 		apiKey:          config.DatadogAPIKey,
+		traceClient:     traceClient,
 	}, nil
 }
 

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -70,7 +70,7 @@ func (dd *datadogMetricSink) Name() string {
 
 func (dd *datadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.InterMetric) error {
 	span, _ := trace.StartSpanFromContext(ctx, "")
-	defer span.Finish()
+	defer span.ClientFinish(dd.traceClient)
 
 	metrics := dd.finalizeMetrics(interMetrics)
 
@@ -101,7 +101,7 @@ func (dd *datadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.
 
 func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
-	defer span.Finish()
+	defer span.ClientFinish(dd.traceClient)
 
 	// fill in the default hostname for packets that didn't set it
 	for i := range events {
@@ -122,7 +122,7 @@ func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []sam
 		// the official dd-agent
 		// we don't actually pass all the body keys that dd-agent passes here... but
 		// it still works
-		err := postHelper(context.TODO(), dd.HTTPClient, dd.statsd, fmt.Sprintf("%s/intake?api_key=%s", dd.ddHostname, dd.apiKey), map[string]map[string][]samplers.UDPEvent{
+		err := postHelper(context.TODO(), dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/intake?api_key=%s", dd.ddHostname, dd.apiKey), map[string]map[string][]samplers.UDPEvent{
 			"events": {
 				"api": events,
 			},
@@ -140,7 +140,7 @@ func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []sam
 		// this endpoint is not documented to take an array... but it does
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
-		err := postHelper(context.TODO(), dd.HTTPClient, dd.statsd, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.ddHostname, dd.apiKey), checks, "flush_checks", false)
+		err := postHelper(context.TODO(), dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.ddHostname, dd.apiKey), checks, "flush_checks", false)
 		if err == nil {
 			log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
@@ -211,7 +211,7 @@ func (dd *datadogMetricSink) finalizeMetrics(metrics []samplers.InterMetric) []D
 
 func (dd *datadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetric, wg *sync.WaitGroup) {
 	defer wg.Done()
-	postHelper(ctx, dd.HTTPClient, dd.statsd, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.ddHostname, dd.apiKey), map[string][]DDMetric{
+	postHelper(ctx, dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.ddHostname, dd.apiKey), map[string][]DDMetric{
 		"series": metricSlice,
 	}, "flush", true)
 }

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -57,7 +57,7 @@ type DDMetric struct {
 }
 
 // NewDatadogMetricSink creates a new Datadog sink for trace spans.
-func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Client, stats *statsd.Client, traceClient *trace.Client) (*datadogMetricSink, error) {
+func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Client, stats *statsd.Client) (*datadogMetricSink, error) {
 	return &datadogMetricSink{
 		HTTPClient:      httpClient,
 		statsd:          stats,

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -114,7 +114,6 @@ func (dd *datadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.
 
 func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
-	defer log.Printf("Flushing event checks with %#v", dd.traceClient)
 	defer span.ClientFinish(dd.traceClient)
 
 	// fill in the default hostname for packets that didn't set it

--- a/metric_sink_test.go
+++ b/metric_sink_test.go
@@ -21,7 +21,7 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		StatsAddress: "localhost:62251",
 	}
 	stats, _ := statsd.NewBuffered(config.StatsAddress, 1024)
-	ddSink, err := NewDatadogMetricSink(&config, float64(10.0), &http.Client{}, stats, nil)
+	ddSink, err := NewDatadogMetricSink(&config, float64(10.0), &http.Client{}, stats)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metric_sink_test.go
+++ b/metric_sink_test.go
@@ -21,7 +21,7 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		StatsAddress: "localhost:62251",
 	}
 	stats, _ := statsd.NewBuffered(config.StatsAddress, 1024)
-	ddSink, err := NewDatadogMetricSink(&config, float64(10.0), &http.Client{}, stats)
+	ddSink, err := NewDatadogMetricSink(&config, float64(10.0), &http.Client{}, stats, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -308,7 +308,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// this endpoint is not documented to take an array... but it does
 			// another curious constraint of this endpoint is that it does not
 			// support "Content-Encoding: deflate"
-			err = postHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, endpoint, batch, "flush_traces", false)
+			err = postHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "flush_traces", false)
 
 			if err == nil {
 				log.WithFields(logrus.Fields{
@@ -373,7 +373,7 @@ func (p *Proxy) doPost(wg *sync.WaitGroup, destination string, batch []samplers.
 		return
 	}
 
-	err = postHelper(context.TODO(), p.HTTPClient, p.Statsd, endpoint, batch, "forward", true)
+	err = postHelper(context.TODO(), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "forward", true)
 	if err == nil {
 		log.WithField("metrics", batchSize).Debug("Completed forward to upstream Veneur")
 	} else {

--- a/proxy.go
+++ b/proxy.go
@@ -47,6 +47,7 @@ type Proxy struct {
 
 	usingConsul     bool
 	enableProfiling bool
+	traceClient     *trace.Client
 }
 
 func NewProxyFromConfig(conf ProxyConfig) (p Proxy, err error) {
@@ -126,6 +127,7 @@ func NewProxyFromConfig(conf ProxyConfig) (p Proxy, err error) {
 		}
 		log.WithField("interval", conf.ConsulRefreshInterval).Info("Will use Consul for service discovery")
 	}
+	p.traceClient = trace.DefaultClient
 
 	// TODO Size of replicas in config?
 	//ret.ForwardDestinations.NumberOfReplicas = ???

--- a/proxy.go
+++ b/proxy.go
@@ -282,7 +282,7 @@ func (p *Proxy) Handler() http.Handler {
 
 func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 	span, _ := trace.StartSpanFromContext(ctx, "veneur.opentracing.proxy.proxy_traces")
-	defer span.Finish()
+	defer span.ClientFinish(p.traceClient)
 
 	tracesByDestination := make(map[string][]*DatadogTraceSpan)
 	for _, h := range p.TraceDestinations.Members() {
@@ -333,7 +333,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 // HTTP requests by MetricKey using the hash ring.
 func (p *Proxy) ProxyMetrics(ctx context.Context, jsonMetrics []samplers.JSONMetric) {
 	span, _ := trace.StartSpanFromContext(ctx, "veneur.opentracing.proxy.proxy_metrics")
-	defer span.Finish()
+	defer span.ClientFinish(p.traceClient)
 
 	jsonMetricsByDestination := make(map[string][]samplers.JSONMetric)
 	for _, h := range p.ForwardDestinations.Members() {

--- a/server.go
+++ b/server.go
@@ -313,7 +313,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		if ret.traceLightstepAccessToken != "" {
 
 			var lsSink spanSink
-			lsSink, err = NewLightStepSpanSink(&conf, ret.Statsd, ret.TagsAsMap)
+			lsSink, err = NewLightStepSpanSink(&conf, ret.Statsd, ret.TraceClient, ret.TagsAsMap)
 			if err != nil {
 				return
 			}

--- a/server.go
+++ b/server.go
@@ -275,12 +275,6 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	conf.TLSKey = REDACTED
 	log.WithField("config", conf).Debug("Initialized server")
 
-	ddSink, err := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd)
-	if err != nil {
-		return
-	}
-	ret.metricSinks = append(ret.metricSinks, ddSink)
-
 	// Configure tracing sinks
 	if len(conf.SsfListenAddresses) > 0 && (conf.DatadogTraceAPIAddress != "" || conf.TraceLightstepAccessToken != "") {
 		// Set up our internal trace client:
@@ -332,6 +326,12 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	} else {
 		trace.Disable()
 	}
+
+	ddSink, err := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd, ret.TraceClient)
+	if err != nil {
+		return
+	}
+	ret.metricSinks = append(ret.metricSinks, ddSink)
 
 	var svc s3iface.S3API
 	awsID := conf.AwsAccessKeyID

--- a/server.go
+++ b/server.go
@@ -431,12 +431,14 @@ func (s *Server) Start() {
 	}
 
 	for _, sink := range s.spanSinks {
+		logrus.WithField("sink", sink.Name()).Info("Starting span sink")
 		if err := sink.Start(s.TraceClient); err != nil {
 			logrus.WithError(err).WithField("sink", sink).Fatal("Error starting span sink")
 		}
 	}
 
 	for _, sink := range s.metricSinks {
+		logrus.WithField("sink", sink.Name()).Info("Starting metric sink")
 		if err := sink.Start(s.TraceClient); err != nil {
 			logrus.WithError(err).WithField("sink", sink).Fatal("Error starting metric sink")
 		}

--- a/server.go
+++ b/server.go
@@ -275,7 +275,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	conf.TLSKey = REDACTED
 	log.WithField("config", conf).Debug("Initialized server")
 
-	ddSink, err := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd, ret.TraceClient)
+	ddSink, err := NewDatadogMetricSink(&conf, ret.interval.Seconds(), ret.HTTPClient, ret.Statsd)
 	if err != nil {
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -166,7 +166,7 @@ func setupVeneurServer(t *testing.T, config Config, transport http.RoundTripper)
 	if transport != nil {
 		server.HTTPClient.Transport = transport
 	}
-
+	server.TraceClient = nil
 	server.Start()
 
 	go server.HTTPServe()

--- a/span_sink.go
+++ b/span_sink.go
@@ -45,10 +45,11 @@ type datadogSpanSink struct {
 	stats        *statsd.Client
 	commonTags   map[string]string
 	traceAddress string
+	traceClient  *trace.Client
 }
 
 // NewDatadogSpanSink creates a new Datadog sink for trace spans.
-func NewDatadogSpanSink(config *Config, stats *statsd.Client, httpClient *http.Client, commonTags map[string]string) (*datadogSpanSink, error) {
+func NewDatadogSpanSink(config *Config, stats *statsd.Client, httpClient *http.Client, traceClient *trace.Client, commonTags map[string]string) (*datadogSpanSink, error) {
 	return &datadogSpanSink{
 		HTTPClient:   httpClient,
 		bufferSize:   config.SsfBufferSize,
@@ -57,6 +58,7 @@ func NewDatadogSpanSink(config *Config, stats *statsd.Client, httpClient *http.C
 		stats:        stats,
 		commonTags:   commonTags,
 		traceAddress: config.DatadogTraceAPIAddress,
+		traceClient:  traceClient,
 	}, nil
 }
 

--- a/span_sink.go
+++ b/span_sink.go
@@ -182,7 +182,7 @@ func (dd *datadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := postHelper(context.TODO(), dd.HTTPClient, dd.stats, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false)
+		err := postHelper(context.TODO(), dd.HTTPClient, dd.stats, dd.traceClient, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false)
 
 		if err == nil {
 			log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")

--- a/span_sink.go
+++ b/span_sink.go
@@ -345,9 +345,12 @@ func (ls *lightStepSpanSink) Ingest(ssfSpan ssf.SSFSpan) error {
 	}
 
 	endTime := time.Unix(ssfSpan.EndTimestamp/1e9, ssfSpan.EndTimestamp%1e9)
-	sp.ClientFinishWithOptions(sp.traceClient, opentracing.FinishOptions{
-		FinishTime: endTime,
-	})
+	finishOpts := opentracing.FinishOptions{FinishTime: endTime}
+	if sp, ok := sp.(*trace.Span); ok {
+		sp.ClientFinishWithOptions(ls.traceClient, finishOpts)
+	} else {
+		sp.FinishWithOptions(finishOpts)
+	}
 
 	service := ssfSpan.Service
 	if service == "" {

--- a/span_sink_test.go
+++ b/span_sink_test.go
@@ -14,7 +14,7 @@ func TestNewDatadogSpanSinkConfig(t *testing.T) {
 		DatadogTraceAPIAddress: "http://trace",
 	}
 	stats, _ := statsd.NewBuffered(config.StatsAddress, 1024)
-	ddSink, err := NewDatadogSpanSink(&config, stats, &http.Client{}, nil)
+	ddSink, err := NewDatadogSpanSink(&config, stats, &http.Client{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/span_sink_test.go
+++ b/span_sink_test.go
@@ -14,7 +14,11 @@ func TestNewDatadogSpanSinkConfig(t *testing.T) {
 		DatadogTraceAPIAddress: "http://trace",
 	}
 	stats, _ := statsd.NewBuffered(config.StatsAddress, 1024)
-	ddSink, err := NewDatadogSpanSink(&config, stats, &http.Client{}, nil, nil)
+	ddSink, err := NewDatadogSpanSink(&config, stats, &http.Client{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ddSink.Start(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/trace/backend.go
+++ b/trace/backend.go
@@ -43,6 +43,27 @@ func (p *backendParams) params() *backendParams {
 	return p
 }
 
+// ClientBackend represents the ability of a client to transport SSF
+// spans to a veneur server.
+type ClientBackend interface {
+	io.Closer
+
+	// SendSync synchronously sends a span to an upstream
+	// veneur.
+	//
+	// On a networked connection, if it encounters a protocol
+	// error in sending, it must loop forever, backing off by
+	// n*the backoff interval (until it reaches the maximal
+	// backoff interval) and tries to reconnect. If SendSync
+	// encounters any non-protocol errors (e.g. in serializing the
+	// SSF span), it must return them without reconnecting.
+	SendSync(ctx context.Context, span *ssf.SSFSpan) error
+
+	// FlushSync causes all (potentially) buffered data to be sent to
+	// the upstream veneur.
+	FlushSync(ctx context.Context) error
+}
+
 // backend is a structure that can send an SSF span to a destination
 // over a persistent connection, handling reconnections. When
 // encountering connection errors, a backend will automatically attempt
@@ -56,23 +77,10 @@ func (p *backendParams) params() *backendParams {
 // losing that span if there are connection problems, such as veneurs
 // getting restarted.
 type backend interface {
-	io.Closer
+	ClientBackend
 
 	params() *backendParams
 	connection(net.Conn)
-
-	// sendSync synchronously sends a span to an upstream
-	// veneur. If it encounters a protocol error in sending, it
-	// must loop forever, backing off by n*the backoff interval
-	// (until it reaches the maximal backoff interval) and tries
-	// to reconnect. If sendSync encounters any non-protocol
-	// errors (e.g. in serializing the SSF span), it must return
-	// them without reconnecting.
-	sendSync(ctx context.Context, span *ssf.SSFSpan) error
-
-	// flushSync causes all (potentially) buffered data to be sent to
-	// the upstream veneur.
-	flushSync(ctx context.Context) error
 }
 
 // packetBackend represents a UDP connection to a veneur server. It
@@ -93,7 +101,7 @@ func (s *packetBackend) Close() error {
 	return s.conn.Close()
 }
 
-func (s *packetBackend) sendSync(ctx context.Context, span *ssf.SSFSpan) error {
+func (s *packetBackend) SendSync(ctx context.Context, span *ssf.SSFSpan) error {
 	if s.conn == nil {
 		if err := connect(ctx, s); err != nil {
 			return err
@@ -108,8 +116,8 @@ func (s *packetBackend) sendSync(ctx context.Context, span *ssf.SSFSpan) error {
 	return err
 }
 
-// flushSync on a PacketStream is a no-op.
-func (s *packetBackend) flushSync(context.Context) error {
+// FlushSync on a PacketStream is a no-op.
+func (s *packetBackend) FlushSync(context.Context) error {
 	return nil
 }
 
@@ -179,11 +187,11 @@ func (ds *streamBackend) connection(conn net.Conn) {
 	}
 }
 
-// sendSync on a DirectStream attempts to write the packet on the
+// SendSync on a DirectStream attempts to write the packet on the
 // connection to the upstream veneur directly. If it encounters a
-// protocol error, sendSync will return the original protocol error once
+// protocol error, SendSync will return the original protocol error once
 // the connection is re-established.
-func (ds *streamBackend) sendSync(ctx context.Context, span *ssf.SSFSpan) error {
+func (ds *streamBackend) SendSync(ctx context.Context, span *ssf.SSFSpan) error {
 	if ds.conn == nil {
 		if err := connect(ctx, ds); err != nil {
 			return err
@@ -206,10 +214,10 @@ func (ds *streamBackend) Close() error {
 	return ds.conn.Close()
 }
 
-// flushSync on a DirectStream flushes the buffer if one exists. If the
-// connection was disconnected prior to flushing, flushSync re-establishes
+// FlushSync on a DirectStream flushes the buffer if one exists. If the
+// connection was disconnected prior to flushing, FlushSync re-establishes
 // it and discards the buffer.
-func (ds *streamBackend) flushSync(ctx context.Context) error {
+func (ds *streamBackend) FlushSync(ctx context.Context) error {
 	if ds.buffer == nil {
 		return nil
 	}

--- a/trace/backend.go
+++ b/trace/backend.go
@@ -36,7 +36,6 @@ type backendParams struct {
 	maxBackoff     time.Duration
 	connectTimeout time.Duration
 	bufferSize     uint
-	cap            uint
 }
 
 func (p *backendParams) params() *backendParams {
@@ -64,19 +63,20 @@ type ClientBackend interface {
 	FlushSync(ctx context.Context) error
 }
 
-// backend is a structure that can send an SSF span to a destination
-// over a persistent connection, handling reconnections. When
-// encountering connection errors, a backend will automatically attempt
-// to reconnect and blocks until reconnecting succeeds.
+// networkBackend is a structure that can send an SSF span to a
+// destination over a persistent connection, handling
+// reconnections. When encountering connection errors, a
+// networkBackend will automatically attempt to reconnect and blocks
+// until reconnecting succeeds.
 //
 // Data loss / resiliency to failure
 //
-// If a backend encounters an error sending a span, it should discard
-// the span and attempt to reconnect. This is intended to make the
-// backend resilient against "poison pill" spans, at the cost of
-// losing that span if there are connection problems, such as veneurs
-// getting restarted.
-type backend interface {
+// If a networkBackend encounters an error sending a span, it should
+// discard the span and attempt to reconnect. This is intended to make
+// the networkBackend resilient against "poison pill" spans, at the
+// cost of losing that span if there are connection problems, such as
+// veneurs getting restarted.
+type networkBackend interface {
 	ClientBackend
 
 	params() *backendParams
@@ -121,7 +121,7 @@ func (s *packetBackend) FlushSync(context.Context) error {
 	return nil
 }
 
-var _ backend = &packetBackend{}
+var _ networkBackend = &packetBackend{}
 
 // streamBackend is a backend for streaming connections.
 type streamBackend struct {
@@ -131,7 +131,7 @@ type streamBackend struct {
 	buffer *bufio.Writer
 }
 
-func connect(ctx context.Context, s backend) error {
+func connect(ctx context.Context, s networkBackend) error {
 	dialer := net.Dialer{}
 
 	params := s.params()
@@ -236,4 +236,4 @@ func (ds *streamBackend) FlushSync(ctx context.Context) error {
 	return err
 }
 
-var _ backend = &streamBackend{}
+var _ networkBackend = &streamBackend{}

--- a/trace/client.go
+++ b/trace/client.go
@@ -72,6 +72,8 @@ func (c *Client) run(ctx context.Context) {
 // client creation.
 type ClientParam func(*Client) error
 
+// ErrClientNotNetworked indicates that the client being constructed
+// does not support options relevant only to networked clients.
 var ErrClientNotNetworked = fmt.Errorf("client is not using a network backend")
 
 // Capacity indicates how many spans a client's channel should

--- a/trace/client.go
+++ b/trace/client.go
@@ -77,7 +77,7 @@ type ClientParam func(*Client) error
 var ErrClientNotNetworked = fmt.Errorf("client is not using a network backend")
 
 // Capacity indicates how many spans a client's channel should
-// accomodate. This parameter can be used on both generic and
+// accommodate. This parameter can be used on both generic and
 // networked backends.
 func Capacity(n uint) ClientParam {
 	return func(cl *Client) error {


### PR DESCRIPTION
#### Summary

This PR adds the ability to define non-networked `Client`s, which will allow us to report traces and metrics inside veneur without going over the network.

- [x] This still needs to hook veneur itself into this, could probably integrate into #228.

One thing that this doesn't do is figure out how to make the trace destination configurable. I think this is fairly optional at the moment, but in the long run, we may want a way to tell veneur to send spans to a thing that's not itself directly (as having tracing disabled at the moment means that it doesn't record spans at all, which is a change in behavior from before).

#### Motivation

It seems displeasing that the way we report spans to veneur from veneur is to send serialized spans over UDP to the address that is just happens to listen on; it's a bit wasteful to serialize/deserialize, and occupies network resources that other clients could use. This change should ensure that we not only process the metrics in a more efficient way (in-memory!), but also to set us up for things like testing-only clients.

#### Test plan
I wrote a unit test to ensure guarantees like the backpressure-via-errors are preserved. Probably needs more tests.

#### Rollout/monitoring/revert plan

Should only need a merge.
