### PR TITLE
Emit a timer for every indicator span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Added
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 
+## Improvements
+* Veneur now emits a timer metric for every "indicator" span that it receives. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 # 1.8.1, 2017-12-05
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Improvements
-* Veneur now emits a timer metric for every "indicator" span that it receives. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 1.8.1, 2017-12-05
 

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ForwardAddress                string    `yaml:"forward_address"`
 	Hostname                      string    `yaml:"hostname"`
 	HTTPAddress                   string    `yaml:"http_address"`
+	IndicatorSpanTimerName        string    `yaml:"indicator_span_timer_name"`
 	Interval                      string    `yaml:"interval"`
 	Key                           string    `yaml:"key"`
 	MetricMaxLength               int       `yaml:"metric_max_length"`

--- a/example.yaml
+++ b/example.yaml
@@ -58,7 +58,10 @@ stats_address: "localhost:8126"
 # http_address: "einhorn@0"
 http_address: "localhost:8127"
 
-
+# The name of timer metrics that "indicator" spans should be tracked
+# under. If this is unset, veneur doesn't report an additional timer
+# metric for indicator spans.
+indicator_span_timer_name: "indicator_span.duration_ms"
 
 # == METRICS CONFIGURATION ==
 

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -88,14 +88,19 @@ func ConvertIndicatorMetrics(span *ssf.SSFSpan, timerName string) (metrics []UDP
 
 	end := time.Unix(span.EndTimestamp/1e9, span.EndTimestamp%1e9)
 	start := time.Unix(span.StartTimestamp/1e9, span.StartTimestamp%1e9)
+	tags := map[string]string{
+		"name":    span.Name,
+		"service": span.Service,
+		"error":   "false",
+	}
+	if span.Error {
+		tags["error"] = "true"
+	}
 	ssfTimer := &ssf.SSFSample{
 		Metric: ssf.SSFSample_HISTOGRAM,
 		Name:   timerName,
 		Value:  float32(end.Sub(start) * time.Millisecond),
-		Tags: map[string]string{
-			"name":    span.Name,
-			"service": span.Service,
-		},
+		Tags:   tags,
 	}
 	timer, err := ParseMetricSSF(ssfTimer)
 	if err != nil {


### PR DESCRIPTION


#### Summary
This change makes veneur track a timer for every indicator SSF span that it receives, tagged with the name of the service and the name of the span.

#### Motivation
Indicator are so versatile, we should use them for more stuff, and this is a very quick & easy thing to use them for!


#### Test plan
Wrote a positive and a negative test for this.


#### Rollout/monitoring/revert plan
Merge!

