### PR TITLE
WIP Allow Veneur to Proxy local HTTP endoints

### DIFF
--- a/fixtures/datadog_metric.json
+++ b/fixtures/datadog_metric.json
@@ -1,0 +1,1663 @@
+{
+    "series": [
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    -1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/etc/stripe/facts/puppet_locked.txt"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    9680992.398920298
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:present",
+                "path:/pay/health/successfully-bootstrapped"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    1875586.5739953518
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/var/run/stripe/restart-required/*"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    25.596588850021362
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:present",
+                "path:/pay/confidant/rendered/all-secrets.json"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    43.20435857772827
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:present",
+                "path:/tmp/reyes.u0.generation"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    -1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/run/vulnerable-processes.running"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    -1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/run/vulnerable-packages.to-upgrade"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    -1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/run/reboot-required.nagios"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "file.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    -1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "expected_status:absent",
+                "path:/var/run/stripe/bootstrapping"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.current_time",
+            "points": [
+                [
+                    1509037548,
+                    1509037548.087327
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "updates.security",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "updates.available",
+            "points": [
+                [
+                    1509037548,
+                    56
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp6.time_wait",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.packets_out.count",
+            "points": [
+                [
+                    1509037548,
+                    42.7
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp4.opening",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.bytes_sent",
+            "points": [
+                [
+                    1509037548,
+                    137276.05
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.in_datagrams",
+            "points": [
+                [
+                    1509037548,
+                    13.85
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp6.opening",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp4.established",
+            "points": [
+                [
+                    1509037548,
+                    46
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.snd_buf_errors",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.packets_in.count",
+            "points": [
+                [
+                    1509037548,
+                    46.65
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.packets_out.error",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp6.closing",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp6.listening",
+            "points": [
+                [
+                    1509037548,
+                    6
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.out_segs",
+            "points": [
+                [
+                    1509037548,
+                    79.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp6.established",
+            "points": [
+                [
+                    1509037548,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp4.connections",
+            "points": [
+                [
+                    1509037548,
+                    20
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.out_datagrams",
+            "points": [
+                [
+                    1509037548,
+                    14.05
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp4.closing",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.rcv_buf_errors",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.in_segs",
+            "points": [
+                [
+                    1509037548,
+                    75.05
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.in_csum_errors",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp6.connections",
+            "points": [
+                [
+                    1509037548,
+                    4
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.in_errors",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp4.time_wait",
+            "points": [
+                [
+                    1509037548,
+                    33
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.retrans_segs",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp4.listening",
+            "points": [
+                [
+                    1509037548,
+                    19
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.packets_in.error",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.listen_drops",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.udp.no_ports",
+            "points": [
+                [
+                    1509037548,
+                    0.1
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "eth0",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.bytes_rcvd",
+            "points": [
+                [
+                    1509037548,
+                    5089.9
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.backlog_drops",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.net.tcp.listen_overflows",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.writing",
+            "points": [
+                [
+                    1509037548,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.reading",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.waiting",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.request_per_s",
+            "points": [
+                [
+                    1509037548,
+                    0.05
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.conn_dropped_per_s",
+            "points": [
+                [
+                    1509037548,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.conn_opened_per_s",
+            "points": [
+                [
+                    1509037548,
+                    0.05
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "nginx.net.connections",
+            "points": [
+                [
+                    1509037548,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.oom.count",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.max",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.median",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.avg",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.count",
+            "points": [
+                [
+                    1509037548,
+                    1.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "rate"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.50percentile",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.90percentile",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.95percentile",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.build_age.99percentile",
+            "points": [
+                [
+                    1509037548,
+                    398.914322
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "veneur.deployed_version",
+            "points": [
+                [
+                    1509037548,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "sha:1b48c52c0aea6e3177e09b32772bf6a83129176d"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.context_switches",
+            "points": [
+                [
+                    1509037548,
+                    37976.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.processes.priorities",
+            "points": [
+                [
+                    1509037548,
+                    11.0
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "priority:low"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.entropy.available",
+            "points": [
+                [
+                    1509037548,
+                    905.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.processes_created",
+            "points": [
+                [
+                    1509037548,
+                    936
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.inodes.total",
+            "points": [
+                [
+                    1509037548,
+                    422537.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.processes.states",
+            "points": [
+                [
+                    1509037548,
+                    1.0
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "state:runnable"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.interrupts",
+            "points": [
+                [
+                    1509037548,
+                    28891
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.inodes.used",
+            "points": [
+                [
+                    1509037548,
+                    494.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.processes.states",
+            "points": [
+                [
+                    1509037548,
+                    184.0
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "state:sleeping"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.processes.priorities",
+            "points": [
+                [
+                    1509037548,
+                    35.0
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "priority:high"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.swapped_in",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.out",
+            "points": [
+                [
+                    1509037548,
+                    1296
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.faults",
+            "points": [
+                [
+                    1509037548,
+                    417462
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.swapped_out",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.major_faults",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.linux.vm.pages.in",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "count"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "puppet.last_successful_run.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    235
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "puppet.last_run.age_seconds",
+            "points": [
+                [
+                    1509037548,
+                    235
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "puppet.is_failing",
+            "points": [
+                [
+                    1509037548,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "stripe.health.is_down",
+            "points": [
+                [
+                    1509037549,
+                    0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "net.netfilter.nf_conntrack_count",
+            "points": [
+                [
+                    1509037549,
+                    "351"
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "net.netfilter.nf_conntrack_max",
+            "points": [
+                [
+                    1509037549,
+                    "262144"
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "datadog.agent.heartbeat",
+            "points": [
+                [
+                    1509037549,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "consul.nodes_passing",
+            "points": [
+                [
+                    1509037549,
+                    1
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "consul_version:0.9.3",
+                "consul_datacenter:qa-northwest",
+                "service:stripe-health"
+            ],
+            "type": "gauge"
+        },
+        {
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "consul.peers",
+            "points": [
+                [
+                    1509037549,
+                    3
+                ]
+            ],
+            "source_type_name": "System",
+            "tags": [
+                "consul_version:0.9.3",
+                "consul_datacenter:qa-northwest",
+                "mode:follower"
+            ],
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.used",
+            "points": [
+                [
+                    1509037549,
+                    428
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    3588256.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.free",
+            "points": [
+                [
+                    1509037549,
+                    67039044
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.used",
+            "points": [
+                [
+                    1509037549,
+                    69820
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.027000000000000003
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.total",
+            "points": [
+                [
+                    1509037549,
+                    1703936
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.total",
+            "points": [
+                [
+                    1509037549,
+                    956041
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.total",
+            "points": [
+                [
+                    1509037549,
+                    67108864
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    6140828.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    765456.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.used",
+            "points": [
+                [
+                    1509037549,
+                    252983
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.free",
+            "points": [
+                [
+                    1509037549,
+                    955613
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.free",
+            "points": [
+                [
+                    1509037549,
+                    1697554
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda15",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    101129.5
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.used",
+            "points": [
+                [
+                    1509037549,
+                    412
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    681932.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.02
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.00044767954512411076
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    1056763060.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda15",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.045
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.total",
+            "points": [
+                [
+                    1509037549,
+                    655360
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda15",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    105866.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    3824164.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.003745445838341346
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    765952.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.total",
+            "points": [
+                [
+                    1509037549,
+                    957437
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.001
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    24944944.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    10174756.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    12.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    3824152.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.free",
+            "points": [
+                [
+                    1509037549,
+                    1034129632.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.369
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.free",
+            "points": [
+                [
+                    1509037549,
+                    957025
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.0010403990745544434
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.free",
+            "points": [
+                [
+                    1509037549,
+                    402377
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvdf",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    21568468.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda15",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    4736.5
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.00043031551945454374
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/xvda1",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.38602142333984374
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "tmpfs",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.used",
+            "points": [
+                [
+                    1509037549,
+                    496.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.fs.inodes.used",
+            "points": [
+                [
+                    1509037549,
+                    6382
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "/dev/mapper/stripe-pay",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.total",
+            "points": [
+                [
+                    1509037549,
+                    26691836.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        },
+        {
+            "device": "udev",
+            "host": "qa-splunkmaster1.northwest.stripe.io",
+            "metric": "system.disk.in_use",
+            "points": [
+                [
+                    1509037549,
+                    0.0
+                ]
+            ],
+            "source_type_name": "System",
+            "type": "gauge"
+        }
+    ]
+}

--- a/handlers_global.go
+++ b/handlers_global.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"compress/zlib"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"io"
@@ -391,8 +392,9 @@ func unmarshalDDMetricsFromHTTP(ctx context.Context, stats *statsd.Client, w htt
 
 		}
 
-		var valBuf []byte
-		math.Float64bits(finalValue)
+		bits := math.Float64bits(finalValue)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
 
 		jsonMetrics[i] = samplers.JSONMetric{
 			MetricKey: samplers.MetricKey{
@@ -401,7 +403,7 @@ func unmarshalDDMetricsFromHTTP(ctx context.Context, stats *statsd.Client, w htt
 				JoinedTags: strings.Join(ddIncMetric.Tags, ","),
 			},
 			Tags:  ddIncMetric.Tags,
-			Value: valBuf,
+			Value: bytes,
 		}
 	}
 

--- a/handlers_global.go
+++ b/handlers_global.go
@@ -1,14 +1,18 @@
 package veneur
 
 import (
+	"bytes"
 	"compress/zlib"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -58,6 +62,16 @@ func handleImport(s *Server) http.Handler {
 		}
 		// the server usually waits for this to return before finalizing the
 		// response, so this part must be done asynchronously
+		go s.ImportMetrics(span.Attach(ctx), jsonMetrics)
+	})
+}
+
+func handleDatadogImport(s *Server) http.Handler {
+	return contextHandler(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		span, jsonMetrics, err := unmarshalDDMetricsFromHTTP(ctx, s.Statsd, w, r)
+		if err != nil {
+			return
+		}
 		go s.ImportMetrics(span.Attach(ctx), jsonMetrics)
 	})
 }
@@ -179,6 +193,104 @@ func unmarshalMetricsFromHTTP(ctx context.Context, stats *statsd.Client, w http.
 	}
 
 	w.WriteHeader(http.StatusAccepted)
+	stats.TimeInMilliseconds("import.response_duration_ns",
+		float64(time.Since(span.Start).Nanoseconds()),
+		[]string{"part:request", fmt.Sprintf("encoding:%s", encoding)},
+		1.0)
+
+	return span, jsonMetrics, nil
+}
+
+// unmarshalDDMetricsFromHTTP takes care of the common need to unmarshal a slice of metrics from a request body,
+// dealing with error handling, decoding, tracing, and the associated metrics.
+func unmarshalDDMetricsFromHTTP(ctx context.Context, stats *statsd.Client, w http.ResponseWriter, r *http.Request) (*trace.Span, []samplers.JSONMetric, error) {
+	var (
+		ddMetrics map[string][]DDMetric
+		body      io.ReadCloser
+		err       error
+		encoding  = r.Header.Get("Content-Encoding")
+		span      *trace.Span
+	)
+
+	span, err = tracer.ExtractRequestChild("/v1/series", r, "veneur.opentracing.import")
+	if err != nil {
+		log.WithError(err).Debug("Could not extract span from request")
+		span = tracer.StartSpan("veneur.opentracing.import").(*trace.Span)
+	} else {
+		log.WithField("trace", span.Trace).Debug("Extracted span from request")
+	}
+	defer span.Finish()
+
+	innerLogger := log.WithField("client", r.RemoteAddr)
+
+	switch encLogger := innerLogger.WithField("encoding", encoding); encoding {
+	case "":
+		body = r.Body
+		encoding = "identity"
+	case "deflate":
+		body, err = zlib.NewReader(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			span.Error(err)
+			encLogger.WithError(err).Error("Could not read compressed request body")
+			stats.Count("import.request_error_total", 1, []string{"cause:deflate"}, 1.0)
+			return nil, nil, err
+		}
+		defer body.Close()
+	default:
+		http.Error(w, encoding, http.StatusUnsupportedMediaType)
+		span.Error(errors.New("Could not determine content-encoding of request"))
+		encLogger.Error("Could not determine content-encoding of request")
+		stats.Count("import.request_error_total", 1, []string{"cause:unknown_content_encoding"}, 1.0)
+		return nil, nil, err
+	}
+
+	if err = json.NewDecoder(body).Decode(&ddMetrics); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		span.Error(err)
+		innerLogger.WithError(err).Error("Could not decode /import request")
+		stats.Count("import.request_error_total", 1, []string{"cause:json"}, 1.0)
+		return nil, nil, err
+	}
+
+	if len(ddMetrics) == 0 {
+		const msg = "Received empty /v1/series request"
+		http.Error(w, msg, http.StatusBadRequest)
+		span.Error(errors.New(msg))
+		innerLogger.WithError(err).Error(msg)
+		return nil, nil, err
+	}
+
+	// Verify we got some serieseses
+	if _, ok := ddMetrics["series"]; ok {
+		const msg = "Received empty or improperly-formed metrics"
+		http.Error(w, msg, http.StatusBadRequest)
+		span.Error(errors.New(msg))
+		innerLogger.Error(msg)
+		return nil, nil, err
+	}
+
+	jsonMetrics := make([]samplers.JSONMetric, len(ddMetrics["series"]))
+	for i, ddMetric := range ddMetrics["series"] {
+		// We're mutating this thing since nothing else is gonna use it
+		sort.Strings(ddMetric.Tags)
+		// Transform the incoming metrics to a JSONMetric, so we can use existing
+		// code to merge it.
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.BigEndian, ddMetric.Value[0][1])
+		jsonMetrics[i] = samplers.JSONMetric{
+			MetricKey: samplers.MetricKey{
+				Name:       ddMetric.Name,
+				Type:       ddMetric.MetricType,
+				JoinedTags: strings.Join(ddMetric.Tags, ","),
+			},
+			Tags:  ddMetric.Tags,
+			Value: buf.Bytes(),
+		}
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+	// TODO Fix metric
 	stats.TimeInMilliseconds("import.response_duration_ns",
 		float64(time.Since(span.Start).Nanoseconds()),
 		[]string{"part:request", fmt.Sprintf("encoding:%s", encoding)},

--- a/http.go
+++ b/http.go
@@ -44,6 +44,7 @@ func (s *Server) Handler() http.Handler {
 
 	mux.Handle(pat.Post("/intake"), handleDatadogEventImport(s))
 	mux.Handle(pat.Post("/v1/series"), handleDatadogImport(s))
+	mux.Handle(pat.Post("/api/v1/check_run"), handleDatadogCheckImport(s))
 
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))
 	mux.Handle(pat.Get("/debug/pprof/profile"), http.HandlerFunc(pprof.Profile))

--- a/http.go
+++ b/http.go
@@ -42,9 +42,9 @@ func (s *Server) Handler() http.Handler {
 
 	mux.Handle(pat.Post("/import"), handleImport(s))
 
-	mux.Handle(pat.Post("/intake"), handleDatadogEventImport(s))
-	mux.Handle(pat.Post("/v1/series"), handleDatadogImport(s))
-	mux.Handle(pat.Post("/api/v1/check_run"), handleDatadogCheckImport(s))
+	mux.Handle(pat.Post("/intake/*"), handleDatadogEventImport(s))
+	mux.Handle(pat.Post("/api/v1/series/*"), handleDatadogImport(s))
+	mux.Handle(pat.Post("/api/v1/check_run/*"), handleDatadogCheckImport(s))
 
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))
 	mux.Handle(pat.Get("/debug/pprof/profile"), http.HandlerFunc(pprof.Profile))

--- a/http.go
+++ b/http.go
@@ -42,7 +42,8 @@ func (s *Server) Handler() http.Handler {
 
 	mux.Handle(pat.Post("/import"), handleImport(s))
 
-	mux.Handle(pat.Post("/v1/series", handleDatadogImport(s)))
+	mux.Handle(pat.Post("/intake"), handleDatadogEventImport(s))
+	mux.Handle(pat.Post("/v1/series"), handleDatadogImport(s))
 
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))
 	mux.Handle(pat.Get("/debug/pprof/profile"), http.HandlerFunc(pprof.Profile))

--- a/http.go
+++ b/http.go
@@ -42,6 +42,8 @@ func (s *Server) Handler() http.Handler {
 
 	mux.Handle(pat.Post("/import"), handleImport(s))
 
+	mux.Handle(pat.Post("/v1/series", handleDatadogImport(s)))
+
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))
 	mux.Handle(pat.Get("/debug/pprof/profile"), http.HandlerFunc(pprof.Profile))
 	mux.Handle(pat.Get("/debug/pprof/symbol"), http.HandlerFunc(pprof.Symbol))

--- a/http_test.go
+++ b/http_test.go
@@ -317,12 +317,6 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 
 	w := httptest.NewRecorder()
 
-	config := localConfig()
-	config.SsfListenAddresses = []string{}
-	s := setupVeneurServer(t, config, nil, nil, nil)
-	defer s.Shutdown()
-	HTTPAddrPort++
-
 	handler := handleImport(s)
 	handler.ServeHTTP(w, r)
 

--- a/http_test.go
+++ b/http_test.go
@@ -342,9 +342,10 @@ func TestDatadogMetricsProxy(t *testing.T) {
 	config := localConfig()
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
+	HTTPAddrPort++
 
 	handler := handleDatadogImport(s)
 	handler.ServeHTTP(w, r)
 
-	assert.Equal(t, http.StatusOK, w.Code, "Test server returned wrong HTTP response code")
+	assert.Equal(t, http.StatusAccepted, w.Code, "Test server returned wrong HTTP response code")
 }

--- a/http_test.go
+++ b/http_test.go
@@ -4,17 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/samplers"
@@ -306,70 +302,23 @@ func TestNokTraceHealthCheck(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code, "Trace healthcheck succeeded when disabled")
 }
 
-func TestBuildDate(t *testing.T) {
-	r := httptest.NewRequest(http.MethodGet, "/builddate", nil)
-
-	config := localConfig()
-	config.SsfListenAddresses = []string{}
-	s := setupVeneurServer(t, config, nil, nil, nil)
-	defer s.Shutdown()
-	HTTPAddrPort++
-
-	w := httptest.NewRecorder()
-
-	handler := s.Handler()
-	handler.ServeHTTP(w, r)
-
-	bts, err := ioutil.ReadAll(w.Body)
-	assert.NoError(t, err, "error reading /builddate")
-
-	assert.Equal(t, string(bts), BUILD_DATE, "received invalid build date")
-
-	// we can't always check this against the current time
-	// because that would break local tests when run with `go test`
-	if BUILD_DATE != defaultLinkValue {
-		date, err := strconv.ParseInt(string(bts), 10, 64)
-		assert.NoError(t, err, "error parsing date %s", string(bts))
-
-		dt := time.Unix(date, 0)
-		duration := time.Since(dt)
-		if duration > 60*time.Minute {
-			assert.Fail(t, fmt.Sprintf("either date %s is invalid, or our builds are taking more than an hour", dt.Format(time.RFC822)))
-		}
-	}
-}
-
-func TestVersion(t *testing.T) {
-	r := httptest.NewRequest(http.MethodGet, "/version", nil)
-
-	config := localConfig()
-	config.SsfListenAddresses = []string{}
-	s := setupVeneurServer(t, config, nil, nil, nil)
-	defer s.Shutdown()
-	HTTPAddrPort++
-
-	w := httptest.NewRecorder()
-
-	handler := s.Handler()
-	handler.ServeHTTP(w, r)
-
-	bts, err := ioutil.ReadAll(w.Body)
-	assert.NoError(t, err, "error reading /version")
-
-	assert.Equal(t, string(bts), VERSION, "received invalid version")
-}
-
 func testServerImportHelper(t *testing.T, data interface{}) {
 	var b bytes.Buffer
 	err := json.NewEncoder(&b).Encode(data)
 	assert.NoError(t, err)
 
+	config := localConfig()
+	config.SsfListenAddresses = []string{}
+	s := setupVeneurServer(t, config, nil, nil, nil)
+	defer s.Shutdown()
+	HTTPAddrPort++
 	r := httptest.NewRequest(http.MethodPost, "/import", &b)
 	r.Header.Set("Content-Encoding", "")
 
 	w := httptest.NewRecorder()
 
 	config := localConfig()
+	config.SsfListenAddresses = []string{}
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
 	HTTPAddrPort++
@@ -378,4 +327,24 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
+}
+
+func TestDatadogMetricsProxy(t *testing.T) {
+	f, err := os.Open(filepath.Join("fixtures", "datadog_metric.json"))
+	assert.NoError(t, err, "Error reading response fixture")
+	defer f.Close()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/series/?api_key=farts", f)
+	r.Header.Set("Content-Encoding", "")
+
+	w := httptest.NewRecorder()
+
+	config := localConfig()
+	s := setupVeneurServer(t, config, nil, nil, nil)
+	defer s.Shutdown()
+
+	handler := handleDatadogImport(s)
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Test server returned wrong HTTP response code")
 }

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -33,7 +33,7 @@ type datadogMetricSink struct {
 // wants when posting to the API
 type DDMetric struct {
 	Name       string        `json:"metric"`
-	Value      [1][2]float64 `json:"points"`
+	Value      [1][2]float64 `json:"points,string"`
 	Tags       []string      `json:"tags,omitempty"`
 	MetricType string        `json:"type"`
 	Hostname   string        `json:"host,omitempty"`

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -157,6 +157,16 @@ func (g *Gauge) Sample(sample float64, sampleRate float32) {
 	g.value = sample
 }
 
+// Combine overwrites gauge (marshalled as a byte slice)
+func (g *Gauge) Combine(other []byte) error {
+	bits := binary.LittleEndian.Uint64(other)
+	otherGauge := math.Float64frombits(bits)
+
+	g.value += otherGauge
+
+	return nil
+}
+
 // Flush generates an InterMetric from the current state of this gauge.
 func (g *Gauge) Flush() []InterMetric {
 	tags := make([]string, len(g.Tags))

--- a/worker.go
+++ b/worker.go
@@ -228,6 +228,10 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 		if err := w.wm.globalCounters[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge counters")
 		}
+	case gaugeTypeName:
+		if err := w.wm.gauges[other.MetricKey].Combine(other.Value); err != nil {
+			log.WithError(err).Error("Could not merge gauges")
+		}
 	case setTypeName:
 		if err := w.wm.sets[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge sets")


### PR DESCRIPTION
#### Summary
Adds endpoints that emulate Datadog's API such that local Datadog agents can send their information to a local veneur.

#### Motivation
We've long desired that Datadog check metrics match Veneur's global aggregation behavior, but since the Agent doesn't use DogStatsD, we didn't have a way to do this.

By adding endpoints to Veneur we allow the agent to submit directly _to_ Veneur. This means everything behaves the same.

#### Test plan
Need to add tests

#### Rollout/monitoring/revert plan
TBD

