### PR TITLE
Drop statsd client from veneur's internal metrics reporting

### DIFF
--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -39,7 +39,7 @@ func main() {
 		logrus.WithError(err).Fatal("Could not initialize proxy")
 	}
 	defer func() {
-		veneur.ConsumePanic(proxy.Sentry, proxy.Statsd, proxy.Hostname, recover())
+		veneur.ConsumePanic(proxy.Sentry, proxy.TraceClient, proxy.Hostname, recover())
 	}()
 	proxy.Start()
 

--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur"
+	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
 
@@ -31,6 +32,8 @@ func main() {
 	logger := logrus.StandardLogger()
 	proxy, err := veneur.NewProxyFromConfig(logger, conf)
 	veneur.SetLogger(logger)
+
+	ssf.NamePrefix = "veneur_proxy."
 
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not initialize proxy")

--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -41,6 +41,13 @@ func main() {
 	defer func() {
 		veneur.ConsumePanic(proxy.Sentry, proxy.TraceClient, proxy.Hostname, recover())
 	}()
+
+	if proxy.TraceClient != trace.DefaultClient && proxy.TraceClient != nil {
+		if trace.DefaultClient != nil {
+			trace.DefaultClient.Close()
+		}
+		trace.DefaultClient = proxy.TraceClient
+	}
 	proxy.Start()
 
 	proxy.HTTPServe()

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -65,7 +65,7 @@ func main() {
 	ssf.NamePrefix = "veneur."
 
 	defer func() {
-		veneur.ConsumePanic(server.Sentry, server.Statsd, server.Hostname, recover())
+		veneur.ConsumePanic(server.Sentry, server.TraceClient, server.Hostname, recover())
 	}()
 
 	if server.TraceClient != nil {

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getsentry/raven-go"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur"
+	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
 
@@ -61,6 +62,8 @@ func main() {
 
 		logrus.WithError(e).Fatal("Could not initialize server")
 	}
+	ssf.NamePrefix = "veneur."
+
 	defer func() {
 		veneur.ConsumePanic(server.Sentry, server.Statsd, server.Hostname, recover())
 	}()

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -10,6 +10,7 @@ type ProxyConfig struct {
 	ForwardTimeout           string `yaml:"forward_timeout"`
 	HTTPAddress              string `yaml:"http_address"`
 	SentryDsn                string `yaml:"sentry_dsn"`
+	SsfDestinationAddress    string `yaml:"ssf_destination_address"`
 	StatsAddress             string `yaml:"stats_address"`
 	TraceAddress             string `yaml:"trace_address"`
 	TraceAPIAddress          string `yaml:"trace_api_address"`

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -6,7 +6,12 @@ http_address: "localhost:8127"
 # How often to refresh from Consul's healthy nodes
 consul_refresh_interval: "30s"
 
+# This field is deprecated - use ssf_destination_address instead!
 stats_address: "localhost:8125"
+
+# The address to which to send SSF spans and metrics - this is the
+# same format as on the veneur server's `ssf_listen_addresses`.
+ssf_destination_address: "udp://localhost:8200"
 
 ### FORWARDING
 # Use a static host for forwarding

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -11,7 +11,7 @@ stats_address: "localhost:8125"
 
 # The address to which to send SSF spans and metrics - this is the
 # same format as on the veneur server's `ssf_listen_addresses`.
-ssf_destination_address: "udp://localhost:8200"
+ssf_destination_address: "udp://localhost:8126"
 
 ### FORWARDING
 # Use a static host for forwarding

--- a/flusher.go
+++ b/flusher.go
@@ -234,6 +234,8 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 	return finalMetrics
 }
 
+const flushTotalMetric = "worker.metrics_flushed_total"
+
 // computeMetricsFlushCounts reports the counts of
 // Counters, Gauges, LocalHistograms, LocalSets, and LocalTimers
 // as metrics. These are shared by both global and local flush operations.
@@ -243,11 +245,11 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 // that should happen *after* the flush-forward operation.
 func (s *Server) computeMetricsFlushCounts(ms metricsSummary) []*ssf.SSFSample {
 	return []*ssf.SSFSample{
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalCounters), map[string]string{"metric_type": "counter"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalGauges), map[string]string{"metric_type": "gauge"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalLocalHistograms), map[string]string{"metric_type": "local_histogram"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalLocalSets), map[string]string{"metric_type": "local_set"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalLocalTimers), map[string]string{"metric_type": "local_timer"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalCounters), map[string]string{"metric_type": "counter"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalGauges), map[string]string{"metric_type": "gauge"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalLocalHistograms), map[string]string{"metric_type": "local_histogram"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalLocalSets), map[string]string{"metric_type": "local_set"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalLocalTimers), map[string]string{"metric_type": "local_timer"}),
 	}
 }
 
@@ -262,11 +264,11 @@ func (s *Server) computeGlobalMetricsFlushCounts(ms metricsSummary) []*ssf.SSFSa
 	// histograms that it received, and then a global veneur reports them
 	// again
 	return []*ssf.SSFSample{
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalGlobalCounters), map[string]string{"metric_type": "global_counter"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalGlobalGauges), map[string]string{"metric_type": "global_gauge"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalHistograms), map[string]string{"metric_type": "histogram"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalSets), map[string]string{"metric_type": "set"}),
-		ssf.Count("worker.metrics_flushed_total", float32(ms.totalTimers), map[string]string{"metric_type": "timer"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalGlobalCounters), map[string]string{"metric_type": "global_counter"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalGlobalGauges), map[string]string{"metric_type": "global_gauge"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalHistograms), map[string]string{"metric_type": "histogram"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalSets), map[string]string{"metric_type": "set"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalTimers), map[string]string{"metric_type": "timer"}),
 	}
 }
 

