### PR TITLE
Combine global/local logic into one unified flush and parallelize sinks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 1.8, pending
+# 1.8.0, pending
+
+## Improvements
+* Veneur no longer **requires** the use of Datadog as a target for flushes. Veneur can now use one or more of any of it's supported sinks as a backend. This realizes our desire for Veneur to be fully vendor agnostic. Thanks [gphat](https://github.com/gphat)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/stripe/veneur.svg?branch=master)](https://travis-ci.org/stripe/veneur)
 [![GoDoc](https://godoc.org/github.com/stripe/veneur?status.svg)](http://godoc.org/github.com/stripe/veneur)
 
-Veneur (venn-urr) is a distributed, fault-tolerant pipeline for runtime data. It provides a server implementation of the [DogStatsD protocol](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format) for aggregating metrics and sending them to downstream storage, typically [Datadog](http://datadoghq.com). It can also act as a [global aggregator](#global-aggregation) for histograms, sets and counters.
+Veneur (venn-urr) is a distributed, fault-tolerant pipeline for runtime data. It provides a server implementation of the [DogStatsD protocol](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format) or [SSF](https://github.com/stripe/veneur/tree/master/ssf) for aggregating metrics and sending them to downstream storage to one or more supported sinks. It can also act as a [global aggregator](#global-aggregation) for histograms, sets and counters.
 
 More generically, Veneur is a convenient sink for various observability primitives.
 

--- a/flusher.go
+++ b/flusher.go
@@ -25,7 +25,6 @@ func (s *Server) Flush(ctx context.Context) {
 	span := tracer.StartSpan("flush").(*trace.Span)
 	defer span.Finish()
 
-	// TODO Move this to an independent ticker routine or something?
 	mem := &runtime.MemStats{}
 	runtime.ReadMemStats(mem)
 
@@ -43,7 +42,7 @@ func (s *Server) Flush(ctx context.Context) {
 		sink.FlushEventsChecks(span.Attach(ctx), events, checks)
 	}
 
-	go s.flushTraces(span.Attach(ctx)) // this too!
+	go s.flushTraces(span.Attach(ctx))
 
 	// don't publish percentiles if we're a local veneur; that's the global
 	// veneur's job
@@ -77,7 +76,7 @@ func (s *Server) Flush(ctx context.Context) {
 		go func(ms metricSink) {
 			err := ms.Flush(span.Attach(ctx), finalMetrics)
 			if err != nil {
-				log.WithError(err).WithField("sink", ms.Name()).Warn("Error flushin sink")
+				log.WithError(err).WithField("sink", ms.Name()).Warn("Error flushing sink")
 			}
 			wg.Done()
 		}(sink)

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -175,7 +175,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	assert.NoError(t, err)
 
 	server.HandleTracePacket(packet)
-	server.Flush(context.TODO())
+	server.Flush(context.Background())
 
 	// wait for remoteServer to process the POST
 	select {
@@ -209,5 +209,5 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	server.HandleTracePacket(packet)
 
 	assert.NoError(t, err)
-	server.Flush(context.TODO())
+	server.Flush(context.Background())
 }

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -174,7 +175,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	assert.NoError(t, err)
 
 	server.HandleTracePacket(packet)
-	server.Flush()
+	server.Flush(context.TODO())
 
 	// wait for remoteServer to process the POST
 	select {
@@ -208,5 +209,5 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	server.HandleTracePacket(packet)
 
 	assert.NoError(t, err)
-	server.Flush()
+	server.Flush(context.TODO())
 }

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -18,6 +18,9 @@ const DatadogResourceKey = "resource"
 
 type metricSink interface {
 	Name() string
+	// Flush receives `InterMetric`s from Veneur and is responsible for "sinking"
+	// these metrics to whatever it's backend wants. Note that the sink must
+	// **not** mutate the incoming metrics as they are shared with other sinks.
 	Flush(context.Context, []samplers.InterMetric) error
 	// This one is temporary?
 	FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck)

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
+const DatadogResourceKey = "resource"
+
 type metricSink interface {
 	Name() string
 	Flush(context.Context, []samplers.InterMetric) error

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -82,7 +82,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 		})
 	}
 
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 }
 
 // TestLocalFilePluginRegister tests that we are able to register
@@ -164,7 +164,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		})
 	}
 
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 }
 
 func parseGzipTSV(r io.Reader) ([][]string, error) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -82,7 +82,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 		})
 	}
 
-	f.server.Flush(context.TODO())
+	f.server.Flush(context.Background())
 }
 
 // TestLocalFilePluginRegister tests that we are able to register
@@ -164,7 +164,7 @@ func TestGlobalServerS3PluginFlush(t *testing.T) {
 		})
 	}
 
-	f.server.Flush(context.TODO())
+	f.server.Flush(context.Background())
 }
 
 func parseGzipTSV(r io.Reader) ([][]string, error) {

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -442,7 +443,7 @@ func (s *Server) Start() {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				s.Flush()
+				s.Flush(context.TODO())
 			}
 		}
 	}()

--- a/server_test.go
+++ b/server_test.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"bytes"
 	"compress/zlib"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -252,7 +253,7 @@ func TestLocalServerUnaggregatedMetrics(t *testing.T) {
 		})
 	}
 
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 
 	ddmetrics := <-f.ddmetrics
 	assert.Equal(t, 6, len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
@@ -280,7 +281,7 @@ func TestGlobalServerFlush(t *testing.T) {
 		})
 	}
 
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 
 	ddmetrics := <-f.ddmetrics
 	assert.Equal(t, len(expectedMetrics), len(ddmetrics.Series), "incorrect number of elements in the flushed series on the remote server")
@@ -390,7 +391,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 		})
 	}
 
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 
 	// the global veneur instance should get valid data
 	td := <-globalTD
@@ -540,7 +541,7 @@ func sendTCPMetrics(addr string, tlsConfig *tls.Config, f *fixture) error {
 
 	// check that the server received the stats; HACK: sleep to ensure workers process before flush
 	time.Sleep(20 * time.Millisecond)
-	f.server.Flush()
+	f.server.Flush(context.TODO())
 	select {
 	case ddmetrics := <-f.ddmetrics:
 		if len(ddmetrics.Series) != 1 {


### PR DESCRIPTION
#### Summary
Improve the Server's `Flush` work from calling `FlushLocal` and `FlushGlobal`, which was a poorly compartmentalized implementation that led to code duplication and confusion.

#### Motivation
At the end of the [Datadog sink PR](https://github.com/stripe/veneur/pull/261) we are in a world with a single, hardcoded sink. This isn't the intent! We want to convert plugins to sinks and execute *all* of them.

This patch aims to do just that, but also takes an opportunity to refactor away the `FlushLocal` and `FlushGlobal` functions. This was done by first inlining them, removing duplicate code, and then refactoring the special cases away. Notably, the `tallyMetrics` size calculation.

#### Notes
* This is intended for post 1.7 so >= 1.8
* At present DD is still the only metric sink, as such I didn't add any tests of consequence because the existing tests do the thing. We'll add "did all sinks run" as a test when we introduce the next patches.
* I added some comments to improve what flush does. Right now it's a rat's nest. This improves the rat's nest incrementally and avoids some tremendously big PR.
* I left a half-ass set of `context.TODO()` sprinkled around because we want to implement a deadline for sinks. I will fix this.

#### Test plan
Existing tests.

r? @aditya-stripe 