### PR TITLE
Fix shutdown race in startSSFUnix

### DIFF
--- a/networking.go
+++ b/networking.go
@@ -160,8 +160,10 @@ func startSSFUnix(s *Server, addr *net.UnixAddr) <-chan struct{} {
 	go func() {
 		conns := make(chan net.Conn)
 		go func() {
-			defer lock.Unlock()
-			defer close(done)
+			defer func() {
+				lock.Unlock()
+				close(done)
+			}()
 			for {
 				conn, err := listener.AcceptUnix()
 				if err != nil {


### PR DESCRIPTION
#### Summary

This PR fixes the shutdown race condition in `startSSFUnix` that caused tests to be flaky. Turns out the order of `defer` statements in this function's work goroutine was inverted (defers are a stack!).

#### Motivation
Flaky tests.


#### Test plan

Reproduced the breakage by running and re-running the test on my laptop within 1 minute. Couldn't repro on the fixed state within 5 minutes. Seems fixed (enough)! (:


#### Rollout/monitoring/revert plan
Just merge.
