### PR TITLE
Refactor veneur-emit to use SSF internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 2.0.0, in progress
 
+## Incompatible changes
+* The semantics around `veneur-emit` command timing have changed: `-shellCommand` argument has been renamed to `-command`, and `-command` is now gone. The only way to time a command is to provide the command and its arguments as separate arguments, the method of passing in a shell-escaped string is no longer supported.
+
 ## Added
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## Added
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
-* `veneur-emit` now takes a `-trace_id` and `-parent_id` argument, which (combined with `-ssf`) lets it submit spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
+* `veneur-emit` now takes `-span_service`, `-trace_id`, and `-parent_id` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
 
 ## Improvements
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
+* `veneur-emit` now takes a `-trace_id` and `-parent_id` argument, which (combined with `-ssf`) lets it submit spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
 
 ## Improvements
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -18,55 +18,117 @@ Full usage:
 ```
 Usage of veneur-emit:
   -command string
-    	Command to time. This will exec 'command', time it, and emit a timer metric.
+        Command to time. This will exec 'command', time it, and emit a timer metric.
   -count int
-    	Report a 'count' metric. Value must be an integer.
+        Report a 'count' metric. Value must be an integer.
   -debug
-    	Turns on debug messages.
+        Turns on debug messages.
   -e_aggr_key string
-    	Add an aggregation key to group event with others with same key.
+        Add an aggregation key to group event with others with same key.
   -e_alert_type string
-    	Alert type must be 'error', 'warning', 'info', or 'success'. (default "info")
+        Alert type must be 'error', 'warning', 'info', or 'success'. (default "info")
   -e_event_tags string
-    	Tag(s) for event, comma separated. Ex: 'service:airflow,host_type:qa'
+        Tag(s) for event, comma separated. Ex: 'service:airflow,host_type:qa'
   -e_hostname string
-    	Hostname for the event.
+        Hostname for the event.
   -e_priority string
-    	Priority of event. Must be 'low' or 'normal'. (default "normal")
+        Priority of event. Must be 'low' or 'normal'. (default "normal")
   -e_source_type string
-    	Add source type to the event.
+        Add source type to the event.
   -e_text string
-    	Text of event. Insert line breaks with an esaped slash (\\n) *
+        Text of event. Insert line breaks with an esaped slash (\\n) *
   -e_time string
-    	Add timestamp to the event. Default is the current Unix epoch timestamp.
+        Add timestamp to the event. Default is the current Unix epoch timestamp.
   -e_title string
-    	Title of event. Ex: 'An exception occurred' *
+        Title of event. Ex: 'An exception occurred' *
   -gauge float
-    	Report a 'gauge' metric. Value must be float64.
+        Report a 'gauge' metric. Value must be float64.
   -hostport string
-    	Address of destination (hostport or listening address URL).
+        Address of destination (hostport or listening address URL).
   -mode string
-    	Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'. (default "metric")
+        Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'. (default "metric")
   -name string
-    	Name of metric to report. Ex: 'daemontools.service.starts'
+        Name of metric to report. Ex: 'daemontools.service.starts'
+  -parent_span_id int
+        ID of the parent span.
   -sc_hostname string
-    	Add hostname to the event.
+        Add hostname to the event.
   -sc_msg string
-    	Message describing state of current state of service check.
+        Message describing state of current state of service check.
   -sc_name string
-    	Service check name. *
+        Service check name. *
   -sc_status string
-    	Integer corresponding to check status. (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)*
+        Integer corresponding to check status. (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)*
   -sc_tags string
-    	Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'
+        Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'
   -sc_time string
-    	Add timestamp to check. Default is current Unix epoch timestamp.
+        Add timestamp to check. Default is current Unix epoch timestamp.
   -shellCommand
-    	Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.
+        Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.
   -ssf
-    	Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)
+        Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)
   -tag string
-    	Tag(s) for metric, comma separated. Ex: 'service:airflow'
+        Tag(s) for metric, comma separated. Ex: 'service:airflow'
   -timing duration
-    	Report a 'timing' metric. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration).
+        Report a 'timing' metric. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration).
+  -trace_id int
+        ID for the trace (top-level) span. Setting a trace ID activated tracing.
+```
+
+Veneur-emit supports two different backend modes: dogstatsd mode (the
+default) and SSF (`-ssf`) mode. In dogstatsd mode, veneur-emit can
+submit metrics, servie checks and events in dogstatsd format. In SSF
+mode, veneur-emit can emit trace spans and metrics to a veneur
+instance.
+
+## Dogstatsd mode
+
+Increment a counter in dogstatsd mode:
+
+``` sh
+veneur-emit -hostport udp://127.0.0.1:8200 -name that.metric.name -tag hi:there -count 1
+```
+
+Time a command in dogstatsd mode:
+
+``` sh
+veneur-emit -hostport udp://127.0.0.1:8200 -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
+```
+
+Submit a service check in dogstatsd mode (this isn't supported in SSF yet):
+
+``` sh
+veneur-emit -hostport udp://127.0.0.1:8200 -sc_name my.service.check -sc_msg "I'm not dead" -sc_status OK
+```
+
+Submit an event in dogstatsd mode (this isn't supported in SSF yet):
+
+``` sh
+veneur-emit -hostport udp://127.0.0.1:8200 -e_text "Something went wrong:\\n\\nTell a lie, it's all good." -e_title "I'm just testing" -e_source_type "demonstration"
+```
+
+## SSF mode
+
+In SSF mode, veneur-emit will construct and submit an SSF span with
+optional metrics. SSF mode does not yet support events or service
+checks.
+
+Increment a counter in SSF mode:
+
+``` sh
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name that.metric.name -tag hi:there -count 1
+```
+
+Time a command in SSF mode:
+
+``` sh
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
+```
+
+Time a command in SSF mode and submit a trace span for the process
+(the `-trace_id` and `-parent_span_id` arguments need to be be set to
+the values from the parent of whatever is calling veneur-emit):
+
+``` sh
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
 ```

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -128,5 +128,5 @@ Time a command in SSF mode and submit a trace span for the process
 the values from the parent of whatever is calling veneur-emit):
 
 ``` sh
-veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -command sleep 30
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -span_service 'testing' -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -17,8 +17,6 @@ Full usage:
 
 ```
 Usage of veneur-emit:
-  -command string
-        Command to time. This will exec 'command', time it, and emit a timer metric.
   -count int
         Report a 'count' metric. Value must be an integer.
   -debug

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -61,7 +61,7 @@ Usage of veneur-emit:
         Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'
   -sc_time string
         Add timestamp to check. Default is current Unix epoch timestamp.
-  -shellCommand
+  -command
         Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.
   -ssf
         Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)
