### PR TITLE
Mandate the use of -ssf with trace IDs in veneur-emit

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -91,6 +91,7 @@ func main() {
 	}
 	logrus.WithField("net", netAddr.Network()).
 		WithField("addr", netAddr.String()).
+		WithField("ssf", *toSSF).
 		Debugf("destination")
 
 	if *mode == "event" {

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -131,6 +131,10 @@ func main() {
 			Fatal("Couldn't set up the main span")
 	}
 	if span.TraceId != 0 {
+		if !*toSSF {
+			logrus.WithField("ssf", *toSSF).
+				Fatal("Can's use tracing in non-ssf operation: Use -ssf to emit trace spans.")
+		}
 		logrus.WithField("trace_id", span.TraceId).
 			WithField("span_id", span.Id).
 			WithField("parent_id", span.ParentId).


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR defangs `-trace_id`: Previously, you could set up a trace span and then submit its metrics (but not the trace id itself) via statsd, which results in terrible confusion on the veneur endpoint that expects protobuf and gets statsd.

#### Motivation
veneur-emit would just silently do the wrong thing.


#### Test plan
Ran on the commandline:

```
$ go run cmd/veneur-emit/main.go -trace_id 2093 -hostport 127.0.0.1:8200 -debug
DEBU[0000] destination                                   addr="127.0.0.1:8200" net=udp ssf=false
FATA[0000] Can's use tracing in non-ssf operation: Use -ssf to emit trace spans.  ssf=false
exit status 1
```

vs. 
```
$ go run cmd/veneur-emit/main.go -trace_id 2093 -hostport 127.0.0.1:8200 -debug -ssf
DEBU[0000] destination                                   addr="127.0.0.1:8200" net=udp ssf=true
DEBU[0000] Tracing is activated                          name= parent_id=0 span_id=4992978687192085924 trace_id=2093
```

#### Rollout/monitoring/revert plan
Just merge; no changelog since it's related to the unreleased previous change.
