### PR TITLE
Allow global gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
 
 ## Improvements
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ If you want a metric to be strictly host-local, you can tell Veneur not to forwa
 
 #### Counters
 
-Relatedly, if you want to forward a counter to the global Veneur instance to reduce tag cardinality, you can tell Veneur to flush it to the global instance by including a `veneurglobalonly` tag in the count's metric packet. This tag will also not appear in Datadog. Note: for global counters to report correctly, the local and global Veneur instances should be configured to have the same flush interval.
+Relatedly, if you want to forward a counter or gauge to the global Veneur instance to reduce tag cardinality, you can tell Veneur to flush it to the global instance by including a `veneurglobalonly` tag in the metric's packet. This `veneurglobalonly` tag is stripped and will not be passed on to sinks.
+
+**Note**: for global counters to report correctly, the local and global Veneur instances should be configured to have the same flush interval.
 
 #### Hostname and Device
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Veneur expires all metrics on each flush. If a metric is no longer being sent (o
 
 To clarify how each metric type behaves in Veneur, please use the following:
 * Counters: Locally accrued, flushed to Datadog (see [magic tags](#magic-tag) for global version)
-* Gauges: Locally accrued, flushed to Datadog
+* Gauges: Locally accrued, flushed to Datadog  (see [magic tags](#magic-tag) for global version)
 * Histograms: Locally accrued, count, max and min flushed to Datadog, percentiles forwarded to `forward_address` for global aggregation when set.
 * Timers: Locally accrued, count, max and min flushed to Datadog, percentiles forwarded to `forward_address` for global aggregation when set.
 * Sets: Locally accrued, forwarded to `forward_address` for global aggregation when set.
@@ -186,11 +186,13 @@ For static configuration you need one Veneur, which we'll call the _global_ inst
 
 If you want a metric to be strictly host-local, you can tell Veneur not to forward it by including a `veneurlocalonly` tag in the metric packet, eg `foo:1|h|#veneurlocalonly`. This tag will not actually appear in DataDog; Veneur removes it.
 
-#### Counters
+#### Global Counters And Gauges
 
 Relatedly, if you want to forward a counter or gauge to the global Veneur instance to reduce tag cardinality, you can tell Veneur to flush it to the global instance by including a `veneurglobalonly` tag in the metric's packet. This `veneurglobalonly` tag is stripped and will not be passed on to sinks.
 
-**Note**: for global counters to report correctly, the local and global Veneur instances should be configured to have the same flush interval.
+**Note**: For global counters to report correctly, the local and global Veneur instances should be configured to have the same flush interval.
+
+**Note**: Global gauges are "random write wins" since they are merged in a non-deterministic order at the global Veneur.
 
 #### Hostname and Device
 

--- a/flusher.go
+++ b/flusher.go
@@ -101,6 +101,7 @@ type metricsSummary struct {
 	totalTimers     int
 
 	totalGlobalCounters int
+	totalGlobalGauges   int
 
 	totalLocalHistograms int
 	totalLocalSets       int
@@ -133,6 +134,7 @@ func (s *Server) tallyMetrics(percentiles []float64) ([]WorkerMetrics, metricsSu
 		ms.totalTimers += len(wm.timers)
 
 		ms.totalGlobalCounters += len(wm.globalCounters)
+		ms.totalGlobalGauges += len(wm.globalGauges)
 
 		ms.totalLocalHistograms += len(wm.localHistograms)
 		ms.totalLocalSets += len(wm.localSets)
@@ -156,6 +158,7 @@ func (s *Server) tallyMetrics(percentiles []float64) ([]WorkerMetrics, metricsSu
 	if !s.IsLocal() {
 		ms.totalLength += ms.totalSets
 		ms.totalLength += ms.totalGlobalCounters
+		ms.totalLength += ms.totalGlobalGauges
 	}
 
 	return tempMetrics, ms
@@ -214,6 +217,11 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 			// there's nothing to flush
 			for _, gc := range wm.globalCounters {
 				finalMetrics = append(finalMetrics, gc.Flush(s.interval)...)
+			}
+
+			// and global gauges
+			for _, gg := range wm.globalGauges {
+				finalMetrics = append(finalMetrics, gg.Flush()...)
 			}
 		}
 	}

--- a/flusher.go
+++ b/flusher.go
@@ -247,7 +247,7 @@ func (s *Server) reportMetricsFlushCounts(ms metricsSummary) {
 }
 
 // reportGlobalMetricsFlushCounts reports the counts of
-// globalCounters, totalHistograms, totalSets, and totalTimers,
+// globalCounters, globalGauges, totalHistograms, totalSets, and totalTimers,
 // which are the three metrics reported *only* by the global
 // veneur instance.
 func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
@@ -257,6 +257,7 @@ func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
 	// histograms that it received, and then a global veneur reports them
 	// again
 	s.Statsd.Count("worker.metrics_flushed_total", int64(ms.totalGlobalCounters), []string{"metric_type:global_counter"}, 1.0)
+	s.Statsd.Count("worker.metrics_flushed_total", int64(ms.totalGlobalGauges), []string{"metric_type:global_gauge"}, 1.0)
 	s.Statsd.Count("worker.metrics_flushed_total", int64(ms.totalHistograms), []string{"metric_type:histogram"}, 1.0)
 	s.Statsd.Count("worker.metrics_flushed_total", int64(ms.totalSets), []string{"metric_type:set"}, 1.0)
 	s.Statsd.Count("worker.metrics_flushed_total", int64(ms.totalTimers), []string{"metric_type:timer"}, 1.0)
@@ -282,6 +283,18 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 					logrus.ErrorKey: err,
 					"type":          "counter",
 					"name":          count.Name,
+				}).Error("Could not export metric")
+				continue
+			}
+			jsonMetrics = append(jsonMetrics, jm)
+		}
+		for _, gauge := range wm.globalGauges {
+			jm, err := gauge.Export()
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"type":          "gauge",
+					"name":          gauge.Name,
 				}).Error("Could not export metric")
 				continue
 			}

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -190,7 +190,7 @@ func (g *Gauge) Export() (JSONMetric, error) {
 	}, nil
 }
 
