### PR TITLE
Optionally enable SO_REUSEPORT in SSF listening

### DIFF
--- a/networking.go
+++ b/networking.go
@@ -107,8 +107,9 @@ func StartSSF(s *Server, a net.Addr, tracePool *sync.Pool) {
 }
 
 func startSSFUDP(s *Server, addr *net.UDPAddr, tracePool *sync.Pool) {
-	// if we want to use multiple readers, make reuseport a parameter, like ReadMetricSocket.
-	listener, err := NewSocket(addr, s.RcvbufBytes, false)
+	// TODO: Make this actually use readers / add a predicate
+	// function for testing if we should SO_REUSEPORT.
+	listener, err := NewSocket(addr, s.RcvbufBytes, s.numReaders > 1)
 	if err != nil {
 		// if any goroutine fails to create the socket, we can't really
 		// recover, so we just blow up


### PR DESCRIPTION
#### Summary
This PR enables SO_REUSEPORT on the SSF listener if we're configured to run multiple listeners already. This isn't perfect, but it's a reasonable proxy for SO_REUSEPORT'ing.

#### Motivation
we just discovered that veneur can't restart in the configuration we run.


#### Test plan
Rolled this to QA.


#### Rollout/monitoring/revert plan
* merge
* actually release 1.7!

