### PR TITLE
Update gogo codegen output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ before_script:
   - go get -u github.com/ChimeraCoder/gojson/gojson
   - go get -u github.com/golang/protobuf/protoc-gen-go
   - go get -u github.com/gogo/protobuf/protoc-gen-gofast
+  - pushd $GOPATH/src/github.com/gogo/protobuf/
+  - git checkout v0.5
+  - popd
+  - go install github.com/gogo/protobuf/protoc-gen-gofast
   - go get -u github.com/golang/dep/cmd/dep
   - go get -u golang.org/x/tools/cmd/stringer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get install -y zip
 RUN go get -u -v github.com/ChimeraCoder/gojson/gojson
 RUN go get -u -v github.com/golang/protobuf/protoc-gen-go
 RUN go get -u -v github.com/gogo/protobuf/protoc-gen-gofast
+RUN cd $GOPATH/src/github.com/gogo/protobuf/ && git checkout v0.5
+RUN go install github.com/gogo/protobuf/protoc-gen-gofast
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u -v golang.org/x/tools/cmd/stringer
 RUN wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip

--- a/ssf/sample.pb.go
+++ b/ssf/sample.pb.go
@@ -17,6 +17,8 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import encoding_binary "encoding/binary"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -360,7 +362,8 @@ func (m *SSFSample) MarshalTo(dAtA []byte) (int, error) {
 	if m.Value != 0 {
 		dAtA[i] = 0x1d
 		i++
-		i = encodeFixed32Sample(dAtA, i, uint32(math.Float32bits(float32(m.Value))))
+		encoding_binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Value))))
+		i += 4
 	}
 	if m.Timestamp != 0 {
 		dAtA[i] = 0x20
@@ -381,7 +384,8 @@ func (m *SSFSample) MarshalTo(dAtA []byte) (int, error) {
 	if m.SampleRate != 0 {
 		dAtA[i] = 0x3d
 		i++
-		i = encodeFixed32Sample(dAtA, i, uint32(math.Float32bits(float32(m.SampleRate))))
+		encoding_binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.SampleRate))))
+		i += 4
 	}
 	if len(m.Tags) > 0 {
 		for k, _ := range m.Tags {
@@ -518,24 +522,6 @@ func (m *SSFSpan) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func encodeFixed64Sample(dAtA []byte, offset int, v uint64) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	dAtA[offset+4] = uint8(v >> 32)
-	dAtA[offset+5] = uint8(v >> 40)
-	dAtA[offset+6] = uint8(v >> 48)
-	dAtA[offset+7] = uint8(v >> 56)
-	return offset + 8
-}
-func encodeFixed32Sample(dAtA []byte, offset int, v uint32) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	return offset + 4
-}
 func encodeVarintSample(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -736,11 +722,8 @@ func (m *SSFSample) Unmarshal(dAtA []byte) error {
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
 			}
+			v = uint32(encoding_binary.LittleEndian.Uint32(dAtA[iNdEx:]))
 			iNdEx += 4
-			v = uint32(dAtA[iNdEx-4])
-			v |= uint32(dAtA[iNdEx-3]) << 8
-			v |= uint32(dAtA[iNdEx-2]) << 16
-			v |= uint32(dAtA[iNdEx-1]) << 24
 			m.Value = float32(math.Float32frombits(v))
 		case 4:
 			if wireType != 0 {
@@ -817,11 +800,8 @@ func (m *SSFSample) Unmarshal(dAtA []byte) error {
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
 			}
+			v = uint32(encoding_binary.LittleEndian.Uint32(dAtA[iNdEx:]))
 			iNdEx += 4
-			v = uint32(dAtA[iNdEx-4])
-			v |= uint32(dAtA[iNdEx-3]) << 8
-			v |= uint32(dAtA[iNdEx-2]) << 16
-			v |= uint32(dAtA[iNdEx-1]) << 24
 			m.SampleRate = float32(math.Float32frombits(v))
 		case 8:
 			if wireType != 2 {


### PR DESCRIPTION
#### Summary
A new version of [gogo protobuf]() was released and it [switches to `binary/encoding` rather than using `unsafe` for `fixed32` and `fixed64` values. 

#### Motivation
This causes our tests to fail due to codegen differences.

#### Test plan
Existing test coverage.

r? @aditya-stripe 