-// Combine is pretty lame for Gauges, as it just overwrites the value.
+// Combine is pretty naïve for Gauges, as it just overwrites the value.
 func (g *Gauge) Combine(other []byte) error {
 	var otherValue float64
 	buf := bytes.NewReader(other)

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -72,6 +72,21 @@ func TestCounterMerge(t *testing.T) {
 	assert.Equal(t, float64(38), metrics[0].Value)
 }
 
+func TestGaugeMerge(t *testing.T) {
+	g := NewGauge("a.b.c", []string{"tag:val"})
+
+	g.Sample(5, 1.0)
+	jm, err := g.Export()
+	assert.NoError(t, err, "should have exported gauge succcesfully")
+
+	gGlobal := NewGauge("a.b.c", []string{"tag2: val2"})
+	gGlobal.value = 1 // So we can overwrite it
+	assert.NoError(t, gGlobal.Combine(jm.Value), "should have combined gauges successfully")
+
+	metrics := gGlobal.Flush()
+	assert.Equal(t, float64(5), metrics[0].Value)
+}
+
 func TestGauge(t *testing.T) {
 	g := NewGauge("a.b.c", []string{"a:b"})
 

--- a/worker.go
+++ b/worker.go
@@ -241,6 +241,10 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 		if err := w.wm.globalCounters[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge counters")
 		}
+	case gaugeTypeName:
+		if err := w.wm.globalGauges[other.MetricKey].Combine(other.Value); err != nil {
+			log.WithError(err).Error("Could not merge gauges")
+		}
 	case setTypeName:
 		if err := w.wm.sets[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge sets")

--- a/worker_test.go
+++ b/worker_test.go
@@ -49,6 +49,39 @@ func TestWorkerLocal(t *testing.T) {
 	assert.Len(t, wm.histograms, 0, "number of global histograms")
 }
 
+func TestWorkerGlobal(t *testing.T) {
+	w := NewWorker(1, nil, logrus.New())
+
+	gc := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "counter",
+		},
+		Value:      1.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}
+	w.ProcessMetric(&gc)
+
+	gg := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "b.c.a",
+			Type: "gauge",
+		},
+		Value:      1.0,
+		Digest:     12346,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}
+	w.ProcessMetric(&gg)
+
+	assert.Equal(t, 1, len(w.wm.globalGauges), "should have 1 global gauge")
+	assert.Equal(t, 0, len(w.wm.gauges), "should have no normal gauges")
+	assert.Equal(t, 1, len(w.wm.globalCounters), "should have 1 global counter")
+	assert.Equal(t, 0, len(w.wm.counters), "should have no local counters")
+}
+
 func TestWorkerImportSet(t *testing.T) {
 	w := NewWorker(1, nil, logrus.New())
 	testset := samplers.NewSet("a.b.c", nil)


### PR DESCRIPTION
#### Summary
Add global gauges by way of  `veneurglobalonly`.

#### Motivation
We've had some asks for this!

#### Test plan
Added some unit tests, likely need one more that verifies that `Worker` dtrt with this *and* with Counters.

r? @stripe/observability 