### PR TITLE
Move HTTP postHelper to it's own package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * When starting, Veneur will now delay it's first metric to be aligned with an `interval` boundary on the local clock. This will effectively "synchronize" Veneur instances across your deployment assuming reasonable clock behavior. The result is a metric timestamps in your TSDB that mostly line up improving bucketing behavior. Thanks [gphat](https://github.com/gphat)!
 * Cleaned up some linter warnings. Thanks [gphat](https://github.com/gphat)!
 * Tests no longer depend on implicit presence of a Datadog metric or span sink. Thanks [gphat](https://github.com/gphat)!
+* Refactor internal HTTP helper into it's own package fix up possible circular deps. Thanks [gphat](https://github.com/gphat)!
 
 ## Bugfixes
 * Fix a panic when using `veneur-emit` to emit metrics via `-ssf` when no tags are specified. Thanks [myndzi](https://github.com/myndzi)

--- a/flusher.go
+++ b/flusher.go
@@ -1,21 +1,16 @@
 package veneur
 
 import (
-	"bytes"
-	"compress/zlib"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"net/http"
 	"net/url"
 	"runtime"
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/http"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/trace"
@@ -344,7 +339,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 
 	// the error has already been logged (if there was one), so we only care
 	// about the success case
-	if postHelper(span.Attach(ctx), s.HTTPClient, s.Statsd, s.TraceClient, endpoint, jsonMetrics, "forward", true) == nil {
+	if http.PostHelper(span.Attach(ctx), s.HTTPClient, s.Statsd, s.TraceClient, endpoint, jsonMetrics, "forward", true, log) == nil {
 		log.WithField("metrics", len(jsonMetrics)).Info("Completed forward to upstream Veneur")
 	}
 }
@@ -386,113 +381,4 @@ func (s *Server) flushTraces(ctx context.Context) {
 	}
 
 	s.SpanWorker.Flush()
-}
-
-// shared code for POSTing to an endpoint, that consumes JSON, that is zlib-
-// compressed, that returns 202 on success, that has a small response
-// action is a string used for statsd metric names and log messages emitted from
-// this function - probably a static string for each callsite
-// you can disable compression with compress=false for endpoints that don't
-// support it
-func postHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Client, tc *trace.Client, endpoint string, bodyObject interface{}, action string, compress bool) error {
-	span, _ := trace.StartSpanFromContext(ctx, "")
-	span.SetTag("action", action)
-	defer span.ClientFinish(tc)
-
-	// attach this field to all the logs we generate
-	innerLogger := log.WithField("action", action)
-
-	marshalStart := time.Now()
-	var (
-		bodyBuffer bytes.Buffer
-		encoder    *json.Encoder
-		compressor *zlib.Writer
-	)
-	if compress {
-		compressor = zlib.NewWriter(&bodyBuffer)
-		encoder = json.NewEncoder(compressor)
-	} else {
-		encoder = json.NewEncoder(&bodyBuffer)
-	}
-	if err := encoder.Encode(bodyObject); err != nil {
-		stats.Count(action+".error_total", 1, []string{"cause:json"}, 1.0)
-		innerLogger.WithError(err).Error("Could not render JSON")
-		return err
-	}
-	if compress {
-		// don't forget to flush leftover compressed bytes to the buffer
-		if err := compressor.Close(); err != nil {
-			stats.Count(action+".error_total", 1, []string{"cause:compress"}, 1.0)
-			innerLogger.WithError(err).Error("Could not finalize compression")
-			return err
-		}
-	}
-	stats.TimeInMilliseconds(action+".duration_ns", float64(time.Since(marshalStart).Nanoseconds()), []string{"part:json"}, 1.0)
-
-	// Len reports the unread length, so we have to record this before the
-	// http client consumes it
-	bodyLength := bodyBuffer.Len()
-	stats.Histogram(action+".content_length_bytes", float64(bodyLength), nil, 1.0)
-
-	req, err := http.NewRequest(http.MethodPost, endpoint, &bodyBuffer)
-
-	if err != nil {
-		stats.Count(action+".error_total", 1, []string{"cause:construct"}, 1.0)
-		innerLogger.WithError(err).Error("Could not construct request")
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if compress {
-		req.Header.Set("Content-Encoding", "deflate")
-	}
-	// we only make http requests at flush time, so keepalive is not a big win
-	req.Close = true
-
-	err = tracer.InjectRequest(span.Trace, req)
-	if err != nil {
-		stats.Count("veneur.opentracing.flush.inject.errors", 1, nil, 1.0)
-		innerLogger.WithError(err).Error("Error injecting header")
-	}
-
-	requestStart := time.Now()
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		if urlErr, ok := err.(*url.Error); ok {
-			// if the error has the url in it, then retrieve the inner error
-			// and ditch the url (which might contain secrets)
-			err = urlErr.Err
-		}
-		stats.Count(action+".error_total", 1, []string{"cause:io"}, 1.0)
-		innerLogger.WithError(err).Error("Could not execute request")
-		return err
-	}
-	stats.TimeInMilliseconds(action+".duration_ns", float64(time.Since(requestStart).Nanoseconds()), []string{"part:post"}, 1.0)
-	defer resp.Body.Close()
-
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		// this error is not fatal, since we only need the body for reporting
-		// purposes
-		stats.Count(action+".error_total", 1, []string{"cause:readresponse"}, 1.0)
-		innerLogger.WithError(err).Error("Could not read response body")
-	}
-	resultLogger := innerLogger.WithFields(logrus.Fields{
-		"endpoint":         endpoint,
-		"request_length":   bodyLength,
-		"request_headers":  req.Header,
-		"status":           resp.Status,
-		"response_headers": resp.Header,
-		"response":         string(responseBody),
-	})
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		stats.Count(action+".error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
-		resultLogger.Error("Could not POST")
-		return err
-	}
-
-	// make sure the error metric isn't sparse
-	stats.Count(action+".error_total", 0, nil, 1.0)
-	resultLogger.Debug("POSTed successfully")
-	return nil
 }

--- a/http/http.go
+++ b/http/http.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/trace"
+)
+
+var tracer = trace.GlobalTracer
+
+// shared code for POSTing to an endpoint, that consumes JSON, that is zlib-
+// compressed, that returns 202 on success, that has a small response
+// action is a string used for statsd metric names and log messages emitted from
+// this function - probably a static string for each callsite
+// you can disable compression with compress=false for endpoints that don't
+// support it
+func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Client, tc *trace.Client, endpoint string, bodyObject interface{}, action string, compress bool, log *logrus.Logger) error {
+	span, _ := trace.StartSpanFromContext(ctx, "")
+	span.SetTag("action", action)
+	defer span.ClientFinish(tc)
+
+	// attach this field to all the logs we generate
+	innerLogger := log.WithField("action", action)
+
+	marshalStart := time.Now()
+	var (
+		bodyBuffer bytes.Buffer
+		encoder    *json.Encoder
+		compressor *zlib.Writer
+	)
+	if compress {
+		compressor = zlib.NewWriter(&bodyBuffer)
+		encoder = json.NewEncoder(compressor)
+	} else {
+		encoder = json.NewEncoder(&bodyBuffer)
+	}
+	if err := encoder.Encode(bodyObject); err != nil {
+		stats.Count(action+".error_total", 1, []string{"cause:json"}, 1.0)
+		innerLogger.WithError(err).Error("Could not render JSON")
+		return err
+	}
+	if compress {
+		// don't forget to flush leftover compressed bytes to the buffer
+		if err := compressor.Close(); err != nil {
+			stats.Count(action+".error_total", 1, []string{"cause:compress"}, 1.0)
+			innerLogger.WithError(err).Error("Could not finalize compression")
+			return err
+		}
+	}
+	stats.TimeInMilliseconds(action+".duration_ns", float64(time.Since(marshalStart).Nanoseconds()), []string{"part:json"}, 1.0)
+
+	// Len reports the unread length, so we have to record this before the
+	// http client consumes it
+	bodyLength := bodyBuffer.Len()
+	stats.Histogram(action+".content_length_bytes", float64(bodyLength), nil, 1.0)
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, &bodyBuffer)
+
+	if err != nil {
+		stats.Count(action+".error_total", 1, []string{"cause:construct"}, 1.0)
+		innerLogger.WithError(err).Error("Could not construct request")
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if compress {
+		req.Header.Set("Content-Encoding", "deflate")
+	}
+	// we only make http requests at flush time, so keepalive is not a big win
+	req.Close = true
+
+	err = tracer.InjectRequest(span.Trace, req)
+	if err != nil {
+		stats.Count("veneur.opentracing.flush.inject.errors", 1, nil, 1.0)
+		innerLogger.WithError(err).Error("Error injecting header")
+	}
+
+	requestStart := time.Now()
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok {
+			// if the error has the url in it, then retrieve the inner error
+			// and ditch the url (which might contain secrets)
+			err = urlErr.Err
+		}
+		stats.Count(action+".error_total", 1, []string{"cause:io"}, 1.0)
+		innerLogger.WithError(err).Error("Could not execute request")
+		return err
+	}
+	stats.TimeInMilliseconds(action+".duration_ns", float64(time.Since(requestStart).Nanoseconds()), []string{"part:post"}, 1.0)
+	defer resp.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		// this error is not fatal, since we only need the body for reporting
+		// purposes
+		stats.Count(action+".error_total", 1, []string{"cause:readresponse"}, 1.0)
+		innerLogger.WithError(err).Error("Could not read response body")
+	}
+	resultLogger := innerLogger.WithFields(logrus.Fields{
+		"endpoint":         endpoint,
+		"request_length":   bodyLength,
+		"request_headers":  req.Header,
+		"status":           resp.Status,
+		"response_headers": resp.Header,
+		"response":         string(responseBody),
+	})
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		stats.Count(action+".error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
+		resultLogger.Error("Could not POST")
+		return err
+	}
+
+	// make sure the error metric isn't sparse
+	stats.Count(action+".error_total", 0, nil, 1.0)
+	resultLogger.Debug("POSTed successfully")
+	return nil
+}

