### PR TITLE
Downgrade noisy error logging to Warn level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * All sinks have been moved to their own packages for smaller code and better interfaces. Thanks [gphat](https://github.com/gphat)!
+* Removed noisy Sentry events that duplicated Datadog error reporting. Thanks, [aditya](https://github.com/chimeracoder)!
 
 # 1.8.1, 2017-12-05
 

--- a/http/http.go
+++ b/http/http.go
@@ -120,7 +120,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Clie
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		stats.Count(action+".error_total", 1, []string{fmt.Sprintf("cause:%d", resp.StatusCode)}, 1.0)
-		resultLogger.Error("Could not POST")
+		resultLogger.WithError(err).Warn("Could not POST")
 		return err
 	}
 

--- a/http/http.go
+++ b/http/http.go
@@ -93,7 +93,10 @@ func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Clie
 			err = urlErr.Err
 		}
 		stats.Count(action+".error_total", 1, []string{"cause:io"}, 1.0)
-		innerLogger.WithError(err).Error("Could not execute request")
+		// Log at Warn level instead of Error, because we don't want to create
+		// Sentry events for these (they're only important in large numbers, and
+		// we already have Datadog metrics for them)
+		innerLogger.WithError(err).Warn("Could not execute request")
 		return err
 	}
 	stats.TimeInMilliseconds(action+".duration_ns", float64(time.Since(requestStart).Nanoseconds()), []string{"part:post"}, 1.0)


### PR DESCRIPTION
#### Summary

We're already emitting Datadog metrics for these, and they're only important in large numbers (which means reporting Sentry events for them is overkill).

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @an-stripe 
cc @cory-stripe 
cc @stripe/observability