### PR TITLE
Link to SSF things

### DIFF
--- a/ssf/README.md
+++ b/ssf/README.md
@@ -20,6 +20,7 @@ Because we want to:
 * You can send SSF as UDP packets to Veneur's `ssf_listen_addresses`.
 * Veneur can also read SSF as a [wire protocol](https://github.com/stripe/veneur/blob/master/protocol/wire.go) over connection protocols such as TCP or UNIX domain sockets
 * You can use the CLI tool [veneur-emit](https://github.com/stripe/veneur/tree/master/cmd/veneur-emit).
+* You can use an SSF trace client in [Go](github.com/stripe/veneur/trace) or [Ruby](https://github.com/stripe/ssf-ruby).
 
 # Philosophy
 

--- a/ssf/README.md
+++ b/ssf/README.md
@@ -15,6 +15,12 @@ Because we want to:
 * collect and combine the great ideas from our [inspiration](https://github.com/stripe/veneur/tree/master/ssf#inspiration)
 * add some of [our own ideas](https://github.com/stripe/veneur/tree/master/ssf#philosophy)
 
+# Using SSF
+
+* You can send SSF as UDP packets to Veneur's `ssf_listen_addresses`.
+* Veneur can also read SSF as a [wire protocol](https://github.com/stripe/veneur/blob/master/protocol/wire.go) over connection protocols such as TCP or UNIX domain sockets
+* You can use the CLI tool [veneur-emit](https://github.com/stripe/veneur/tree/master/cmd/veneur-emit).
+
 # Philosophy
 
 We've got some novel ideas that we've put in to SSF. It might help to be familiar with the concepts in our [inspiration](https://github.com/stripe/veneur/tree/master/ssf#inspiration). Here is our founding philosophy of SSF:


### PR DESCRIPTION
#### Summary
Link to details on how to use SSF from it's README.

#### Motivation
The SSF README doesn't currently mention the wire protocol, which seems like an oversight.

#### Notes
No changelog, since this isn't a code change.

r? @asf-stripe 