### PR TITLE
Fix indicator span timer metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Improvements
-* Veneur now emits a timer metric for every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Veneur now emits a timer metric giving the duration (in nanoseconds) of every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * All sinks have been moved to their own packages for smaller code and better interfaces. Thanks [gphat](https://github.com/gphat)!
 * Removed noisy Sentry events that duplicated Datadog error reporting. Thanks, [aditya](https://github.com/chimeracoder)!
 * Veneur now reuses HTTP connections for forwarding and Datadog flushes. Furthermore each phase of the HTTP request is traced and can be seen using the trace sink of your choice. This should drastically improve performance and reliability for installs with large numbers of instances. Thanks [gphat](https://github.com/gphat)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * A [SignalFX sink](https://github.com/stripe/veneur/tree/master/sinks/signalfx) has been added for flushing metrics to [SignalFX](https://signalfx.com/). Thanks, [gphat](https://github.com/gphat)!
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
-* `veneur-emit` now takes `-span_service`, `-trace_id`, and `-parent_id` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
+* `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -61,9 +61,10 @@ var (
 	scMsg       = flag.String("sc_msg", "", "Message describing state of current state of service check.")
 
 	// Tracing flags
-	traceID  = flag.Int64("trace_id", 0, "ID for the trace (top-level) span. Setting a trace ID activated tracing.")
-	parentID = flag.Int64("parent_span_id", 0, "ID of the parent span.")
-	service  = flag.String("span_service", "veneur-emit", "Service name to associate with the span.")
+	traceID   = flag.Int64("trace_id", 0, "ID for the trace (top-level) span. Setting a trace ID activated tracing.")
+	parentID  = flag.Int64("parent_span_id", 0, "ID of the parent span.")
+	service   = flag.String("span_service", "veneur-emit", "Service name to associate with the span.")
+	indicator = flag.Bool("indicator", false, "Mark the reported span as an indicator span")
 )
 
 // MinimalClient represents the functions that we call on Clients in veneur-emit.
@@ -236,6 +237,7 @@ func setupSpan(traceID, parentID *int64, name, tags string) (*ssf.SSFSpan, error
 		span.Name = name
 		span.Tags = ssfTags(tags)
 		span.Service = *service
+		span.Indicator = *indicator
 	}
 	return span, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -186,7 +186,7 @@ func TestParseSSFIndicatorSpan(t *testing.T) {
 		m := metrics[0]
 		assert.Equal(t, "timer_name", m.Name)
 		assert.Equal(t, "histogram", m.Type)
-		assert.InEpsilon(t, float32(duration*time.Millisecond), m.Value, 0.001)
+		assert.InEpsilon(t, float32(duration/time.Nanosecond), m.Value, 0.001)
 		if assert.Equal(t, 3, len(m.Tags)) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)
@@ -229,7 +229,8 @@ func TestParseSSFIndicatorSpanWithError(t *testing.T) {
 		m := metrics[0]
 		assert.Equal(t, "timer_name", m.Name)
 		assert.Equal(t, "histogram", m.Type)
-		assert.InEpsilon(t, float32(duration*time.Millisecond), m.Value, 0.001)
+		assert.InEpsilon(t, float32(duration/time.Nanosecond), m.Value, 0.001,
+			"Duration seems incorrect: %f vs. %d", m.Value, duration/time.Nanosecond)
 		if assert.Equal(t, 3, len(m.Tags)) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -95,12 +95,7 @@ func ConvertIndicatorMetrics(span *ssf.SSFSpan, timerName string) (metrics []UDP
 	if span.Error {
 		tags["error"] = "true"
 	}
-	ssfTimer := &ssf.SSFSample{
-		Metric: ssf.SSFSample_HISTOGRAM,
-		Name:   timerName,
-		Value:  float32(end.Sub(start) * time.Millisecond),
-		Tags:   tags,
-	}
+	ssfTimer := ssf.Timing(timerName, end.Sub(start), time.Nanosecond, tags)
 	timer, err := ParseMetricSSF(ssfTimer)
 	if err != nil {
 		return metrics, err

--- a/server.go
+++ b/server.go
@@ -114,8 +114,6 @@ type Server struct {
 	spanSinks   []sinks.SpanSink
 	metricSinks []sinks.MetricSink
 
-	indicatorSpanTimerName string
-
 	TraceClient  *trace.Client
 	traceBackend *internalTraceBackend
 }
@@ -238,7 +236,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 	for i, w := range ret.Workers {
 		processors[i] = w
 	}
-	metricSink, err := metrics.NewMetricExtractionSink(processors, ret.indicatorSpanTimerName, log)
+	metricSink, err := metrics.NewMetricExtractionSink(processors, conf.IndicatorSpanTimerName, log)
 	if err != nil {
 		return ret, err
 	}
@@ -417,8 +415,6 @@ func NewFromConfig(conf Config) (*Server, error) {
 		ret.registerPlugin(localFilePlugin)
 		log.Info(fmt.Sprintf("Local file logging to %s", conf.FlushFile))
 	}
-
-	ret.indicatorSpanTimerName = conf.IndicatorSpanTimerName
 
 	// closed in Shutdown; Same approach and http.Shutdown
 	ret.shutdown = make(chan struct{})


### PR DESCRIPTION
#### Summary
This PR fixes the bugs exposed by testing the indicator span timer metric in our real-life systems:

* The metrics reporter sink now actually starts with the correct timer name (it was set too late)
* It now uses the ssf metrics creation helpers, also setting a sample rate (it was 0 before, which breaks in all kinds of hilarious ways).
* It reports the metric in nanoseconds, which should give better granularity and clarity.

Also, we now allow passing the `-indicator` flag to veneur-emit, which makes testing this easier.

#### Motivation
The bugs above ):

#### Test plan

Updating tests, but mostly running this in prod&praying because the tests don't exercise the whole system, boo.


#### Rollout/monitoring/revert plan

1. Merge
2. Update our QA config files to call the metric `_ns`, as it's no longer milliseconds (:
