### PR TITLE
Fix nil log and add test for span sink

### DIFF
--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -57,6 +57,7 @@ func NewDatadogMetricSink(interval float64, flushMaxPerBody int, hostname string
 		flushMaxPerBody: flushMaxPerBody,
 		hostname:        hostname,
 		tags:            tags,
+		log:             log,
 	}, nil
 }
 


### PR DESCRIPTION
#### Summary
Fix missing log set in Datadog's `NewDatadogMetricSink`.

#### Motivation
When used for a flush, the missing `log` was causing a panic. The lack of adequate tests was to blame, so I fixed that while I was here.

#### Test plan
Added lots of tests!

r? @an-stripe 