### PR TITLE
Include all veneur executables (and add to PATH) in docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Veneur no longer **requires** the use of Datadog as a target for flushes. Veneur can now use one or more of any of it's supported sinks as a backend. This realizes our desire for Veneur to be fully vendor agnostic. Thanks [gphat](https://github.com/gphat)!
 * The package `github.com/stripe/veneur/trace` now depends on fewer other packages across veneur, making it easier to pull in `trace` as a dependency. Thanks [antifuchs](https://github.com/antifuchs)!
 * A veneur server with tracing enabled now submits traces and spans concerning its own operation to itself internally without sending them over UDP. Thanks [antifuchs](https://github.com/antifuchs)!
+* veneur-prometheus and veneur-proxy executables are now included in the docker images. Thanks [jac](https://github.com/jac-stripe)
+* All veneur executables are now in $PATH in the docker images. Thanks [jac](https://github.com/jac-stripe)
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/public-docker-images/Dockerfile-alpine
+++ b/public-docker-images/Dockerfile-alpine
@@ -41,6 +41,8 @@ RUN go test -v -timeout 60s -ldflags "-X github.com/stripe/veneur.VERSION=$(git 
 FROM test AS build
 RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur ./cmd/veneur
 RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-emit ./cmd/veneur-emit
+RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-prometheus ./cmd/veneur-prometheus
+RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-proxy ./cmd/veneur-proxy
 
 
 FROM alpine:3.6 AS release
@@ -49,4 +51,5 @@ WORKDIR /veneur/
 EXPOSE 8126/UDP 8126/TCP 8127/TCP 8128/UDP
 COPY --from=build /build/* /veneur/
 COPY --from=src /go/src/github.com/stripe/veneur/example.yaml /veneur/config.yaml
+ENV PATH="/veneur:${PATH}"
 CMD ["/veneur/veneur", "-f", "config.yaml"]

--- a/public-docker-images/Dockerfile-debian-sid
+++ b/public-docker-images/Dockerfile-debian-sid
@@ -39,6 +39,8 @@ RUN go test -race -v -timeout 60s -ldflags "-X github.com/stripe/veneur.VERSION=
 FROM test AS build
 RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur ./cmd/veneur
 RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-emit ./cmd/veneur-emit
+RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-prometheus ./cmd/veneur-prometheus
+RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-proxy ./cmd/veneur-proxy
 
 
 FROM debian:sid AS release
@@ -47,4 +49,5 @@ WORKDIR /veneur/
 EXPOSE 8126/UDP 8126/TCP 8127/TCP 8128/UDP
 COPY --from=build /build/* /veneur/
 COPY --from=src /go/src/github.com/stripe/veneur/example.yaml /veneur/config.yaml
+ENV PATH="/veneur:${PATH}"
 CMD ["/veneur/veneur", "-f", "config.yaml"]


### PR DESCRIPTION
#### Summary
Include all veneur executables (and add to PATH) in docker images


#### Motivation
veneur-prometheus is useful, so it should be included in the docker image. All executables should also be in $PATH.


#### Test plan
- built both images
- docker ran them
- veneur executable was in $PATH for both of them
- veneur-prometheus executable seemed to execute


#### Rollout/monitoring/revert plan
the docker images will need to be built and pushed again

