### PR TITLE
Align tick with interval boundaries for bucketing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * veneur-prometheus and veneur-proxy executables are now included in the docker images. Thanks [jac](https://github.com/jac-stripe)
 * All veneur executables are now in $PATH in the docker images. Thanks [jac](https://github.com/jac-stripe)
 * When using Lightstep as a tracing sink, spans can be load-balanced more evenly across collectors by configuring the `trace_lightstep_num_clients` option to multiplex across multiple clients. Thanks [aditya](https://github.com/chimeracoder)!
+* When starting, Veneur will now delay it's first metric to be aligned with an `interval` boundary on the local clock. This will effectively "synchronize" Veneur instances across your deployment assuming reasonable clock behavior. The result is a metric timestamps in your TSDB that mostly line up improving bucketing behavior. Thanks [gphat](https://github.com/gphat)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ To clarify how each metric type behaves in Veneur, please use the following:
 * Timers: Locally accrued, count, max and min flushed to Datadog, percentiles forwarded to `forward_address` for global aggregation when set.
 * Sets: Locally accrued, forwarded to `forward_address` for global aggregation when set.
 
+# Other Notes
+
+* Veneur aligns its flush timing with the local clock. For the default interval of `10s` Veneur will generally emit metrics at 00, 10, 20, 30, … seconds after the minute.
+* Veneur will delay it's first metric emission to align the clock as stated above. This may result in a brief quiet period on a restart at worst < `interval` seconds long.
+
 # Usage
 
 ```

--- a/server.go
+++ b/server.go
@@ -459,7 +459,7 @@ func (s *Server) Start() {
 
 		// We want to align our ticker to a multiple of it's duration for
 		// convenience of bucketing.
-		<-time.After(s.CalculateTickDelay(time.Now()))
+		<-time.After(CalculateTickDelay(s.interval, time.Now()))
 
 		// We aligned the ticker to our interval above. It's worth noting that just
 		// because we aligned once we're not gauranteed to be perfect on each
@@ -856,12 +856,6 @@ func (s *Server) Shutdown() {
 	graceful.Shutdown()
 }
 
-// CalculateTickDelay takes the provided time, `Truncate`s it a rounded-down
-// multiple of `interval`, then adds `interval` back to find the "next" tick.
-func (s *Server) CalculateTickDelay(t time.Time) time.Duration {
-	return t.Truncate(s.interval).Add(s.interval).Sub(t)
-}
-
 // IsLocal indicates whether veneur is running as a local instance
 // (forwarding non-local data to a global veneur instance) or is running as a global
 // instance (sending all data directly to the final destination).
@@ -927,3 +921,9 @@ func (tb *internalTraceBackend) FlushSync(ctx context.Context) error {
 var ErrNoSpanWorker = fmt.Errorf("Can not submit traces to an unstarted server")
 
 var _ trace.ClientBackend = &internalTraceBackend{}
+
+// CalculateTickDelay takes the provided time, `Truncate`s it a rounded-down
+// multiple of `interval`, then adds `interval` back to find the "next" tick.
+func CalculateTickDelay(interval time.Duration, t time.Time) time.Duration {
+	return t.Truncate(interval).Add(interval).Sub(t)
+}

--- a/server.go
+++ b/server.go
@@ -459,7 +459,7 @@ func (s *Server) Start() {
 
 		// We want to align our ticker to a multiple of it's duration for
 		// convenience of bucketing.
-		time.Sleep(s.CalculateTickDelay(time.Now()))
+		<-time.After(s.CalculateTickDelay(time.Now()))
 
 		// We aligned the ticker to our interval above. It's worth noting that just
 		// because we aligned once we're not gauranteed to be perfect on each

--- a/server.go
+++ b/server.go
@@ -458,11 +458,8 @@ func (s *Server) Start() {
 		}()
 
 		// We want to align our ticker to a multiple of it's duration for
-		// convenience of bucketing. This `Sleep` works by taking the current time,
-		// `Truncate`ing to a rounded-down multiple of `interval`, then adding the
-		// the interval back to find the "next" tick. We then wait that long before
-		// starting our ticker.
-		time.Sleep(time.Now().Truncate(s.interval).Add(s.interval).Sub(time.Now()))
+		// convenience of bucketing.
+		time.Sleep(s.CalculateTickDelay(time.Now()))
 
 		// We aligned the ticker to our interval above. It's worth noting that just
 		// because we aligned once we're not gauranteed to be perfect on each
@@ -857,6 +854,12 @@ func (s *Server) Shutdown() {
 	log.Info("Shutting down server gracefully")
 	close(s.shutdown)
 	graceful.Shutdown()
+}
+
+// CalculateTickDelay takes the provided time, `Truncate`s it a rounded-down
+// multiple of `interval`, then adds `interval` back to find the "next" tick.
+func (s *Server) CalculateTickDelay(t time.Time) time.Duration {
+	return t.Truncate(s.interval).Add(s.interval).Sub(t)
 }
 
 // IsLocal indicates whether veneur is running as a local instance

--- a/server.go
+++ b/server.go
@@ -457,12 +457,12 @@ func (s *Server) Start() {
 			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
 		}()
 
-		// We want to align our ticker to a multiple of it's duration for
+		// We want to align our ticker to a multiple of its duration for
 		// convenience of bucketing.
 		<-time.After(CalculateTickDelay(s.interval, time.Now()))
 
 		// We aligned the ticker to our interval above. It's worth noting that just
-		// because we aligned once we're not gauranteed to be perfect on each
+		// because we aligned once we're not guaranteed to be perfect on each
 		// subsequent tick. This code is small, however, and should service the
 		// incoming tick signal fast enough that the amount we are "off" is
 		// negligible.

--- a/server_test.go
+++ b/server_test.go
@@ -874,6 +874,19 @@ func nullLogger() *logrus.Logger {
 	return logger
 }
 
+func TestCalculateTickerDelay(t *testing.T) {
+	config := localConfig()
+	config.Interval = "10s"
+	f := newFixture(t, config)
+	defer f.Close()
+
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	theTime, _ := time.Parse(layout, str)
+	delay := f.server.CalculateTickDelay(theTime)
+	assert.Equal(t, 3.629, delay.Seconds(), "Delay is incorrect")
+}
+
 // BenchmarkSendSSFUNIX sends b.N metrics to veneur and waits until
 // all of them have been read (not processed).
 func BenchmarkSendSSFUNIX(b *testing.B) {

--- a/server_test.go
+++ b/server_test.go
@@ -875,15 +875,12 @@ func nullLogger() *logrus.Logger {
 }
 
 func TestCalculateTickerDelay(t *testing.T) {
-	config := localConfig()
-	config.Interval = "10s"
-	f := newFixture(t, config)
-	defer f.Close()
+	interval, _ := time.ParseDuration("10s")
 
 	layout := "2006-01-02T15:04:05.000Z"
 	str := "2014-11-12T11:45:26.371Z"
 	theTime, _ := time.Parse(layout, str)
-	delay := f.server.CalculateTickDelay(theTime)
+	delay := CalculateTickDelay(interval, theTime)
 	assert.Equal(t, 3.629, delay.Seconds(), "Delay is incorrect")
 }
 


### PR DESCRIPTION
#### Summary
Align Veneur's internal flush ticker with the interval for nice bucketing.


#### Motivation
We got an issue from @hermanbanken in #296 that pointed our Veneur's choice to "tick" outside of a convenient boundary was causing some bucketing issues. This isn't the first time we've heard this, but it's the first time someone helped us understand _why_.

To that end, this patch changes veneur to delay the start of it's ticker by <= `interval` so as to align with nice, round clock buckets.

#### Test plan
Test incoming, in writing this PR text I realized how to test it. :)

r? @stripe/observability 