@@ -90,7 +90,7 @@ veneur-emit -hostport udp://127.0.0.1:8200 -name that.metric.name -tag hi:there 
 Time a command in dogstatsd mode:
 
 ``` sh
-veneur-emit -hostport udp://127.0.0.1:8200 -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
+veneur-emit -hostport udp://127.0.0.1:8200 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```
 
 Submit a service check in dogstatsd mode (this isn't supported in SSF yet):
@@ -120,7 +120,7 @@ veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name that.metric.nam
 Time a command in SSF mode:
 
 ``` sh
-veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```
 
 Time a command in SSF mode and submit a trace span for the process
@@ -128,5 +128,5 @@ Time a command in SSF mode and submit a trace span for the process
 the values from the parent of whatever is calling veneur-emit):
 
 ``` sh
-veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -shellCommand sleep 30
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -140,6 +140,10 @@ func main() {
 			}
 		}
 	} else if *mode == "event" {
+		if *toSSF {
+			logrus.WithField("mode", *mode).
+				Fatal("Unsupported mode with SSF")
+		}
 		logrus.Debug("Sending event")
 		nconn, _ := net.Dial(network, addr)
 		pkt, err := buildEventPacket(passedFlags)
@@ -149,6 +153,10 @@ func main() {
 		nconn.Write(pkt.Bytes())
 		logrus.Debugf("Buffer string: %s", pkt.String())
 	} else if *mode == "sc" {
+		if *toSSF {
+			logrus.WithField("mode", *mode).
+				Fatal("Unsupported mode with SSF")
+		}
 		logrus.Debug("Sending service check")
 		nconn, _ := net.Dial(network, addr)
 		pkt, err := buildSCPacket(passedFlags)

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -77,7 +77,7 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	addr, netAddr, err := destination(passedFlags, hostport, *toSSF)
+	addr, netAddr, err := destination(hostport, *toSSF)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting destination address.")
 	}
@@ -165,10 +165,10 @@ func tags(tag string) []string {
 	return tags
 }
 
-func destination(passedFlags map[string]flag.Value, hostport *string, useSSF bool) (string, net.Addr, error) {
+func destination(hostport *string, useSSF bool) (string, net.Addr, error) {
 	var addr string
-	if passedFlags["hostport"] != nil {
-		addr = passedFlags["hostport"].String()
+	if hostport != nil {
+		addr = *hostport
 	} else {
 		return "", nil, errors.New("you must specify a valid hostport")
 	}

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -174,13 +174,22 @@ func flags() map[string]flag.Value {
 	return passedFlags
 }
 
-func tags(tag string) []string {
-	var tags []string
-	if len(tag) == 0 {
+func ssfTags(csv string) map[string]string {
+	tags := map[string]string{}
+	if len(csv) == 0 {
 		return tags
 	}
-	for _, elem := range strings.Split(tag, ",") {
-		tags = append(tags, elem)
+	for _, elem := range strings.Split(csv, ",") {
+		if len(elem) == 0 {
+			continue
+		}
+		tag := strings.Split(elem, ":")
+		switch len(tag) {
+		case 2:
+			tags[tag[0]] = tag[1]
+		case 1:
+			tags[tag[0]] = ""
+		}
 	}
 	return tags
 }
@@ -219,11 +228,7 @@ func setupSpan(traceID, parentID *int64, name, tags string) (*ssf.SSFSpan, error
 		}
 		span.Id = bigid.Int64()
 		span.Name = name
-		span.Tags = map[string]string{}
-		for _, elem := range strings.Split(tags, ",") {
-			tag := strings.Split(elem, ":")
-			span.Tags[tag[0]] = tag[1]
-		}
+		span.Tags = ssfTags(tags)
 	}
 	return span, nil
 }

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -27,10 +27,10 @@ import (
 
 var (
 	// Generic flags
-	hostport     = flag.String("hostport", "", "Address of destination (hostport or listening address URL).")
-	mode         = flag.String("mode", "metric", "Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'.")
-	debug        = flag.Bool("debug", false, "Turns on debug messages.")
-	shellCommand = flag.Bool("shellCommand", false, "Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.")
+	hostport = flag.String("hostport", "", "Address of destination (hostport or listening address URL).")
+	mode     = flag.String("mode", "metric", "Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'.")
+	debug    = flag.Bool("debug", false, "Turns on debug messages.")
+	command  = flag.Bool("command", false, "Turns on command-timing mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.")
 
 	// Metric flags
 	name   = flag.String("name", "", "Name of metric to report. Ex: 'daemontools.service.starts'")
@@ -272,7 +272,7 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 	var err error
 	status := 0
 	if *mode == "metric" {
-		if *shellCommand {
+		if *command {
 			var start, ended time.Time
 
 			status, start, ended, err = timeCommand(flag.Args())

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -162,7 +162,7 @@ func main() {
 func flags() map[string]flag.Value {
 	flag.Parse()
 	// hacky way to detect which flags were *actually* set
-	passedFlags := make(map[string]flag.Value)
+	passedFlags := map[string]flag.Value{}
 	flag.Visit(func(f *flag.Flag) {
 		passedFlags[f.Name] = f.Value
 	})
@@ -210,7 +210,7 @@ func setupSpan(traceID, parentID *int64, name, tags string) *ssf.SSFSpan {
 		}
 		span.Id = rand.Int63()
 		span.Name = name
-		span.Tags = make(map[string]string)
+		span.Tags = map[string]string{}
 		for _, elem := range strings.Split(tags, ",") {
 			tag := strings.Split(elem, ":")
 			span.Tags[tag[0]] = tag[1]
@@ -241,7 +241,7 @@ func timeCommand(command []string) (exitStatus int, start time.Time, ended time.
 func bareMetric(name string, tags string) *ssf.SSFSample {
 	metric := &ssf.SSFSample{}
 	metric.Name = name
-	metric.Tags = make(map[string]string)
+	metric.Tags = map[string]string{}
 	if tags != "" {
 		for _, elem := range strings.Split(tags, ",") {
 			tag := strings.Split(elem, ":")

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -203,7 +203,7 @@ func destination(hostport *string, useSSF bool) (string, net.Addr, error) {
 
 func setupSpan(traceID, parentID *int64, name, tags string) *ssf.SSFSpan {
 	span := &ssf.SSFSpan{}
-	if *toSSF && traceID != nil {
+	if traceID != nil {
 		span.TraceId = *traceID
 		if parentID != nil {
 			span.ParentId = *parentID

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -255,7 +255,7 @@ func timingSample(duration time.Duration, name string, tags string) *ssf.SSFSamp
 	m := bareMetric(name, tags)
 	m.Metric = ssf.SSFSample_HISTOGRAM
 	m.Unit = "ms"
-	m.Value = float32(duration * time.Millisecond)
+	m.Value = float32(duration / time.Millisecond)
 	return m
 }
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -255,7 +255,7 @@ func timingSample(duration time.Duration, name string, tags string) *ssf.SSFSamp
 	m := bareMetric(name, tags)
 	m.Metric = ssf.SSFSample_HISTOGRAM
 	m.Unit = "ms"
-	m.Value = float32(duration / time.Millisecond)
+	m.Value = float32(duration * time.Millisecond)
 	return m
 }
 
@@ -340,6 +340,9 @@ func sendStatsd(addr string, span *ssf.SSFSpan) error {
 			err = client.Gauge(metric.Name, float64(metric.Value), tags, 1.0)
 		case ssf.SSFSample_HISTOGRAM:
 			if metric.Unit == "ms" {
+				// Treating the "ms" unit special is a
+				// bit wonky, but it seems like the
+				// right tool for the job here:
 				err = client.TimeInMilliseconds(metric.Name, float64(metric.Value), tags, 1.0)
 			} else {
 				err = client.Histogram(metric.Name, float64(metric.Value), tags, 1.0)

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -63,6 +63,7 @@ var (
 	// Tracing flags
 	traceID  = flag.Int64("trace_id", 0, "ID for the trace (top-level) span. Setting a trace ID activated tracing.")
 	parentID = flag.Int64("parent_span_id", 0, "ID of the parent span.")
+	service  = flag.String("span_service", "veneur-emit", "Service name to associate with the span.")
 )
 
 // MinimalClient represents the functions that we call on Clients in veneur-emit.
@@ -229,6 +230,7 @@ func setupSpan(traceID, parentID *int64, name, tags string) (*ssf.SSFSpan, error
 		span.Id = bigid.Int64()
 		span.Name = name
 		span.Tags = ssfTags(tags)
+		span.Service = *service
 	}
 	return span, nil
 }

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -30,7 +30,6 @@ var (
 	hostport     = flag.String("hostport", "", "Address of destination (hostport or listening address URL).")
 	mode         = flag.String("mode", "metric", "Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'.")
 	debug        = flag.Bool("debug", false, "Turns on debug messages.")
-	command      = flag.String("command", "", "Command to time. This will exec 'command', time it, and emit a timer metric.")
 	shellCommand = flag.Bool("shellCommand", false, "Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.")
 
 	// Metric flags

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -75,7 +75,8 @@ func TestTimeCommand(t *testing.T) {
 func TestGauge(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["gauge"] = newValue("3")
-	span, _, err := createMetric(testFlag, "testMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 1)
 	assert.Equal(t, ssf.SSFSample_GAUGE, span.Metrics[0].Metric)
@@ -86,7 +87,8 @@ func TestGauge(t *testing.T) {
 func TestCount(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["count"] = newValue("3")
-	span, _, err := createMetric(testFlag, "testMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 1)
 	assert.Equal(t, ssf.SSFSample_COUNTER, span.Metrics[0].Metric)
@@ -97,7 +99,8 @@ func TestCount(t *testing.T) {
 func TestTiming(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["timing"] = newValue("3ms")
-	span, _, err := createMetric(testFlag, "testMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 1)
 	assert.Equal(t, ssf.SSFSample_HISTOGRAM, span.Metrics[0].Metric)
@@ -110,7 +113,8 @@ func TestMultiple(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["gauge"] = newValue("3")
 	testFlag["count"] = newValue("2")
-	span, _, err := createMetric(testFlag, "testMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 2)
 	assert.Equal(t, "testMetric", span.Metrics[1].Name)
@@ -119,7 +123,8 @@ func TestMultiple(t *testing.T) {
 
 func TestNone(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
-	span, _, err := createMetric(testFlag, "testMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 0)
 }
@@ -128,17 +133,18 @@ func TestBadCalls(t *testing.T) {
 	var err error
 	testFlag := make(map[string]flag.Value)
 	testFlag["gauge"] = newValue("notanumber")
-	_, _, err = createMetric(testFlag, "testBadMetric", "")
+	span := &ssf.SSFSpan{}
+	_, err = createMetric(span, testFlag, "testBadMetric", "")
 	assert.Error(t, err)
 
 	testFlag = make(map[string]flag.Value)
 	testFlag["timing"] = newValue("40megayears")
-	_, _, err = createMetric(testFlag, "testBadMetric", "")
+	_, err = createMetric(span, testFlag, "testBadMetric", "")
 	assert.Error(t, err)
 
 	testFlag = make(map[string]flag.Value)
 	testFlag["count"] = newValue("four")
-	_, _, err = createMetric(testFlag, "testBadMetric", "")
+	_, err = createMetric(span, testFlag, "testBadMetric", "")
 	assert.Error(t, err)
 }
 
@@ -209,7 +215,8 @@ func TestCreateMetrics(t *testing.T) {
 
 	testFlag["gauge"] = newValue("3.14")
 	testFlag["count"] = newValue("2")
-	span, _, err := createMetric(testFlag, "test.metric", "tag1:value1")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "test.metric", "tag1:value1")
 	assert.NoError(t, err)
 	assert.Len(t, span.Metrics, 2)
 	for _, metric := range span.Metrics {
@@ -244,7 +251,8 @@ func (tb *testBackend) FlushSync(ctx context.Context) error {
 func TestSendSpan(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	dataWritten = []byte{}
-	span, _, _ := createMetric(testFlag, "test.metric", "tag1:value1")
+	span := &ssf.SSFSpan{}
+	_, _ = createMetric(span, testFlag, "test.metric", "tag1:value1")
 
 	ch := make(chan *ssf.SSFSpan, 1)
 	errors := make(chan error, 1)
@@ -265,7 +273,8 @@ func TestBadSendSpan(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	dataWritten = []byte{}
 
-	span, _, _ := createMetric(testFlag, "test.metric", "tag1:value1")
+	span := &ssf.SSFSpan{}
+	_, _ = createMetric(span, testFlag, "test.metric", "tag1:value1")
 
 	ch := make(chan *ssf.SSFSpan, 1)
 	errors := make(chan error, 1)

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -33,10 +31,6 @@ var (
 	dataWritten []byte
 )
 
-type fakeClient struct {
-	Tags []string
-}
-
 type fakeValue struct {
 	value string
 }
@@ -52,41 +46,6 @@ func (v *fakeValue) Set(s string) error {
 
 func newValue(s string) *fakeValue {
 	return &fakeValue{value: s}
-}
-
-func (c *fakeClient) Gauge(name string, value float64, tags []string, rate float64) error {
-	calledFunctions["gauge"] = true
-	if badCall {
-		return errors.New("error sending metric")
-	}
-	return nil
-}
-func (c *fakeClient) Count(name string, value int64, tags []string, rate float64) error {
-	calledFunctions["count"] = true
-	if badCall {
-		return errors.New("error sending metric")
-	}
-	return nil
-}
-func (c *fakeClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	calledFunctions["timing"] = true
-	if badCall {
-		return errors.New("error sending metric")
-	}
-	return nil
-}
-
-type fakeConn struct{}
-
-func (c *fakeConn) Write(data []byte) (int, error) {
-	dataWritten = data
-	return len(data), nil
-}
-
-type badConn struct{}
-
-func (c *badConn) Write(data []byte) (int, error) {
-	return 0, errors.New("bad write")
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -246,6 +247,24 @@ func (tb *testBackend) SendSync(ctx context.Context, span *ssf.SSFSpan) error {
 
 func (tb *testBackend) FlushSync(ctx context.Context) error {
 	return nil
+}
+
+func TestSetupSpanWithTracing(t *testing.T) {
+	span := setupSpan(proto.Int64(1), proto.Int64(2), "oink", "hi:there")
+	assert.NotZero(t, span.Id)
+	assert.Equal(t, int64(1), span.TraceId)
+	assert.Equal(t, int64(2), span.ParentId)
+	assert.Equal(t, "oink", span.Name)
+	assert.Equal(t, 1, len(span.Tags))
+}
+
+func TestSetupSpanWithoutTracing(t *testing.T) {
+	span := setupSpan(nil, nil, "oink", "hi:there")
+	assert.Zero(t, span.Id)
+	assert.Zero(t, span.TraceId)
+	assert.Zero(t, span.ParentId)
+	assert.Equal(t, "", span.Name)
+	assert.Equal(t, 0, len(span.Tags))
 }
 
 func TestSendSpan(t *testing.T) {

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -175,17 +175,10 @@ func TestNilHostport(t *testing.T) {
 }
 
 func TestTags(t *testing.T) {
-	testTag := "tag1,tag2,tag3"
-	expectedOutput := []string{"tag1", "tag2", "tag3"}
-	output := tags(testTag)
-	if len(expectedOutput) != len(output) {
-		t.Error("Did not return correct tags array.")
-	}
-	for i := 0; i < len(output); i++ {
-		if expectedOutput[i] != output[i] {
-			t.Error("Did not return correct tags array.")
-		}
-	}
+	testTag := "tag1,tag2,tag3,,tag4:value"
+	expectedOutput := map[string]string{"tag1": "", "tag2": "", "tag3": "", "tag4": "value"}
+	output := ssfTags(testTag)
+	assert.Equal(t, expectedOutput, output)
 }
 
 func TestFlags(t *testing.T) {

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -250,21 +250,25 @@ func (tb *testBackend) FlushSync(ctx context.Context) error {
 }
 
 func TestSetupSpanWithTracing(t *testing.T) {
-	span := setupSpan(proto.Int64(1), proto.Int64(2), "oink", "hi:there")
-	assert.NotZero(t, span.Id)
-	assert.Equal(t, int64(1), span.TraceId)
-	assert.Equal(t, int64(2), span.ParentId)
-	assert.Equal(t, "oink", span.Name)
-	assert.Equal(t, 1, len(span.Tags))
+	span, err := setupSpan(proto.Int64(1), proto.Int64(2), "oink", "hi:there")
+	if assert.NoError(t, err) {
+		assert.NotZero(t, span.Id)
+		assert.Equal(t, int64(1), span.TraceId)
+		assert.Equal(t, int64(2), span.ParentId)
+		assert.Equal(t, "oink", span.Name)
+		assert.Equal(t, 1, len(span.Tags))
+	}
 }
 
 func TestSetupSpanWithoutTracing(t *testing.T) {
-	span := setupSpan(nil, nil, "oink", "hi:there")
-	assert.Zero(t, span.Id)
-	assert.Zero(t, span.TraceId)
-	assert.Zero(t, span.ParentId)
-	assert.Equal(t, "", span.Name)
-	assert.Equal(t, 0, len(span.Tags))
+	span, err := setupSpan(nil, nil, "oink", "hi:there")
+	if assert.NoError(t, err) {
+		assert.Zero(t, span.Id)
+		assert.Zero(t, span.TraceId)
+		assert.Zero(t, span.ParentId)
+		assert.Equal(t, "", span.Name)
+		assert.Equal(t, 0, len(span.Tags))
+	}
 }
 
 func TestSendSpan(t *testing.T) {

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -143,10 +143,8 @@ func TestBadCalls(t *testing.T) {
 }
 
 func TestHostport(t *testing.T) {
-	testFlag := make(map[string]flag.Value)
 	testHostport := "127.0.0.1:8200"
-	testFlag["hostport"] = newValue(testHostport)
-	addr, netAddr, err := destination(testFlag, &testHostport, false)
+	addr, netAddr, err := destination(&testHostport, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "udp://127.0.0.1:8200", addr)
 	assert.Equal(t, "127.0.0.1:8200", netAddr.String())
@@ -154,10 +152,8 @@ func TestHostport(t *testing.T) {
 }
 
 func TestHostportAsURL(t *testing.T) {
-	testFlag := make(map[string]flag.Value)
 	testHostport := "tcp://127.0.0.1:8200"
-	testFlag["hostport"] = newValue(testHostport)
-	addr, netAddr, err := destination(testFlag, &testHostport, false)
+	addr, netAddr, err := destination(&testHostport, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "tcp://127.0.0.1:8200", addr)
 	assert.Equal(t, "tcp", netAddr.Network())
@@ -165,8 +161,7 @@ func TestHostportAsURL(t *testing.T) {
 }
 
 func TestNilHostport(t *testing.T) {
-	testFlag := make(map[string]flag.Value)
-	addr, netAddr, err := destination(testFlag, nil, false)
+	addr, netAddr, err := destination(nil, false)
 	assert.Empty(t, addr)
 	assert.Nil(t, netAddr)
 	assert.Error(t, err)


### PR DESCRIPTION
#### Summary

This PR refactors `veneur-emit` to use SSF as its internal data representation, which reduces the places that logic has to happen to a single place, and makes it much more comfortable to submit data via SSF.

In addition, this PR:

* Adds a `-parent_id` and `-trace_id` flag, which makes veneur-emit generate SSF spans for tracing (they're only relevant when timing command line programs)
* Refactors tests to more directly assert stuff is happening and gets rid of a bunch of mocks in the process.

Still todo:

- [ ] figure out which of `-command` or `-shellCommand` we want to keep (it currently keeps `-shellCommand` but it's a displeasing name)

#### Motivation
Currently, veneur-emit duplicates a lot of code to support both SSF and dogstatsd, and in doing so doesn't implement all features that dogstatsd supports. I'd like to get rid of the duplication & elevate SSF to a fully supported thing in v-e.

#### Test plan

- Added tests
- [x] check that `veneur-emit -timing 20.3s -name some.timing.command` reports the right amount of time (it previously reported milliseconds)
- [x] roll to a QA machine:
 - [x] time a command in tracing mode
 - [x]  time a command with SSF and no tracing mode
 - [x]  time a command with dogstatsd

#### Rollout/monitoring/revert plan
Merge & push when necessary. This PR doesn't change commandlines incompatibly.

