### PR TITLE
Fix DD plugin tag failures

### DIFF
--- a/metric_sink.go
+++ b/metric_sink.go
@@ -52,6 +52,7 @@ func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Cli
 		interval:        interval,
 		flushMaxPerBody: config.FlushMaxPerBody,
 		hostname:        config.Hostname,
+		tags:            config.Tags,
 		ddHostname:      config.DatadogAPIHostname,
 		apiKey:          config.DatadogAPIKey,
 	}, nil

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -51,6 +51,7 @@ func NewDatadogMetricSink(config *Config, interval float64, httpClient *http.Cli
 		statsd:          stats,
 		interval:        interval,
 		flushMaxPerBody: config.FlushMaxPerBody,
+		hostname:        config.Hostname,
 		ddHostname:      config.DatadogAPIHostname,
 		apiKey:          config.DatadogAPIKey,
 	}, nil

--- a/server_test.go
+++ b/server_test.go
@@ -261,37 +261,6 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 	assert.Equal(t, "butts:farts", ddmetrics.Series[0].Tags[0], "Metric is not tagged with server tags")
 }
 
-// TestFlushMaxSize tests the behavior of
-// the veneur client splitting a post across multiple requests.
-func TestFlushMaxSize(t *testing.T) {
-	metricValues, _ := generateMetrics()
-	config := localConfig()
-	config.FlushMaxPerBody = 2
-	f := newFixture(t, config)
-	defer f.Close()
-
-	for _, value := range metricValues {
-		f.server.Workers[0].ProcessMetric(&samplers.UDPMetric{
-			MetricKey: samplers.MetricKey{
-				Name: "a.b.c",
-				Type: "histogram",
-			},
-			Value:      value,
-			Digest:     12345,
-			SampleRate: 1.0,
-			Scope:      samplers.LocalOnly,
-		})
-	}
-
-	f.server.Flush()
-
-	// Verify we get 3 sets of 2, other tests can verify the internals
-	for i := 1; i <= 3; i++ {
-		ddmetrics := <-f.ddmetrics
-		assert.Equal(t, 2, len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
-	}
-}
-
 func TestGlobalServerFlush(t *testing.T) {
 	metricValues, expectedMetrics := generateMetrics()
 	config := globalConfig()

--- a/server_test.go
+++ b/server_test.go
@@ -235,6 +235,7 @@ func (f *fixture) Close() {
 func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 	metricValues, expectedMetrics := generateMetrics()
 	config := localConfig()
+	config.Tags = []string{"butts:farts"}
 	f := newFixture(t, config)
 	defer f.Close()
 
@@ -256,6 +257,8 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 	ddmetrics := <-f.ddmetrics
 	assert.Equal(t, 6, len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
 	assertMetrics(t, ddmetrics, expectedMetrics)
+	assert.Equal(t, "localhost", ddmetrics.Series[0].Hostname, "Metric is not tagged with hostname")
+	assert.Equal(t, "butts:farts", ddmetrics.Series[0].Tags[0], "Metric is not tagged with server tags")
 }
 
 // TestFlushMaxSize tests the behavior of


### PR DESCRIPTION
#### Summary
Properly tag metrics emitted by Datadog.

#### Motivation
The DD sink code didn't have a test to ensure end to end tagging, and I left it out. This adds it back and adds a test.

#### Test plan
Tests included!

r? @aditya-stripe 