### PR TITLE
WIP: Jitter HTTP POSTs to datadog

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -339,7 +339,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 
 	// the error has already been logged (if there was one), so we only care
 	// about the success case
-	if http.PostHelper(span.Attach(ctx), s.HTTPClient, s.Statsd, s.TraceClient, endpoint, jsonMetrics, "forward", true, log) == nil {
+	if http.PostHelper(span.Attach(ctx), s.HTTPClient, s.Statsd, s.TraceClient, endpoint, jsonMetrics, "forward", true, true, log) == nil {
 		log.WithField("metrics", len(jsonMetrics)).Info("Completed forward to upstream Veneur")
 	}
 }

--- a/http/http.go
+++ b/http/http.go
@@ -24,7 +24,7 @@ var tracer = trace.GlobalTracer
 // this function - probably a static string for each callsite
 // you can disable compression with compress=false for endpoints that don't
 // support it
-func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Client, tc *trace.Client, endpoint string, bodyObject interface{}, action string, compress bool, log *logrus.Logger) error {
+func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Client, tc *trace.Client, endpoint string, bodyObject interface{}, action string, compress bool, closeConnection bool, log *logrus.Logger) error {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	span.SetTag("action", action)
 	defer span.ClientFinish(tc)
@@ -76,7 +76,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Clie
 		req.Header.Set("Content-Encoding", "deflate")
 	}
 	// we only make http requests at flush time, so keepalive is not a big win
-	req.Close = true
+	req.Close = closeConnection
 
 	err = tracer.InjectRequest(span.Trace, req)
 	if err != nil {

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -127,7 +127,7 @@ func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []sam
 			"events": {
 				"api": events,
 			},
-		}, "flush_events", true, log)
+		}, "flush_events", true, false, log)
 		if err == nil {
 			log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
 		} else {
@@ -141,7 +141,7 @@ func (dd *datadogMetricSink) FlushEventsChecks(ctx context.Context, events []sam
 		// this endpoint is not documented to take an array... but it does
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.ddHostname, dd.apiKey), checks, "flush_checks", false, log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.ddHostname, dd.apiKey), checks, "flush_checks", false, false, log)
 		if err == nil {
 			log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
@@ -222,7 +222,7 @@ func (dd *datadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 	time.Sleep(jitter)
 	vhttp.PostHelper(ctx, dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.ddHostname, dd.apiKey), map[string][]DDMetric{
 		"series": metricSlice,
-	}, "flush", true, log)
+	}, "flush", true, false, log)
 }
 
 type blackholeMetricSink struct {

--- a/metric_sink.go
+++ b/metric_sink.go
@@ -217,7 +217,7 @@ func (dd *datadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 	interval := time.Duration(int64(dd.interval)) * time.Second
 	bigJitter, err := rand.Int(rand.Reader, big.NewInt(int64(interval)/2))
 	if err == nil {
-		jitter = time.Duration(bigJitter.Int64()) / time.Millisecond
+		jitter = time.Duration(bigJitter.Int64())
 	}
 	time.Sleep(jitter)
 	vhttp.PostHelper(ctx, dd.HTTPClient, dd.statsd, dd.traceClient, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.ddHostname, dd.apiKey), map[string][]DDMetric{

--- a/proxy.go
+++ b/proxy.go
@@ -311,7 +311,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// this endpoint is not documented to take an array... but it does
 			// another curious constraint of this endpoint is that it does not
 			// support "Content-Encoding: deflate"
-			err = vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "flush_traces", false, log)
+			err = vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "flush_traces", false, false, log)
 
 			if err == nil {
 				log.WithFields(logrus.Fields{
@@ -376,7 +376,7 @@ func (p *Proxy) doPost(wg *sync.WaitGroup, destination string, batch []samplers.
 		return
 	}
 
-	err = vhttp.PostHelper(context.TODO(), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "forward", true, log)
+	err = vhttp.PostHelper(context.TODO(), p.HTTPClient, p.Statsd, p.traceClient, endpoint, batch, "forward", true, false, log)
 	if err == nil {
 		log.WithField("metrics", batchSize).Debug("Completed forward to upstream Veneur")
 	} else {

--- a/server.go
+++ b/server.go
@@ -151,7 +151,13 @@ func NewFromConfig(conf Config) (ret Server, err error) {
 	if err != nil {
 		return
 	}
+
+	transport := &http.Transport{
+		IdleConnTimeout:     30 * time.Second,
+		MaxIdleConnsPerHost: 1,
+	}
 	ret.HTTPClient = &http.Client{
+		Transport: transport,
 		// make sure that POSTs to datadog do not overflow the flush interval
 		Timeout: ret.interval * 9 / 10,
 		// we're fine with using the default transport and redirect behavior

--- a/span_sink.go
+++ b/span_sink.go
@@ -181,7 +181,7 @@ func (dd *datadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.stats, dd.traceClient, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false, log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.stats, dd.traceClient, fmt.Sprintf("%s/spans", dd.traceAddress), finalTraces, "flush_traces", false, false, log)
 
 		if err == nil {
 			log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR makes hosts jitter their HTTP POST requests up to half the metric aggregation interval (so up to 5s, if I understand correctly?). That way, we shouldn't see all our hosts across our infra trying to post to dd at the same time (which seems to overload the endpoint, causing delays in metric submission). This still means our metrics don't make it there very quickly - they're delayed by a random number of seconds - but at least it should help us spread out load on the dd endpoint (and conversely, our proxies!)

#### Motivation

We're seeing some high metrics submission times in 1.8 across our fleet, and suspect this may be related.


#### Test plan
Didn't yet.

- [ ] test this.


#### Rollout/monitoring/revert plan

Merge & roll (:
