### PR TITLE
Metric-reporting span sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
 * `veneur-emit` now takes `-span_service`, `-trace_id`, and `-parent_id` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
+* The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 
 ## Improvements
 * Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -189,21 +189,6 @@ func TestFlags(t *testing.T) {
 	}
 }
 
-func TestBareMetrics(t *testing.T) {
-	metric := bareMetric("test_name", "tag1:value1,tag2:value2")
-	if metric.Name != "test_name" {
-		t.Error("Bare metric does not have correct name.")
-	}
-	testTag1 := metric.Tags["tag1"]
-	testTag2 := metric.Tags["tag2"]
-	if testTag1 != "value1" || testTag2 != "value2" {
-		t.Error("Bare metric does not have correct tags.")
-	}
-	if metric.Value != 0 {
-		t.Error("Bare metric is not bare.")
-	}
-}
-
 func TestCreateMetrics(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 

--- a/flusher.go
+++ b/flusher.go
@@ -397,9 +397,5 @@ func resolveEndpoint(endpoint string) (string, error) {
 }
 
 func (s *Server) flushTraces(ctx context.Context) {
-	if !s.TracingEnabled() {
-		return
-	}
-
 	s.SpanWorker.Flush()
 }

--- a/http.go
+++ b/http.go
@@ -32,12 +32,7 @@ func (s *Server) Handler() http.Handler {
 	})
 
 	mux.HandleFuncC(pat.Get("/healthcheck/tracing"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
-		if s.TracingEnabled() {
-			w.Write([]byte("ok\n"))
-		} else {
-			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte("nok\n"))
-		}
+		w.Write([]byte("ok\n"))
 	})
 
 	mux.Handle(pat.Post("/import"), handleImport(s))

--- a/http.go
+++ b/http.go
@@ -31,6 +31,7 @@ func (s *Server) Handler() http.Handler {
 		w.Write([]byte(VERSION))
 	})
 
+	// TODO3.0: Maybe remove this endpoint as it is kinda useless now that tracing is always on.
 	mux.HandleFuncC(pat.Get("/healthcheck/tracing"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))
 	})

--- a/http_test.go
+++ b/http_test.go
@@ -286,7 +286,7 @@ func TestOkTraceHealthCheck(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "Trace healthcheck did not succeed")
 }
 
