### PR TITLE
Remove two warnings for config states that are peaceful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)
+* Remove spurious warnings about unset configuration settings. Thanks [antifuchs](https://github.com/antifuchs)
 
 # 1.7.0, 2017-10-19
 

--- a/span_sink.go
+++ b/span_sink.go
@@ -231,13 +231,16 @@ func NewLightStepSpanSink(config *Config, stats *statsd.Client, commonTags map[s
 		port = lightstepDefaultPort
 	}
 
-	reconPeriod, err := time.ParseDuration(config.TraceLightstepReconnectPeriod)
-	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
-			"interval":         config.TraceLightstepReconnectPeriod,
-			"default_interval": lightstepDefaultInterval,
-		}).Warn("Failed to parse reconnect duration, using default.")
-		reconPeriod = lightstepDefaultInterval
+	reconPeriod := lightstepDefaultInterval
+	if config.TraceLightstepReconnectPeriod != "" {
+		reconPeriod, err = time.ParseDuration(config.TraceLightstepReconnectPeriod)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				"interval":         config.TraceLightstepReconnectPeriod,
+				"default_interval": lightstepDefaultInterval,
+			}).Warn("Failed to parse reconnect duration, using default.")
+			reconPeriod = lightstepDefaultInterval
+		}
 	}
 
 	log.WithFields(logrus.Fields{

--- a/span_sink.go
+++ b/span_sink.go
@@ -224,12 +224,11 @@ func NewLightStepSpanSink(config *Config, stats *statsd.Client, commonTags map[s
 
 	port, err := strconv.Atoi(host.Port())
 	if err != nil {
-		port = lightstepDefaultPort
-	} else {
 		log.WithError(err).WithFields(logrus.Fields{
 			"port":         port,
 			"default_port": lightstepDefaultPort,
 		}).Warn("Error parsing LightStep port, using default")
+		port = lightstepDefaultPort
 	}
 
 	reconPeriod, err := time.ParseDuration(config.TraceLightstepReconnectPeriod)


### PR DESCRIPTION
#### Summary

This PR makes two config warnings only get issued if a user of veneur actually sets the corresponding config setting.

#### Motivation
We should only warn if there's something to warn about

#### Test plan
- [ ] roll this version to QA and see if it warns about our config


#### Rollout/monitoring/revert plan

straight-up mergeable for the next release.

