### PR TITLE
Remove use of named returns

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -183,26 +183,27 @@ func tags(tag string) []string {
 	return tags
 }
 
-func destination(passedFlags map[string]flag.Value, hostport *string, useSSF bool) (addr string, network string, err error) {
-	network = "udp"
+func destination(passedFlags map[string]flag.Value, hostport *string, useSSF bool) (string, string, error) {
+	var network = "udp"
+	var addr string
 	if passedFlags["hostport"] != nil {
 		addr = passedFlags["hostport"].String()
 	} else if hostport != nil {
 		addr = *hostport
 	} else {
-		err = errors.New("you must specify a valid hostport")
-		return
+		err := errors.New("you must specify a valid hostport")
+		return addr, network, err
 	}
 	address, parseErr := protocol.ResolveAddr(addr)
 	if parseErr != nil {
 		// This is fine - we can attempt to treat the
 		// host:port combination as a UDP address.
-		return
+		return addr, network, nil
 	}
 	// Looks like we got a listener spec URL, translate that into an address:
 	network = address.Network()
 	addr = address.String()
-	return addr, network, err
+	return addr, network, nil
 }
 
 func timeCommand(client MinimalClient, command []string, name string, tags []string) (int, error) {

--- a/server.go
+++ b/server.go
@@ -299,7 +299,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 		ret.traceBackend = &internalTraceBackend{statsd: ret.Statsd}
 		ret.TraceClient, err = trace.NewBackendClient(ret.traceBackend, trace.Capacity(200))
 		if err != nil {
-			return
+			return ret, err
 		}
 
 		// configure Datadog as a Span sink

--- a/server.go
+++ b/server.go
@@ -276,13 +276,13 @@ func NewFromConfig(conf Config) (*Server, error) {
 	}
 
 	if conf.DatadogAPIKey != "" {
-		ddSink, err2 := datadog.NewDatadogMetricSink(
+		ddSink, err := datadog.NewDatadogMetricSink(
 			ret.interval.Seconds(), conf.FlushMaxPerBody, conf.Hostname, ret.Tags,
 			conf.DatadogAPIHostname, conf.DatadogAPIKey, ret.HTTPClient, ret.Statsd,
 			log,
 		)
-		if err2 != nil {
-			return ret, err2
+		if err != nil {
+			return ret, err
 		}
 		ret.metricSinks = append(ret.metricSinks, ddSink)
 	}

--- a/server.go
+++ b/server.go
@@ -119,7 +119,9 @@ type Server struct {
 }
 
 // NewFromConfig creates a new veneur server from a configuration specification.
-func NewFromConfig(conf Config) (ret Server, err error) {
+func NewFromConfig(conf Config) (*Server, error) {
+	ret := &Server{}
+
 	ret.Hostname = conf.Hostname
 	ret.Tags = conf.Tags
 
@@ -148,9 +150,10 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 		ret.HistogramAggregates.Count = len(conf.Aggregates)
 	}
 
+	var err error
 	ret.interval, err = time.ParseDuration(conf.Interval)
 	if err != nil {
-		return
+		return ret, err
 	}
 	ret.HTTPClient = &http.Client{
 		// make sure that POSTs to datadog do not overflow the flush interval
@@ -160,7 +163,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 
 	ret.Statsd, err = statsd.NewBuffered(conf.StatsAddress, 1024)
 	if err != nil {
-		return
+		return ret, err
 	}
 	ret.Statsd.Namespace = "veneur."
 	ret.Statsd.Tags = append(ret.Tags, "veneurlocalonly")
@@ -170,7 +173,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	if conf.SentryDsn != "" {
 		ret.Sentry, err = raven.New(conf.SentryDsn)
 		if err != nil {
-			return
+			return ret, err
 		}
 	}
 
@@ -242,14 +245,14 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	if conf.TLSKey != "" {
 		if conf.TLSCertificate == "" {
 			err = errors.New("tls_key is set; must set tls_certificate")
-			return
+			return ret, err
 		}
 
 		// load the TLS key and certificate
 		var cert tls.Certificate
 		cert, err = tls.X509KeyPair([]byte(conf.TLSCertificate), []byte(conf.TLSKey))
 		if err != nil {
-			return
+			return ret, err
 		}
 
 		clientAuthMode := tls.NoClientCert
@@ -261,7 +264,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			ok := clientCAs.AppendCertsFromPEM([]byte(conf.TLSAuthorityCertificate))
 			if !ok {
 				err = errors.New("tls_authority_certificate: Could not load any certificates")
-				return
+				return ret, err
 			}
 		}
 
@@ -279,7 +282,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 			log,
 		)
 		if err2 != nil {
-			return
+			return ret, err2
 		}
 		ret.metricSinks = append(ret.metricSinks, ddSink)
 	}
@@ -330,7 +333,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 				conf.TraceLightstepAccessToken, ret.Statsd, ret.TagsAsMap, log,
 			)
 			if err != nil {
-				return
+				return ret, err
 			}
 			ret.spanSinks = append(ret.spanSinks, lsSink)
 
@@ -398,7 +401,7 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 
 	log.WithField("config", conf).Debug("Initialized server")
 
-	return
+	return ret, err
 }
 
 // Start spins up the Server to do actual work, firing off goroutines for

--- a/server_test.go
+++ b/server_test.go
@@ -172,7 +172,7 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 	server.Start()
 
 	go server.HTTPServe()
-	return &server
+	return server
 }
 
 type channelMetricSink struct {


### PR DESCRIPTION
#### Summary
Removes the use of named return variables in all the places I could find them.

#### Motivation
* We don't like these, as explicit returns are much easier to read
* We remove a linter error by returning a pointer (copying the mutex)
* We stop running into that damned shadowing err thing

#### Test plan
Existing tests

r? @asf-stripe 