-func TestNokTraceHealthCheck(t *testing.T) {
+func TestNoTracingConfiguredTraceHealthCheck(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/healthcheck/tracing", nil)
 
 	config := localConfig()
@@ -303,7 +303,7 @@ func TestNokTraceHealthCheck(t *testing.T) {
 	handler := server.Handler()
 	handler.ServeHTTP(w, r)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "Trace healthcheck succeeded when disabled")
+	assert.Equal(t, http.StatusOK, w.Code, "Trace healthcheck reports tracing is enabled")
 }
 
 func TestBuildDate(t *testing.T) {

--- a/protocol/wire.go
+++ b/protocol/wire.go
@@ -101,13 +101,23 @@ func (m *Message) TraceSpan() (*ssf.SSFSpan, error) {
 
 // ValidTrace takes in an SSF span and determines if it is valid or not.
 // It also makes sure the Tags is non-nil, since we use it later.
-func ValidTrace(sample *ssf.SSFSpan) bool {
+func ValidTrace(span *ssf.SSFSpan) bool {
 	ret := true
-	ret = ret && sample.Id != 0
-	ret = ret && sample.TraceId != 0
-	ret = ret && sample.StartTimestamp != 0
-	ret = ret && sample.EndTimestamp != 0
+	ret = ret && span.Id != 0
+	ret = ret && span.TraceId != 0
+	ret = ret && span.StartTimestamp != 0
+	ret = ret && span.EndTimestamp != 0
 	return ret
+}
+
+// ValidateTrace takes in an SSF span and determines if it is valid or
+// not.  It also makes sure the Tags is non-nil, since we use it
+// later. If the span is not valid, it returns an error.
+func ValidateTrace(span *ssf.SSFSpan) error {
+	if !ValidTrace(span) {
+		return &InvalidTrace{span}
+	}
+	return nil
 }
 
 // Metrics returns the ssf samples contained in an SSF span. It does

--- a/protocol/wire_test.go
+++ b/protocol/wire_test.go
@@ -28,17 +28,13 @@ func TestReadSSFStream(t *testing.T) {
 	require.NoError(t, err)
 	// Read the first frame:
 	{
-		read, err := ReadSSF(buf)
-		require.NoError(t, err)
-		span, err := read.TraceSpan()
+		span, err := ReadSSF(buf)
 		require.NoError(t, err)
 		assert.Equal(t, *msg, *span)
 	}
 	// Read the second frame:
 	{
-		read, err := ReadSSF(buf)
-		require.NoError(t, err)
-		span, err := read.TraceSpan()
+		span, err := ReadSSF(buf)
 		require.NoError(t, err)
 		assert.Equal(t, *msg, *span)
 	}

--- a/regression_test.go
+++ b/regression_test.go
@@ -32,15 +32,14 @@ func TestTagNameSetNameNotSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Eror when marshalling sample")
 
-	msg, errSSF := protocol.ParseSSF(buf)
+	span, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
-	if assert.NotNil(t, msg) {
-		newSample, err := msg.TraceSpan()
+	if assert.NotNil(t, span) {
 		assert.NoError(t, err)
-		if assert.NotNil(t, newSample) {
-			assert.Equal(t, sample.Tags["name"], newSample.Name, "Name via Tag did not propogate")
+		if assert.NotNil(t, span) {
+			assert.Equal(t, sample.Tags["name"], span.Name, "Name via Tag did not propogate")
 			assert.NoError(t, errSSF)
-			assert.Empty(t, newSample.Tags["name"])
+			assert.Empty(t, span.Tags["name"])
 		}
 	}
 }
@@ -57,15 +56,14 @@ func TestTagNameSetNameSet(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err, "Error when marshalling sample")
 
-	msg, errSSF := protocol.ParseSSF(buf)
+	span, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
-	if assert.NotNil(t, msg) {
-		newSample, err := msg.TraceSpan()
+	if assert.NotNil(t, span) {
 		assert.NoError(t, err)
-		if assert.NotNil(t, newSample) {
-			assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
+		if assert.NotNil(t, span) {
+			assert.Equal(t, sample.Name, span.Name, "Name did not propogate")
 			assert.NoError(t, errSSF)
-			assert.NotEmpty(t, newSample.Tags["name"])
+			assert.NotEmpty(t, span.Tags["name"])
 		}
 	}
 }
@@ -77,13 +75,12 @@ func TestNoTagName(t *testing.T) {
 	buf, err := proto.Marshal(&sample)
 	assert.NoError(t, err)
 
-	msg, errSSF := protocol.ParseSSF(buf)
+	span, errSSF := protocol.ParseSSF(buf)
 	assert.NoError(t, err)
-	if assert.NotNil(t, msg) {
-		newSample, err := msg.TraceSpan()
+	if assert.NotNil(t, span) {
 		assert.NoError(t, err)
-		if assert.NotNil(t, newSample) {
-			assert.Equal(t, sample.Name, newSample.Name, "Name did not propogate")
+		if assert.NotNil(t, span) {
+			assert.Equal(t, sample.Name, span.Name, "Name did not propogate")
 			assert.NoError(t, errSSF)
 		}
 	}
@@ -98,14 +95,13 @@ func TestOperation(t *testing.T) {
 	packet, err := ioutil.ReadAll(pb)
 	assert.NoError(t, err)
 
-	msg, errSSF := protocol.ParseSSF(packet)
+	span, errSSF := protocol.ParseSSF(packet)
 	assert.NoError(t, errSSF)
-	if assert.NotNil(t, msg) {
-		sample, errSSF := msg.TraceSpan()
+	if assert.NotNil(t, span) {
 		assert.NoError(t, err)
-		if assert.NotNil(t, sample) {
+		if assert.NotNil(t, span) {
 			assert.NoError(t, errSSF)
-			assert.NotNil(t, sample)
+			assert.NotNil(t, span)
 		}
 	}
 }

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/ssf"
 )
 
@@ -57,8 +56,8 @@ func (m *MetricKey) String() string {
 // error occurs in processing any of the metrics, ExtractMetrics
 // collects them into the error type InvalidMetrics and returns this
 // error alongside any valid metrics that could be parsed.
-func ConvertMetrics(m *protocol.Message) ([]UDPMetric, error) {
-	samples := m.Metrics()
+func ConvertMetrics(m *ssf.SSFSpan) ([]UDPMetric, error) {
+	samples := m.Metrics
 	metrics := make([]UDPMetric, 0, len(samples)+1)
 	invalid := []*ssf.SSFSample{}
 

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/sinks/datadog"
 	"github.com/stripe/veneur/sinks/lightstep"
+	"github.com/stripe/veneur/sinks/metrics"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
@@ -223,7 +224,11 @@ func NewFromConfig(conf Config) (*Server, error) {
 
 	// Set up a span sink that extracts metrics from SSF spans and
 	// reports them via the metric workers:
-	metricSink, err := NewMetricExtractionSink(ret.Workers, ret.indicatorSpanTimerName)
+	processors := make([]metrics.Processor, len(ret.Workers))
+	for i, w := range ret.Workers {
+		processors[i] = w
+	}
+	metricSink, err := metrics.NewMetricExtractionSink(processors, ret.indicatorSpanTimerName)
 	if err != nil {
 		return ret, err
 	}

--- a/server.go
+++ b/server.go
@@ -623,7 +623,7 @@ func (s *Server) handleSSF(msg *protocol.Message, tags []string) {
 
 	s.Statsd.Incr("ssf.spans.received_total", tags, .1)
 	s.Statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
-	s.SpanWorker.SpanChan <- *span
+	s.SpanWorker.SpanChan <- span
 
 	indicatorMetrics, err := samplers.ConvertIndicatorMetrics(span, s.indicatorSpanTimerName)
 	if err != nil {
@@ -945,7 +945,7 @@ func (tb *internalTraceBackend) SendSync(ctx context.Context, span *ssf.SSFSpan)
 	}
 	ch := make(chan struct{})
 	go func() {
-		tb.spanWorker.SpanChan <- *span
+		tb.spanWorker.SpanChan <- span
 		close(ch)
 	}()
 	select {

--- a/server.go
+++ b/server.go
@@ -228,7 +228,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 	for i, w := range ret.Workers {
 		processors[i] = w
 	}
-	metricSink, err := metrics.NewMetricExtractionSink(processors, ret.indicatorSpanTimerName)
+	metricSink, err := metrics.NewMetricExtractionSink(processors, ret.indicatorSpanTimerName, log)
 	if err != nil {
 		return ret, err
 	}

--- a/server.go
+++ b/server.go
@@ -221,6 +221,14 @@ func NewFromConfig(conf Config) (*Server, error) {
 
 	ret.EventWorker = NewEventWorker(ret.Statsd)
 
+	// Set up a span sink that extracts metrics from SSF spans and
+	// reports them via the metric workers:
+	metricSink, err := NewMetricExtractionSink(ret.Workers, ret.indicatorSpanTimerName)
+	if err != nil {
+		return ret, err
+	}
+	ret.spanSinks = append(ret.spanSinks, metricSink)
+
 	for _, addrStr := range conf.StatsdListenAddresses {
 		addr, err := protocol.ResolveAddr(addrStr)
 		if err != nil {

--- a/sinks/blackhole/blackhole.go
+++ b/sinks/blackhole/blackhole.go
@@ -58,7 +58,7 @@ func (b *blackholeSpanSink) Start(*trace.Client) error {
 	return nil
 }
 
-func (b *blackholeSpanSink) Ingest(ssf.SSFSpan) error {
+func (b *blackholeSpanSink) Ingest(*ssf.SSFSpan) error {
 	return nil
 }
 

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	vhttp "github.com/stripe/veneur/http"
+	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
@@ -277,6 +278,9 @@ func (dd *DatadogSpanSink) Start(cl *trace.Client) error {
 
 // Ingest takes the span and adds it to the ringbuffer.
 func (dd *DatadogSpanSink) Ingest(span *ssf.SSFSpan) error {
+	if err := protocol.ValidateTrace(span); err != nil {
+		return err
+	}
 	dd.mutex.Lock()
 	defer dd.mutex.Unlock()
 

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -276,7 +276,7 @@ func (dd *DatadogSpanSink) Start(cl *trace.Client) error {
 }
 
 // Ingest takes the span and adds it to the ringbuffer.
-func (dd *DatadogSpanSink) Ingest(span ssf.SSFSpan) error {
+func (dd *DatadogSpanSink) Ingest(span *ssf.SSFSpan) error {
 	dd.mutex.Lock()
 	defer dd.mutex.Unlock()
 
@@ -291,14 +291,14 @@ func (dd *DatadogSpanSink) Ingest(span ssf.SSFSpan) error {
 func (dd *DatadogSpanSink) Flush() {
 	dd.mutex.Lock()
 
-	ssfSpans := make([]ssf.SSFSpan, 0, dd.buffer.Len())
+	ssfSpans := make([]*ssf.SSFSpan, 0, dd.buffer.Len())
 
 	dd.buffer.Do(func(t interface{}) {
 		const tooEarly = 1497
 		const tooLate = 1497629343000000
 
 		if t != nil {
-			ssfSpan, ok := t.(ssf.SSFSpan)
+			ssfSpan, ok := t.(*ssf.SSFSpan)
 			if !ok {
 				dd.log.Error("Got an unknown object in tracing ring!")
 				// We'll just skip this one so we don't poison pill or anything.

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -151,7 +151,7 @@ func TestDatadogFlushSpans(t *testing.T) {
 	start := time.Now()
 	end := start.Add(2 * time.Second)
 
-	testSpan := ssf.SSFSpan{
+	testSpan := &ssf.SSFSpan{
 		TraceId:        1,
 		ParentId:       1,
 		Id:             2,

--- a/sinks/internal/metrics.go
+++ b/sinks/internal/metrics.go
@@ -1,0 +1,96 @@
+// Package internal provides sinks that are used by veneur internally.
+package internal
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur"
+	"github.com/stripe/veneur/protocol"
+	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+type metricExtractionSink struct {
+	workers                []*veneur.Worker
+	indicatorSpanTimerName string
+}
+
+var _ sinks.SpanSink = &metricExtractionSink{}
+
+// NewMetricExtractionSink sets up and creates a span sink that
+// extracts metrics ("samples") from SSF spans and reports them to a
+// veneur's metrics workers.
+func NewMetricExtractionSink(mw []*veneur.Worker, timerName string) (sinks.SpanSink, error) {
+	return &metricExtractionSink{mw, timerName}, nil
+}
+
+// Name returns "metric_extraction".
+func (m metricExtractionSink) Name() string {
+	return "metric_extraction"
+}
+
+// Start is a no-op.
+func (m metricExtractionSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (m *metricExtractionSink) sendMetrics(metrics []samplers.UDPMetric) {
+	for _, metric := range metrics {
+		m.workers[metric.Digest%uint32(len(m.workers))].PacketChan <- metric
+	}
+}
+
+func (m *metricExtractionSink) sendSample(sample *ssf.SSFSample) error {
+	metric, err := samplers.ParseMetricSSF(sample)
+	if err != nil {
+		return err
+	}
+	m.sendMetrics([]samplers.UDPMetric{metric})
+	return nil
+}
+
+// Ingest extracts metrics from an SSF span, and feeds them into the
+// appropriate metric sinks.
+func (m metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
+	metrics, err := samplers.ConvertMetrics(span)
+	if err != nil {
+		if _, ok := err.(samplers.InvalidMetrics); ok {
+			logrus.WithError(err).
+				Warn("Could not parse metrics from SSF Message")
+			m.sendSample(ssf.Count("veneur.ssf.error_total", 1, map[string]string{
+				"packet_type": "ssf_metric",
+				"step":        "extract_metrics",
+				"reason":      "invalid_metrics",
+			}))
+		} else {
+			logrus.WithError(err).Error("Unexpected error extracting metrics from SSF Message")
+			m.sendSample(ssf.Count("veneur.ssf.error_total", 1, map[string]string{
+				"packet_type": "ssf_metric",
+				"step":        "extract_metrics",
+				"reason":      "unexpected_error",
+				"error":       err.Error(),
+			}))
+			return err
+		}
+	}
+	m.sendMetrics(metrics)
+
+	if err := protocol.ValidateTrace(span); err != nil {
+		return err
+	}
+
+	indicatorMetrics, err := samplers.ConvertIndicatorMetrics(span, m.indicatorSpanTimerName)
+	if err != nil {
+		logrus.WithError(err).
+			WithField("span_name", span.Name).
+			Warn("Couldn't extract indicator metrics for span")
+		return err
+	}
+	m.sendMetrics(indicatorMetrics)
+	return nil
+}
+
+func (m metricExtractionSink) Flush() {
+	return
+}

--- a/sinks/internal/metrics_test.go
+++ b/sinks/internal/metrics_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur"
+	"github.com/stripe/veneur/ssf"
+)
+
+func TestMetricExtractor(t *testing.T) {
+	logger := logrus.StandardLogger()
+	sink := metricExtractionSink{
+		workers:                []*veneur.Worker{veneur.NewWorker(0, nil, logger)},
+		indicatorSpanTimerName: "foo",
+	}
+
+	start := time.Now()
+	end := start.Add(5 * time.Second)
+	span := &ssf.SSFSpan{
+		Id:             5,
+		TraceId:        5,
+		StartTimestamp: start.UnixNano(),
+		EndTimestamp:   end.UnixNano(),
+		Metrics: []*ssf.SSFSample{
+			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
+			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
+		},
+	}
+	done := make(chan int)
+	go func() {
+		n := 0
+		for m := range sink.workers[0].PacketChan {
+			hasP := false
+			for _, tag := range m.Tags {
+				hasP = (tag == "purpose:testing")
+			}
+			if !hasP {
+				t.Logf("Received unexpected additional metric %#v", m)
+				continue
+			}
+			n++
+		}
+		done <- n
+	}()
+	assert.NoError(t, sink.Ingest(span))
+	close(sink.workers[0].PacketChan)
+	assert.Equal(t, 2, <-done, "Should have sent the right number of metrics")
+}
+
+func TestIndicatorMetricExtractor(t *testing.T) {
+	logger := logrus.StandardLogger()
+	sink := metricExtractionSink{
+		workers:                []*veneur.Worker{veneur.NewWorker(0, nil, logger)},
+		indicatorSpanTimerName: "foo",
+	}
+
+	start := time.Now()
+	end := start.Add(5 * time.Second)
+	span := &ssf.SSFSpan{
+		Id:             5,
+		TraceId:        5,
+		Service:        "indicator_testing",
+		StartTimestamp: start.UnixNano(),
+		EndTimestamp:   end.UnixNano(),
+		Indicator:      true,
+	}
+	done := make(chan int)
+	go func() {
+		n := 0
+		for m := range sink.workers[0].PacketChan {
+			hasP := false
+			for _, tag := range m.Tags {
+				hasP = (tag == "service:indicator_testing")
+			}
+			if !hasP {
+				t.Logf("Received unexpected additional metric %#v", m)
+				continue
+			}
+			n++
+		}
+		done <- n
+	}()
+	assert.NoError(t, sink.Ingest(span))
+	close(sink.workers[0].PacketChan)
+	assert.Equal(t, 1, <-done, "Should have sent the right number of metrics")
+}

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -115,7 +115,7 @@ func (ls *LightStepSpanSink) Name() string {
 
 // Ingest takes in a span and passed it along to the LS client after
 // some sanity checks and improvements are made.
-func (ls *LightStepSpanSink) Ingest(ssfSpan ssf.SSFSpan) error {
+func (ls *LightStepSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	parentID := ssfSpan.ParentId
 	if parentID <= 0 {
 		parentID = 0

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -12,6 +12,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
@@ -116,6 +117,10 @@ func (ls *LightStepSpanSink) Name() string {
 // Ingest takes in a span and passed it along to the LS client after
 // some sanity checks and improvements are made.
 func (ls *LightStepSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+	if err := protocol.ValidateTrace(ssfSpan); err != nil {
+		return err
+	}
+
 	parentID := ssfSpan.ParentId
 	if parentID <= 0 {
 		parentID = 0

--- a/sinks/lightstep/lightstep_test.go
+++ b/sinks/lightstep/lightstep_test.go
@@ -109,7 +109,7 @@ func TestLSSpanSinkIngest(t *testing.T) {
 	start := time.Now()
 	end := start.Add(2 * time.Second)
 
-	testSpan := ssf.SSFSpan{
+	testSpan := &ssf.SSFSpan{
 		TraceId:        1,
 		ParentId:       1,
 		Id:             2,

--- a/sinks/metrics/metrics_test.go
+++ b/sinks/metrics/metrics_test.go
@@ -16,7 +16,7 @@ func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []metrics.Processor{worker}
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo")
+	sink, err := metrics.NewMetricExtractionSink(workers, "foo", logger)
 	require.NoError(t, err)
 
 	start := time.Now()
@@ -56,7 +56,7 @@ func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []metrics.Processor{worker}
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo")
+	sink, err := metrics.NewMetricExtractionSink(workers, "foo", logger)
 	require.NoError(t, err)
 
 	start := time.Now()

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -34,10 +34,14 @@ type SpanSink interface {
 	// background processing tasks that the sink might have to run
 	// in the background. It's invoked when the server starts.
 	Start(*trace.Client) error
+
+	// Name returns the span sink's name for debugging purposes
 	Name() string
+
 	// Flush receives `SSFSpan`s from Veneur **as they arrive**. If the sink wants
 	// to buffer spans it may do so and defer sending until `Flush` is called.
-	Ingest(ssf.SSFSpan) error
+	Ingest(*ssf.SSFSpan) error
+
 	// Invoked at the same interval as metric flushes, this can be used as a
 	// signal for the sink to write out if it was buffering or something.
 	Flush()

--- a/span_sink_test.go
+++ b/span_sink_test.go
@@ -1,1 +1,0 @@
-package veneur

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -1,40 +1,69 @@
 package ssf
 
+import "time"
+
+// SampleOption is a functional option that can be used for less
+// commonly needed fields in sample creation helper functions.
+type SampleOption func(*SSFSample)
+
+// Unit is a functional option for creating an SSFSample. It sets the
+// sample's unit name to the name passed.
+func Unit(name string) SampleOption {
+	return func(s *SSFSample) {
+		s.Unit = name
+	}
+}
+
+// Timestamp is a functional option for creating an SSFSample. It sets
+// the timestamp field on the sample to the timestamp passed.
+func Timestamp(ts time.Time) SampleOption {
+	return func(s *SSFSample) {
+		s.Timestamp = ts.UnixNano()
+	}
+}
+
+func create(base *SSFSample, opts []SampleOption) *SSFSample {
+	for _, opt := range opts {
+		opt(base)
+	}
+	return base
+}
+
 // Count returns an SSFSample representing an increment / decrement of
 // a counter. It's a convenience wrapper around constructing SSFSample
 // objects.
-func Count(name string, value float32, tags map[string]string) *SSFSample {
-	return &SSFSample{
+func Count(name string, value float32, tags map[string]string, opts ...SampleOption) *SSFSample {
+	return create(&SSFSample{
 		Metric:     SSFSample_COUNTER,
 		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,
-	}
+	}, opts)
 }
 
 // Gauge returns an SSFSample representing a gauge at a certain
 // value. It's a convenience wrapper around constructing SSFSample
 // objects.
-func Gauge(name string, value float32, tags map[string]string) *SSFSample {
-	return &SSFSample{
+func Gauge(name string, value float32, tags map[string]string, opts ...SampleOption) *SSFSample {
+	return create(&SSFSample{
 		Metric:     SSFSample_GAUGE,
 		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,
-	}
+	}, opts)
 }
 
 // Histogram returns an SSFSample representing a value on a histogram,
 // like a timer or other range. It's a convenience wrapper around
 // constructing SSFSample objects.
-func Histogram(name string, value float32, tags map[string]string) *SSFSample {
-	return &SSFSample{
+func Histogram(name string, value float32, tags map[string]string, opts ...SampleOption) *SSFSample {
+	return create(&SSFSample{
 		Metric:     SSFSample_HISTOGRAM,
 		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,
-	}
+	}, opts)
 }

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -4,8 +4,9 @@ package ssf
 // a counter. It's a convenience wrapper around constructing SSFSample
 // objects.
 func Count(name string, value float32, tags map[string]string) *SSFSample {
-	return *SSFSample{
+	return &SSFSample{
 		Metric:     SSFSample_COUNTER,
+		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,
@@ -18,6 +19,7 @@ func Count(name string, value float32, tags map[string]string) *SSFSample {
 func Gauge(name string, value float32, tags map[string]string) *SSFSample {
 	return &SSFSample{
 		Metric:     SSFSample_GAUGE,
+		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,
@@ -30,6 +32,7 @@ func Gauge(name string, value float32, tags map[string]string) *SSFSample {
 func Histogram(name string, value float32, tags map[string]string) *SSFSample {
 	return &SSFSample{
 		Metric:     SSFSample_HISTOGRAM,
+		Name:       name,
 		Value:      value,
 		Tags:       tags,
 		SampleRate: 1.0,

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -1,0 +1,37 @@
+package ssf
+
+// Count returns an SSFSample representing an increment / decrement of
+// a counter. It's a convenience wrapper around constructing SSFSample
+// objects.
+func Count(name string, value float32, tags map[string]string) *SSFSample {
+	return *SSFSample{
+		Metric:     SSFSample_COUNTER,
+		Value:      value,
+		Tags:       tags,
+		SampleRate: 1.0,
+	}
+}
+
+// Gauge returns an SSFSample representing a gauge at a certain
+// value. It's a convenience wrapper around constructing SSFSample
+// objects.
+func Gauge(name string, value float32, tags map[string]string) *SSFSample {
+	return &SSFSample{
+		Metric:     SSFSample_GAUGE,
+		Value:      value,
+		Tags:       tags,
+		SampleRate: 1.0,
+	}
+}
+
+// Histogram returns an SSFSample representing a value on a histogram,
+// like a timer or other range. It's a convenience wrapper around
+// constructing SSFSample objects.
+func Histogram(name string, value float32, tags map[string]string) *SSFSample {
+	return &SSFSample{
+		Metric:     SSFSample_HISTOGRAM,
+		Value:      value,
+		Tags:       tags,
+		SampleRate: 1.0,
+	}
+}

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -7,18 +7,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type constructor func(name string, value float32, tags map[string]string) *SSFSample
+type constructor func(name string, value float32, tags map[string]string, opts ...SampleOption) *SSFSample
 
 func TestValidity(t *testing.T) {
-	tests := []constructor{Count, Gauge, Histogram}
-	for _, elt := range tests {
+	tests := map[string]constructor{"count": Count, "gauge": Gauge, "histogram": Histogram}
+	for name, elt := range tests {
 		test := elt
-		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", name), func(t *testing.T) {
 			t.Parallel()
 			sample := test("foo", 1, map[string]string{"purpose": "testing"})
 			assert.Equal(t, "foo", sample.Name)
 			assert.Equal(t, float32(1), sample.Value)
 			assert.Equal(t, map[string]string{"purpose": "testing"}, sample.Tags)
+		})
+		t.Run(fmt.Sprintf("%s/unit", name), func(t *testing.T) {
+			t.Parallel()
+			sample := test("foo", 1, map[string]string{"purpose": "testing"}, Unit("farts"))
+			assert.Equal(t, "foo", sample.Name)
+			assert.Equal(t, float32(1), sample.Value)
+			assert.Equal(t, map[string]string{"purpose": "testing"}, sample.Tags)
+			assert.Equal(t, "farts", sample.Unit)
 		})
 	}
 }

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -24,6 +24,30 @@ func TestValidity(t *testing.T) {
 	}
 }
 
+func TestTimingMS(t *testing.T) {
+	tests := []struct {
+		res  time.Duration
+		name string
+	}{
+		{time.Nanosecond, "ns"},
+		{time.Microsecond, "µs"},
+		{time.Millisecond, "ms"},
+		{time.Second, "s"},
+		{time.Minute, "min"},
+		{time.Hour, "h"},
+	}
+	for _, elt := range tests {
+		test := elt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			sample := Timing("foo", 20*test.res, test.res, nil)
+			assert.Equal(t, float32(20), sample.Value)
+			assert.Equal(t, test.name, sample.Unit)
+
+		})
+	}
+}
+
 func TestOptions(t *testing.T) {
 	then := time.Now().Add(-20 * time.Second)
 	testFuns := map[string]constructor{"count": Count, "gauge": Gauge, "histogram": Histogram}

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -1,0 +1,24 @@
+package ssf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type constructor func(name string, value float32, tags map[string]string) *SSFSample
+
+func TestValidity(t *testing.T) {
+	tests := []constructor{Count, Gauge, Histogram}
+	for _, elt := range tests {
+		test := elt
+		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+			t.Parallel()
+			sample := test("foo", 1, map[string]string{"purpose": "testing"})
+			assert.Equal(t, "foo", sample.Name)
+			assert.Equal(t, float32(1), sample.Value)
+			assert.Equal(t, map[string]string{"purpose": "testing"}, sample.Tags)
+		})
+	}
+}

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -62,7 +62,7 @@ func TestUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *protocol.Message, 4)
+	outPkg := make(chan *ssf.SSFSpan, 4)
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
 		for {
 			pkg, err := protocol.ReadSSF(in)
@@ -102,7 +102,7 @@ func TestUNIXBuffered(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *protocol.Message, 4)
+	outPkg := make(chan *ssf.SSFSpan, 4)
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
 		for {
 			pkg, err := protocol.ReadSSF(in)
@@ -149,7 +149,7 @@ func TestUNIXBufferedFlushing(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *protocol.Message, 4)
+	outPkg := make(chan *ssf.SSFSpan, 4)
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
 		for {
 			pkg, err := protocol.ReadSSF(in)
@@ -255,7 +255,7 @@ func TestReconnectUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *protocol.Message, 4)
+	outPkg := make(chan *ssf.SSFSpan, 4)
 	// A server that can read one span and then immediately closes
 	// the connection:
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {
@@ -323,7 +323,7 @@ func TestReconnectBufferedUNIX(t *testing.T) {
 	laddr, err := net.ResolveUnixAddr("unix", sockName)
 	require.NoError(t, err)
 
-	outPkg := make(chan *protocol.Message, 4)
+	outPkg := make(chan *ssf.SSFSpan, 4)
 	// A server that can read one span and then immediately closes
 	// the connection:
 	cleanup := serveUNIX(t, laddr, func(in net.Conn) {

--- a/worker.go
+++ b/worker.go
@@ -32,6 +32,11 @@ type Worker struct {
 	wm         WorkerMetrics
 }
 
+// IngestUDP on a Worker feeds the metric into the worker's PacketChan.
+func (w *Worker) IngestUDP(metric samplers.UDPMetric) {
+	w.PacketChan <- metric
+}
+
 // WorkerMetrics is just a plain struct bundling together the flushed contents of a worker
 type WorkerMetrics struct {
 	// we do not want to key on the metric's Digest here, because those could

--- a/worker.go
+++ b/worker.go
@@ -355,7 +355,7 @@ func (ew *EventWorker) Flush() ([]samplers.UDPEvent, []samplers.UDPServiceCheck)
 
 // SpanWorker is similar to a Worker but it collects events and service checks instead of metrics.
 type SpanWorker struct {
-	SpanChan chan ssf.SSFSpan
+	SpanChan chan *ssf.SSFSpan
 	sinks    []sinks.SpanSink
 	stats    *statsd.Client
 }
@@ -363,7 +363,7 @@ type SpanWorker struct {
 // NewSpanWorker creates an SpanWorker ready to collect events and service checks.
 func NewSpanWorker(sinks []sinks.SpanSink, stats *statsd.Client) *SpanWorker {
 	return &SpanWorker{
-		SpanChan: make(chan ssf.SSFSpan),
+		SpanChan: make(chan *ssf.SSFSpan),
 		sinks:    sinks,
 		stats:    stats,
 	}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds a span sink whose entire purpose is to take an SSF span, extract metrics from it, and report them into a veneur server's metrics worker. Additionally, I'm adding some helper functions to the SSF package which allow easy construction of SSF samples.

This opens up the way to having the internal veneur client be the sole client we use to report everything about veneur's internal working, without traversing the network at all: No more packets sent from veneur to its own UDP port!

#### Motivation
Mostly, I was worried that the internal client couldn't ingest metrics-carrying ssf packets. Additionally, putting the processing for these metrics on the span sink means the server's code gets less cluttered with that whole metrics-extraction stuff, and we have a single piece that we can test more easily.


#### Test plan
Wrote tests!


#### Rollout/monitoring/revert plan
This should probably go into 2.0!