--- a/proxy.go
+++ b/proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/profile"
 	"github.com/sirupsen/logrus"
+	vhttp "github.com/stripe/veneur/http"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/trace"
 	"github.com/zenazn/goji/bind"
@@ -310,7 +311,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// this endpoint is not documented to take an array... but it does
 			// another curious constraint of this endpoint is that it does not
 			// support "Content-Encoding: deflate"
-			err = postHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "flush_traces", false)
+			err = vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "flush_traces", false, log)
 
 			if err == nil {
 				log.WithFields(logrus.Fields{
@@ -375,7 +376,7 @@ func (p *Proxy) doPost(wg *sync.WaitGroup, destination string, batch []samplers.
 		return
 	}
 
-	err = postHelper(context.TODO(), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "forward", true)
+	err = vhttp.PostHelper(context.TODO(), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "forward", true, log)
 	if err == nil {
 		log.WithField("metrics", batchSize).Debug("Completed forward to upstream Veneur")
 	} else {

--- a/span_sink.go
+++ b/span_sink.go
@@ -15,6 +15,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sirupsen/logrus"
+	vhttp "github.com/stripe/veneur/http"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
@@ -180,7 +181,7 @@ func (dd *datadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := postHelper(context.TODO(), dd.HTTPClient, dd.stats, dd.traceClient, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.stats, dd.traceClient, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false, log)
 
 		if err == nil {
 			log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")


### PR DESCRIPTION
#### Summary
Make an `http` package and put `postHelper` in it.


#### Motivation
Lots of things use this, which is great for code reuse. But some upcoming changes I want to make — moving sinks to their own packages — would create circular deps if we tried to import and get `postHelper` there.

#### Test plan
Existing tests.

r? @stripe/observability 