### PR TITLE
Refactor veneur/trace, no longer depend on veneur/samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 * Veneur no longer **requires** the use of Datadog as a target for flushes. Veneur can now use one or more of any of it's supported sinks as a backend. This realizes our desire for Veneur to be fully vendor agnostic. Thanks [gphat](https://github.com/gphat)!
+* The package `github.com/stripe/veneur/trace` now depends on fewer other packages across veneur, making it easier to pull in `trace` as a dependency. Thanks [antifuchs](https://github.com/antifuchs)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/regression_test.go
+++ b/regression_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	proto "github.com/golang/protobuf/proto"
-	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/ssf"
 )
 
@@ -32,7 +32,7 @@ func TestTagNameSetNameNotSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Eror when marshalling sample")
 
-	msg, errSSF := samplers.ParseSSF(buf)
+	msg, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
 	if assert.NotNil(t, msg) {
 		newSample, err := msg.TraceSpan()
@@ -57,7 +57,7 @@ func TestTagNameSetNameSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Error when marshalling sample")
 
-	msg, errSSF := samplers.ParseSSF(buf)
+	msg, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
 	if assert.NotNil(t, msg) {
 		newSample, err := msg.TraceSpan()
@@ -77,7 +77,7 @@ func TestNoTagName(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err)
 
-	msg, errSSF := samplers.ParseSSF(buf)
+	msg, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
 	if assert.NotNil(t, msg) {
 		newSample, err := msg.TraceSpan()
@@ -98,7 +98,7 @@ func TestOperation(t *testing.T) {
 	packet, err := ioutil.ReadAll(pb)
 	assert.NoError(t, err)
 
-	msg, errSSF := samplers.ParseSSF(packet)
+	msg, errSSF := protocol.ParseSSF(packet)
 	assert.NoError(t, errSSF)
 	if assert.NotNil(t, msg) {
 		sample, errSSF := msg.TraceSpan()

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/protocol"
-	"github.com/stripe/veneur/samplers"
 )
 
 func TestNoClient(t *testing.T) {
@@ -60,7 +59,7 @@ func TestUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *samplers.Message, 4)
+	outPkg := make(chan *protocol.Message, 4)
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
 		for {
 			pkg, err := protocol.ReadSSF(in)
@@ -100,7 +99,7 @@ func TestUNIXBuffered(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *samplers.Message, 4)
+	outPkg := make(chan *protocol.Message, 4)
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
 		for {
 			pkg, err := protocol.ReadSSF(in)
@@ -204,7 +203,7 @@ func TestReconnectUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *samplers.Message, 4)
+	outPkg := make(chan *protocol.Message, 4)
 	// A server that can read one span and then immediately closes
 	// the connection:
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
@@ -272,7 +271,7 @@ func TestReconnectBufferedUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *samplers.Message, 4)
+	outPkg := make(chan *protocol.Message, 4)
 	// A server that can read one span and then immediately closes
 	// the connection:
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {


### PR DESCRIPTION
#### Summary

This change reduces the dependency footprint of veneur/trace, which should make it less difficult to pull into projects as a vendored dependency.

#### Motivation
Previously, `trace` depended on `samplers`, which pulls in stuff like hyperloglog and other veneur internals that users of our tracing library don't need/want.


#### Test plan
Regression tests still pass!


#### Rollout/monitoring/revert plan
Just merge, then bump the vendored package in libraries depending on this.