--- a/forward_test.go
+++ b/forward_test.go
@@ -120,7 +120,6 @@ func TestE2EForwardingIndicatorMetrics(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		metrics := <-ch
-		require.Equal(t, 3, len(metrics), "metrics:\n%#v", metrics)
 		for _, suffix := range []string{".50percentile", ".75percentile", ".99percentile"} {
 			mName := "indicator.span.timer" + suffix
 			found := false

--- a/http.go
+++ b/http.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
 
 	"goji.io"
 	"goji.io/pat"
@@ -65,7 +67,7 @@ func (s *Server) ImportMetrics(ctx context.Context, jsonMetrics []samplers.JSONM
 		nextChunk, workerIndex := sortedIter.Chunk()
 		s.Workers[workerIndex].ImportChan <- nextChunk
 	}
-	s.Statsd.TimeInMilliseconds("import.response_duration_ns", float64(time.Since(span.Start).Nanoseconds()), []string{"part:merge"}, 1.0)
+	metrics.ReportOne(s.TraceClient, ssf.Timing("import.response_duration_ns", time.Since(span.Start), time.Nanosecond, map[string]string{"part": "merge"}))
 }
 
 // sorts a set of jsonmetrics by what worker they belong to

--- a/networking.go
+++ b/networking.go
@@ -45,7 +45,7 @@ func startStatsdUDP(s *Server, addr *net.UDPAddr, packetPool *sync.Pool) net.Add
 	for i := 0; i < s.numReaders; i++ {
 		go func() {
 			defer func() {
-				ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+				ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
 			}()
 			// each goroutine gets its own socket
 			// if the sockets support SO_REUSEPORT, then this will cause the
@@ -111,7 +111,7 @@ func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) net.Add
 
 	go func() {
 		defer func() {
-			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+			ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
 		}()
 		s.ReadTCPSocket(listener)
 	}()
@@ -149,7 +149,7 @@ func startSSFUDP(s *Server, addr *net.UDPAddr, tracePool *sync.Pool) net.Addr {
 	}
 	go func() {
 		defer func() {
-			ConsumePanic(s.Sentry, s.Statsd, s.Hostname, recover())
+			ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
 		}()
 		s.ReadSSFPacketSocket(listener, tracePool)
 	}()

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
@@ -22,7 +21,6 @@ import (
 
 type dummyPlugin struct {
 	logger *logrus.Logger
-	statsd *statsd.Client
 	flush  func(context.Context, []samplers.InterMetric) error
 }
 
@@ -55,7 +53,7 @@ func TestGlobalServerPluginFlush(t *testing.T) {
 	f := newFixture(t, config, nil, nil)
 	defer f.Close()
 
-	dp := &dummyPlugin{logger: log, statsd: f.server.Statsd}
+	dp := &dummyPlugin{logger: log}
 
 	dp.flush = func(ctx context.Context, metrics []samplers.InterMetric) error {
 		assert.Equal(t, len(expectedMetrics), len(metrics))

--- a/proxy.go
+++ b/proxy.go
@@ -137,7 +137,7 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 	if conf.SsfDestinationAddress != "" {
 		p.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress,
 			trace.Buffered,
-			trace.FlushInterval(10*time.Second),
+			trace.FlushInterval(3*time.Second),
 		)
 		if err != nil {
 			logger.WithField("ssf_destination_address", conf.SsfDestinationAddress).

--- a/proxy.go
+++ b/proxy.go
@@ -132,7 +132,16 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 		}
 		logger.WithField("interval", conf.ConsulRefreshInterval).Info("Will use Consul for service discovery")
 	}
+
 	p.TraceClient = trace.DefaultClient
+	if conf.SsfDestinationAddress != "" {
+		p.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress)
+		if err != nil {
+			logger.WithField("ssf_destination_address", conf.SsfDestinationAddress).
+				WithError(err).
+				Fatal("Error using SSF destination address")
+		}
+	}
 
 	// TODO Size of replicas in config?
 	//ret.ForwardDestinations.NumberOfReplicas = ???

--- a/proxy.go
+++ b/proxy.go
@@ -135,7 +135,10 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 
 	p.TraceClient = trace.DefaultClient
 	if conf.SsfDestinationAddress != "" {
-		p.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress)
+		p.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress,
+			trace.Buffered,
+			trace.FlushInterval(10*time.Second),
+		)
 		if err != nil {
 			logger.WithField("ssf_destination_address", conf.SsfDestinationAddress).
 				WithError(err).

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -162,16 +162,14 @@ func ParseMetricSSF(metric *ssf.SSFSample) (UDPMetric, error) {
 	tempTags := make([]string, 0)
 	for key, value := range metric.Tags {
 		if key == "veneurlocalonly" {
-			// delete the tag from the list
 			ret.Scope = LocalOnly
-			break
-		} else if key == "veneurglobalonly" {
-			// delete the tag from the list
-			ret.Scope = GlobalOnly
-			break
-		} else {
-			tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
+			continue
 		}
+		if key == "veneurglobalonly" {
+			ret.Scope = GlobalOnly
+			continue
+		}
+		tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
 	}
 	sort.Strings(tempTags)
 	ret.Tags = tempTags

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -14,14 +14,14 @@ func consumeAndCatchPanic(s *Server) (result interface{}) {
 	defer func() {
 		result = recover()
 	}()
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, "panic")
+	ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, "panic")
 	return
 }
 
 func TestConsumePanicWithoutSentry(t *testing.T) {
 	s := &Server{}
 	// does nothing
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, nil)
+	ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, nil)
 
 	recovered := consumeAndCatchPanic(s)
 	if recovered != "panic" {
@@ -49,7 +49,7 @@ func TestConsumePanicWithSentry(t *testing.T) {
 	s.Sentry.Transport = fakeTransport
 
 	// nil does nothing
-	ConsumePanic(s.Sentry, s.Statsd, s.Hostname, nil)
+	ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, nil)
 	if len(fakeTransport.packets) != 0 {
 		t.Error("ConsumePanic(nil) should not send data:", fakeTransport.packets)
 	}

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -89,7 +89,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	server := setupVeneurServer(t, config, nil, nil, nil)
 	defer server.Shutdown()
 
-	ddSink, err := datadog.NewDatadogSpanSink("http://example.com", 100, server.Statsd, server.HTTPClient, server.TagsAsMap, logrus.New())
+	ddSink, err := datadog.NewDatadogSpanSink("http://example.com", 100, server.HTTPClient, server.TagsAsMap, logrus.New())
 
 	server.TraceClient = nil
 	server.spanSinks = append(server.spanSinks, ddSink)
@@ -124,7 +124,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	defer server.Shutdown()
 
 	//collector string, reconnectPeriod string, maximumSpans int, numClients int, accessToken string
-	lsSink, err := lightstep.NewLightStepSpanSink("example.com", "5m", 10000, 1, "secret", server.Statsd, server.TagsAsMap, log)
+	lsSink, err := lightstep.NewLightStepSpanSink("example.com", "5m", 10000, 1, "secret", server.TagsAsMap, log)
 	server.spanSinks = append(server.spanSinks, lsSink)
 
 	packet, err := ioutil.ReadAll(protobuf)

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,8 +105,7 @@ func TestDeviceMagicTag(t *testing.T) {
 
 func TestNewDatadogSpanSinkConfig(t *testing.T) {
 	// test the variables that have been renamed
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	ddSink, err := NewDatadogSpanSink("http://example.com", 100, stats, &http.Client{}, nil, logrus.New())
+	ddSink, err := NewDatadogSpanSink("http://example.com", 100, &http.Client{}, nil, logrus.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,11 +142,9 @@ func (rt *DatadogRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 
 func TestDatadogFlushSpans(t *testing.T) {
 	// test the variables that have been renamed
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
 	transport := &DatadogRoundTripper{Endpoint: "/v0.3/traces", Contains: "farts-srv"}
-
-	ddSink, err := NewDatadogSpanSink("http://example.com", 100, stats, &http.Client{Transport: transport}, nil, logrus.New())
+	ddSink, err := NewDatadogSpanSink("http://example.com", 100, &http.Client{Transport: transport}, nil, logrus.New())
 	assert.NoError(t, err)
 
 	start := time.Now()
@@ -202,7 +198,6 @@ func ddTestServer(t *testing.T, endpoint, contains string) (*httptest.Server, ch
 
 func TestDatadogMetricRouting(t *testing.T) {
 	// test the variables that have been renamed
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
 
 	tests := []struct {
@@ -254,7 +249,6 @@ func TestDatadogMetricRouting(t *testing.T) {
 				log:             logrus.New(),
 				tags:            []string{"a:b", "c:d"},
 				interval:        10,
-				statsd:          stats,
 			}
 			done := make(chan struct{})
 			go func() {

--- a/sinks/lightstep/lightstep_test.go
+++ b/sinks/lightstep/lightstep_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sirupsen/logrus"
@@ -102,8 +101,7 @@ func (tls *testLSSpan) Log(data opentracing.LogData) {
 
 func TestLSSinkConstructor(t *testing.T) {
 
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	_, err := NewLightStepSpanSink("http://example.com", "5m", 1000, 1, "secret", stats, map[string]string{"foo": "bar"}, logrus.New())
+	_, err := NewLightStepSpanSink("http://example.com", "5m", 1000, 1, "secret", map[string]string{"foo": "bar"}, logrus.New())
 	assert.NoError(t, err)
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/event"
 	"github.com/signalfx/golib/sfxclient"
@@ -38,8 +37,7 @@ func (fs *FakeSink) AddEvents(ctx context.Context, events []*event.Event) (err e
 
 func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), nil)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,9 +61,8 @@ func TestNewSignalFxSink(t *testing.T) {
 }
 
 func TestSignalFxFlushRouting(t *testing.T) {
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -117,9 +114,8 @@ func TestSignalFxFlushRouting(t *testing.T) {
 }
 
 func TestSignalFxFlushGauge(t *testing.T) {
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -149,9 +145,8 @@ func TestSignalFxFlushGauge(t *testing.T) {
 }
 
 func TestSignalFxFlushCounter(t *testing.T) {
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -183,9 +178,8 @@ func TestSignalFxFlushCounter(t *testing.T) {
 }
 
 func TestSignalFxEventFlush(t *testing.T) {
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +16,7 @@ func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []ssfmetrics.Processor{worker}
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", stats, logger)
+	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	require.NoError(t, err)
 
 	start := time.Now()
@@ -58,8 +56,7 @@ func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []ssfmetrics.Processor{worker}
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", stats, logger)
+	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	require.NoError(t, err)
 
 	start := time.Now()

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -73,12 +73,8 @@ func TestIndicatorMetricExtractor(t *testing.T) {
 	go func() {
 		n := 0
 		for m := range worker.PacketChan {
-			hasP := false
-			for _, tag := range m.Tags {
-				hasP = hasP || (tag == "service:indicator_testing")
-			}
-			if !hasP {
-				t.Logf("Received unexpected additional metric %#v", m)
+			if m.Name != "foo" {
+				t.Logf("Received additional metric %#v", m)
 				continue
 			}
 			n++

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -152,6 +152,18 @@ func Histogram(name string, value float32, tags map[string]string, opts ...Sampl
 	}, opts)
 }
 
+// Set returns an SSFSample representing a value on a set, useful for
+// counting the unique values that occur in a certain time bound.
+func Set(name string, value string, tags map[string]string, opts ...SampleOption) *SSFSample {
+	return create(&SSFSample{
+		Metric:     SSFSample_SET,
+		Name:       name,
+		Message:    value,
+		Tags:       tags,
+		SampleRate: 1.0,
+	}, opts)
+}
+
 // Timing returns an SSFSample (really a histogram) representing the
 // timing in the given resolution.
 func Timing(name string, value time.Duration, resolution time.Duration, tags map[string]string, opts ...SampleOption) *SSFSample {

--- a/worker.go
+++ b/worker.go
@@ -1,15 +1,15 @@
 package veneur
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
 )
 
 const counterTypeName = "counter"
@@ -20,16 +20,16 @@ const timerTypeName = "timer"
 
 // Worker is the doodad that does work.
 type Worker struct {
-	id         int
-	PacketChan chan samplers.UDPMetric
-	ImportChan chan []samplers.JSONMetric
-	QuitChan   chan struct{}
-	processed  int64
-	imported   int64
-	mutex      *sync.Mutex
-	stats      *statsd.Client
-	logger     *logrus.Logger
-	wm         WorkerMetrics
+	id          int
+	PacketChan  chan samplers.UDPMetric
+	ImportChan  chan []samplers.JSONMetric
+	QuitChan    chan struct{}
+	processed   int64
+	imported    int64
+	mutex       *sync.Mutex
+	traceClient *trace.Client
+	logger      *logrus.Logger
+	wm          WorkerMetrics
 }
 
 // IngestUDP on a Worker feeds the metric into the worker's PacketChan.
@@ -138,18 +138,18 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 }
 
 // NewWorker creates, and returns a new Worker object.
-func NewWorker(id int, stats *statsd.Client, logger *logrus.Logger) *Worker {
+func NewWorker(id int, cl *trace.Client, logger *logrus.Logger) *Worker {
 	return &Worker{
-		id:         id,
-		PacketChan: make(chan samplers.UDPMetric),
-		ImportChan: make(chan []samplers.JSONMetric),
-		QuitChan:   make(chan struct{}),
-		processed:  0,
-		imported:   0,
-		mutex:      &sync.Mutex{},
-		stats:      stats,
-		logger:     logger,
-		wm:         NewWorkerMetrics(),
+		id:          id,
+		PacketChan:  make(chan samplers.UDPMetric),
+		ImportChan:  make(chan []samplers.JSONMetric),
+		QuitChan:    make(chan struct{}),
+		processed:   0,
+		imported:    0,
+		mutex:       &sync.Mutex{},
+		traceClient: cl,
+		logger:      logger,
+		wm:          NewWorkerMetrics(),
 	}
 }
 
@@ -284,15 +284,11 @@ func (w *Worker) Flush() WorkerMetrics {
 	w.mutex.Unlock()
 
 	// Track how much time each worker takes to flush.
-	w.stats.TimeInMilliseconds(
-		"flush.worker_duration_ns",
-		float64(time.Since(start).Nanoseconds()),
-		nil,
-		1.0,
-	)
-
-	w.stats.Count("worker.metrics_processed_total", processed, []string{}, 1.0)
-	w.stats.Count("worker.metrics_imported_total", imported, []string{}, 1.0)
+	metrics.ReportBatch(w.traceClient, []*ssf.SSFSample{
+		ssf.Timing("flush.worker_duration_ns", time.Since(start), time.Millisecond, nil),
+		ssf.Count("worker.metrics_processed_total", float32(processed), nil),
+		ssf.Count("worker.metrics_imported_total", float32(imported), nil),
+	})
 
 	return ret
 }
@@ -311,16 +307,16 @@ type EventWorker struct {
 	mutex            *sync.Mutex
 	events           []samplers.UDPEvent
 	checks           []samplers.UDPServiceCheck
-	stats            *statsd.Client
+	traceClient      *trace.Client
 }
 
 // NewEventWorker creates an EventWorker ready to collect events and service checks.
-func NewEventWorker(stats *statsd.Client) *EventWorker {
+func NewEventWorker(cl *trace.Client) *EventWorker {
 	return &EventWorker{
 		EventChan:        make(chan samplers.UDPEvent),
 		ServiceCheckChan: make(chan samplers.UDPServiceCheck),
 		mutex:            &sync.Mutex{},
-		stats:            stats,
+		traceClient:      cl,
 	}
 }
 
@@ -354,23 +350,23 @@ func (ew *EventWorker) Flush() ([]samplers.UDPEvent, []samplers.UDPServiceCheck)
 	ew.checks = nil
 
 	ew.mutex.Unlock()
-	ew.stats.TimeInMilliseconds("flush.event_worker_duration_ns", float64(time.Since(start).Nanoseconds()), nil, 1.0)
+	metrics.ReportOne(ew.traceClient, ssf.Timing("flush.event_worker_duration_ns", time.Since(start), time.Nanosecond, nil))
 	return retevts, retsvchecks
 }
 
 // SpanWorker is similar to a Worker but it collects events and service checks instead of metrics.
 type SpanWorker struct {
-	SpanChan chan *ssf.SSFSpan
-	sinks    []sinks.SpanSink
-	stats    *statsd.Client
+	SpanChan    chan *ssf.SSFSpan
+	sinks       []sinks.SpanSink
+	traceClient *trace.Client
 }
 
 // NewSpanWorker creates an SpanWorker ready to collect events and service checks.
-func NewSpanWorker(sinks []sinks.SpanSink, stats *statsd.Client) *SpanWorker {
+func NewSpanWorker(sinks []sinks.SpanSink, cl *trace.Client) *SpanWorker {
 	return &SpanWorker{
-		SpanChan: make(chan *ssf.SSFSpan),
-		sinks:    sinks,
-		stats:    stats,
+		SpanChan:    make(chan *ssf.SSFSpan),
+		sinks:       sinks,
+		traceClient: cl,
 	}
 }
 
@@ -382,9 +378,11 @@ func (tw *SpanWorker) Work() {
 		for _, s := range tw.sinks {
 			err := s.Ingest(m)
 			if err != nil {
-				// If a sink goes wacko and errors a lot, we stand to emit a loooot of metrics
-				// here since span ingest rates can be very high. C'est la vie.
-				tw.stats.Count("worker.span.ingest_error_total", 1, []string{fmt.Sprintf("sink:%s", s.Name())}, 1.0)
+				// If a sink goes wacko and errors a lot, we stand to emit a
+				// loooot of metrics towards all span workers here since
+				// span ingest rates can be very high. C'est la vie.
+				metrics.ReportOne(tw.traceClient,
+					ssf.Count("worker.span.ingest_error_total", 1, map[string]string{"sink": s.Name()}))
 			}
 		}
 	}
@@ -397,6 +395,7 @@ func (tw *SpanWorker) Flush() {
 	for _, s := range tw.sinks {
 		sinkFlushStart := time.Now()
 		s.Flush()
-		tw.stats.TimeInMilliseconds("worker.span.flush_duration_ns", float64(time.Since(sinkFlushStart).Nanoseconds()), []string{fmt.Sprintf("sink:%s", s.Name())}, 1.0)
+		metrics.ReportOne(tw.traceClient,
+			ssf.Timing("worker.span.flush_duration_ns", time.Since(sinkFlushStart), time.Nanosecond, map[string]string{"sink": s.Name()}))
 	}
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR reworks veneur such that its metrics get reported not through statsd, spewing packets at its own UDP listening port, but sending them through its own `*trace.Client` (typically internal), by attaching them to an SSF span.

#### Motivation
I'd like us to cause as little network traffic as possible, reduce syscalls, gain more clarity around what gets reported how.


#### Test plan
I made sure the tests still work, but then most of them don't exercise the path where we actually send metrics through the trace backend.

To try it out, roll this to our QA and see:
- [x] do metrics still get reported in the first place? (They should be!)
- [x] how are dashboards affected on the hosts that this is running on?
- [x] how is CPU / memory usage affected by this, possibly syscall volume too?

#### Rollout/monitoring/revert plan

This will likely affect dashboards - if you roll this out, you will notice a severe drop in UDP packets.

There is an ordering requirement for rolling it out, too:

1. Roll out local veneur servers
2. Roll out global veneur servers
3. Roll out veneur proxies

Proxies must come last because they report SSF metrics to a local veneur server, and that server must know to expect them/report them correctly - so the versions must match up