### PR TITLE
Set flush interval sync to off by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	SsfListenAddresses            []string  `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string    `yaml:"stats_address"`
 	StatsdListenAddresses         []string  `yaml:"statsd_listen_addresses"`
+	SynchronizeWithInterval       bool      `yaml:"synchronize_with_interval"`
 	Tags                          []string  `yaml:"tags"`
 	TcpAddress                    string    `yaml:"tcp_address"`
 	TLSAuthorityCertificate       string    `yaml:"tls_authority_certificate"`

--- a/example.yaml
+++ b/example.yaml
@@ -45,6 +45,11 @@ forward_address: ""
 # series data.
 interval: "10s"
 
+# Veneur can "sychronize" it's flushes with the system clock, flushing at even
+# intervals i.e. 0, 10, 20… to align with the `interval`. This is disabled by
+# default for now, as it can cause thundering herds in large installations.
+synchronize_with_interval: false
+
 # Veneur emits its own metrics; this configures where we send them. It's ok
 # to point veneur at itself for metrics consumption!
 stats_address: "localhost:8126"


### PR DESCRIPTION
#### Summary
Allow flush sync to be toggled and disable it by default.

#### Motivation
We created #297 to fix #296 only find things gummed up when we deployed it. We suspect this is contention around both DNS and HTTP. Having lots of host flush simultaneously can bee a performance problem.

To allow 1.8 to go out and to avoid adding metric latency for #326 this patch allows us to toggle off the behavior. Other installations can test on their end and determine if this works. In the meantime we can explore keep-alive and other options.

#### Test plan
Added unit test to ensure defaults.

#### Rollout/monitoring/revert plan
Merging this should allow us to put 1.8 back.

r? @asf-stripe 