### PR TITLE
If the hostname isn't configured, don't attempt to send to Datadog

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -294,6 +294,11 @@ func (s *Server) flushRemote(ctx context.Context, finalMetrics []samplers.DDMetr
 		return
 	}
 
+	if s.DDHostname == "" {
+		log.Debug("Datadog api not configured, skipping.")
+		return
+	}
+
 	// break the metrics into chunks of approximately equal size, such that
 	// each chunk is less than the limit
 	// we compute the chunks using rounding-up integer division


### PR DESCRIPTION
#### Summary
If you're using a plugin to sink metrics to another place and don't want to use datadog, removing the datadog hostname from the config results in an error every time a flush happens. This change just short-circuits the datadog metrics flushing when there is no DDHostname defined in the config.

#### Motivation
I want to use Veneur and the InfluxDB sink without using the Datadog service, therefore I would like to be able to omit the datadog hostname and expect it to not to attempt to datadog in that case.


#### Test plan
I have tested this by verifying that the application no longer attempts to connect when the config setting is missing. 

*I couldn't figure out how to automate the testing for this, I'm open to suggestions* 😄


#### Rollout/monitoring/revert plan
There are no changes needed for existing usage of the veneur server. This is a fix for anyone that doesn't have a datadog hostname defined in their config. 