### PR TITLE
Server: Don't report an error when encountering a framing error

### DIFF
--- a/server.go
+++ b/server.go
@@ -690,7 +690,7 @@ func (s *Server) ReadSSFStreamSocket(serverConn net.Conn) {
 			if protocol.IsFramingError(err) {
 				log.WithError(err).
 					WithField("remote", serverConn.RemoteAddr()).
-					Error("Frame error reading from SSF connection. Closing.")
+					Info("Frame error reading from SSF connection. Closing.")
 				s.Statsd.Incr("ssf.error_total",
 					append([]string{"packet_type:unknown", "reason:framing"}, tags...),
 					1.0)


### PR DESCRIPTION
This usually indicates a problem with a client, e.g. a hang-up, not
something that we should track in Sentry.

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR makes framing errors into a thing that doesn't get reported to sentry.

#### Motivation
They usually indicate client problems. It's good to know about them, but you can't "resolve" them, so we should only track a metric for them.


#### Test plan
I didn't; not sure how to test that, tbh.


#### Rollout/monitoring/revert plan
Merge & run in our infra for a while
