### PR TITLE
Add a functional option to automatically flush buffered clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0, in progress
+
+## Added
+* Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 # 1.8.1, 2017-12-05
 
 ## Improvements


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adds two functional options for creating trace Clients, `FlushWith` and `FlushInterval`, which will automatically flush the buffer on a buffered client every period of a Ticker.

#### Motivation
This is meant to improve the ergonomics of buffered Clients: Every user of buffered clients currently has to implement the same thing all the time, and if we run the flusher in the Client itself, we can automatically stop the ticker when the client gets closed.

#### Test plan
Wrote a test.


#### Rollout/monitoring/revert plan

Merge, update client code.
