### PR TITLE
Track errors when recording spans

### DIFF
--- a/server.go
+++ b/server.go
@@ -158,6 +158,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	}
 	ret.Statsd.Namespace = "veneur."
 	ret.Statsd.Tags = append(ret.Tags, "veneurlocalonly")
+	trace.DefaultClient.SetErrorStats(ret.Statsd)
 
 	// nil is a valid sentry client that noops all methods, if there is no DSN
 	// we can just leave it as nil

--- a/trace/client.go
+++ b/trace/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/stripe/veneur/protocol"
@@ -36,6 +37,9 @@ type Client struct {
 	backend
 	cancel context.CancelFunc
 	ops    chan op
+
+	stats    IncrClient
+	statsMtx sync.Mutex
 }
 
 // Close tears down the entire client. It waits until the backend has
@@ -59,6 +63,18 @@ func (c *Client) run(ctx context.Context) {
 		}
 		do(ctx, c.backend)
 	}
+}
+
+type IncrClient interface {
+	Incr(name string, tags []string, rate float64) error
+}
+
+// SetStats sets an IncrClient used for reporting errors
+func (c *Client) SetErrorStats(statsClient IncrClient) {
+	c.statsMtx.Lock()
+	defer c.statsMtx.Unlock()
+
+	c.stats = statsClient
 }
 
 // ClientParam is an option for NewClient. Its implementation borrows

--- a/trace/client.go
+++ b/trace/client.go
@@ -69,7 +69,7 @@ type IncrClient interface {
 	Incr(name string, tags []string, rate float64) error
 }
 
-// SetStats sets an IncrClient used for reporting errors
+// SetErrorStats sets an IncrClient used for reporting errors
 func (c *Client) SetErrorStats(statsClient IncrClient) {
 	c.statsMtx.Lock()
 	defer c.statsMtx.Unlock()


### PR DESCRIPTION
#### Summary

If we're encountering an error when recording a span, we want to know about it! This helps us catch situations like dropping spans due to the channel buffer being full.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @asf-stripe 