### PR TITLE
Reuse HTTP connections and trace them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * All sinks have been moved to their own packages for smaller code and better interfaces. Thanks [gphat](https://github.com/gphat)!
 * Removed noisy Sentry events that duplicated Datadog error reporting. Thanks, [aditya](https://github.com/chimeracoder)!
+* Veneur now reuses HTTP connections for forwarding and Datadog flushes. Furthermore each phase of the HTTP request is traced and can be seen using the trace sink of your choice. This should drastically improve performance and reliability for installs with large numbers of instances. Thanks [gphat](https://github.com/gphat)!
 
 # 1.8.1, 2017-12-05
 

--- a/http/http.go
+++ b/http/http.go
@@ -53,6 +53,7 @@ func (hct *httpClientTracer) getClientTrace() *httptrace.ClientTrace {
 		GotFirstResponseByte: hct.gotFirstResponseByte,
 		ConnectStart:         hct.connectStart,
 		WroteRequest:         hct.wroteRequest,
+		PutIdleConn:          hct.putIdleConn,
 	}
 }
 
@@ -98,6 +99,11 @@ func (hct *httpClientTracer) connectStart(network, addr string) {
 // wroteRequest marks the write being completed
 func (hct *httpClientTracer) wroteRequest(info httptrace.WroteRequestInfo) {
 	hct.startSpan("http.finishedWrite")
+}
+
+// putIdleConn is the last thing called, so wrap up any pending spans
+func (hct *httpClientTracer) putIdleConn(err error) {
+	hct.currentSpan.ClientFinish(hct.traceClient)
 }
 
 // PostHelper is shared code for POSTing to an endpoint, that consumes JSON, is zlib-

--- a/http/http.go
+++ b/http/http.go
@@ -102,6 +102,8 @@ func (hct *httpClientTracer) wroteRequest(info httptrace.WroteRequestInfo) {
 
 // finishSpan is called to ensure we're done tracing
 func (hct *httpClientTracer) finishSpan() {
+	hct.mutex.Lock()
+	defer hct.mutex.Unlock()
 	hct.currentSpan.ClientFinish(hct.traceClient)
 }
 

--- a/server.go
+++ b/server.go
@@ -156,10 +156,15 @@ func NewFromConfig(conf Config) (*Server, error) {
 	if err != nil {
 		return ret, err
 	}
+
+	transport := &http.Transport{
+		IdleConnTimeout: ret.interval * 2, // If we're idle more than one interval something is up
+	}
+
 	ret.HTTPClient = &http.Client{
 		// make sure that POSTs to datadog do not overflow the flush interval
-		Timeout: ret.interval * 9 / 10,
-		// we're fine with using the default transport and redirect behavior
+		Timeout:   ret.interval * 9 / 10,
+		Transport: transport,
 	}
 
 	ret.Statsd, err = statsd.NewBuffered(conf.StatsAddress, 1024)


### PR DESCRIPTION
#### Summary
Revamp HTTP usage by Veneur:
* Reuse HTTP connections
  * Measure the new versus reused connections
* Remove explicit re-resolution of names, as Go's standard resolver does *not* cache. There was no reason to do this…
* except to measure DNS resolution time! As such we…
* Use `net/http/httptrace` to trace the connection cycle:
  * DNS
  * connection
  * write
  * response
  * n.b. Most of these spans are moot when a connection is reused
* And as a result remove differences between various flush call's measurements.

Here's a shot in action!

<img width="1002" alt="screen shot 2017-12-04 at 8 20 52 am" src="https://user-images.githubusercontent.com/23101296/33563371-9ac42f1a-d8cc-11e7-9205-c9baf9171ab2.png">

It continues to work for forwarding flushes as well:

<img width="1009" alt="screen shot 2017-12-04 at 8 33 32 am" src="https://user-images.githubusercontent.com/23101296/33563867-e7040c3c-d8cd-11e7-9299-90e1ffa3bdcd.png">

#### Motivation
We had to make #327 because having every Veneur instance flush simultaneously can be problematic. We actively observed DNS timeouts and long DNS durations through the `part:dns` portion of our `resolveEndpoint` code. We also observed long "POST" durations, but this code did **not** explicitly resolve and therefore our measurement did not differentiate between the various phases of the flush.

This change homogenizes all of the HTTTP posts we do with a single form of measurement.Now we can confidently understand _why_ the thing is slow.

Secondly, the reuse of connections **removes** the DNS and connection phases of most HTTP operations we perform. This moves our scaling problem to one of persistent connections, which is much easier to deal with.  We shouldn't have to worry about giant DNS herds or connection spikes. If we do, this can be mitigated by running a few more global instances.

Natural deployment mechanisms add jitter to the startup of Veneurs, so we'll see reasonable "herd" sizes at connection times. 

#### Needs

* How is this best tested?
* Are there any risks aside from "what happens when a machine goes away?"
* Are the measures legit?
* Should keep-alive be configurable?
* Do we need to change the client's default configuration of max connections, etc? (`MaxIdleConns`, `MaxIdleConnsPerHost`, `IdleConnTimeout` seem juicy?)

#### Test plan
* Verified that HAProxy on our boxes has enough room for lots of connections.
* Has been run on a single QA instance to verify it doesn't cause single-instance problems, verified all traces work!
* Run this in QA for a bit, see if we notice anything odd on veneur proxy, global veneurs or the HAProxy bits we use

Others?
* Merge, enable syncing on a large host set and test in prod!

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
