### PR TITLE
Don't assume tags are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.8, pending
+
+## Bugfixes
+* Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)
+
 # 1.7.0, 2017-10-19
 
 ## Notes for upgrading from previous versions

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -231,9 +231,11 @@ func bareMetric(name string, tags string) *ssf.SSFSample {
 	metric := &ssf.SSFSample{}
 	metric.Name = name
 	metric.Tags = make(map[string]string)
-	for _, elem := range strings.Split(tags, ",") {
-		tag := strings.Split(elem, ":")
-		metric.Tags[tag[0]] = tag[1]
+	if tags != "" {
+		for _, elem := range strings.Split(tags, ",") {
+			tag := strings.Split(elem, ":")
+			metric.Tags[tag[0]] = tag[1]
+		}
 	}
 	return metric
 }


### PR DESCRIPTION
#### Summary/Motivation
Calling `veneur-emit` with `-ssf`, a metric (e.g. `-count 1`), and no tags would result in a panic and a stack dump, which is a sub-optimal user experience.

#### Test plan
Built and ran in docker, it did not crash anymore

#### Rollout/monitoring/revert plan
Just merge

R? @gphat 

