### PR TITLE
Log RNG seed during tests

### DIFF
--- a/samplers/metrictype_string.go
+++ b/samplers/metrictype_string.go
@@ -2,7 +2,7 @@
 
 package samplers
 
-import "fmt"
+import "strconv"
 
 const _MetricType_name = "CounterMetricGaugeMetric"
 
@@ -10,7 +10,7 @@ var _MetricType_index = [...]uint8{0, 13, 24}
 
 func (i MetricType) String() string {
 	if i < 0 || i >= MetricType(len(_MetricType_index)-1) {
-		return fmt.Sprintf("MetricType(%d)", i)
+		return "MetricType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _MetricType_name[_MetricType_index[i]:_MetricType_index[i+1]]
 }

--- a/server_test.go
+++ b/server_test.go
@@ -38,6 +38,14 @@ const DefaultServerTimeout = 100 * time.Millisecond
 
 var DebugMode bool
 
+func seedRand() {
+	seed := time.Now().Unix()
+	log.WithFields(logrus.Fields{
+		"randSeed": seed,
+	}).Info("Re-seeding random number generator")
+	rand.Seed(seed)
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	DebugMode = flag.Lookup("test.v").Value.(flag.Getter).Get().(bool)
@@ -404,7 +412,7 @@ func TestLocalServerMixedMetrics(t *testing.T) {
 }
 
 func TestSplitBytes(t *testing.T) {
-	rand.Seed(time.Now().Unix())
+	seedRand()
 	buf := make([]byte, 1000)
 
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
#### Summary

This only applies to the top-level veneur package, not `tdigest` or `trace`. The former doesn't currently import a logger, and I'd rather not add it just for this ticket unless we need it. The latter does, but the functionality that we test doesn't use the RNG directly, and it's unclear that it would either be useful or usable if we did log the seed for the tests in that package.

#### Motivation

https://jira.corp.stripe.com/browse/OBS-2034

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @stripe/observability