### PR TITLE
Use span_name for tag instead of name

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -191,8 +191,8 @@ func TestParseSSFIndicatorSpan(t *testing.T) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)
 			assert.Equal(t, "error:false", tags[0])
-			assert.Equal(t, fmt.Sprintf("name:%s", span.Name), tags[1])
-			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[2])
+			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[1])
+			assert.Equal(t, fmt.Sprintf("span_name:%s", span.Name), tags[2])
 		}
 	}
 }
@@ -235,8 +235,8 @@ func TestParseSSFIndicatorSpanWithError(t *testing.T) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)
 			assert.Equal(t, "error:true", tags[0])
-			assert.Equal(t, fmt.Sprintf("name:%s", span.Name), tags[1])
-			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[2])
+			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[1])
+			assert.Equal(t, fmt.Sprintf("span_name:%s", span.Name), tags[2])
 		}
 	}
 }

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -88,9 +88,9 @@ func ConvertIndicatorMetrics(span *ssf.SSFSpan, timerName string) (metrics []UDP
 	end := time.Unix(span.EndTimestamp/1e9, span.EndTimestamp%1e9)
 	start := time.Unix(span.StartTimestamp/1e9, span.StartTimestamp%1e9)
 	tags := map[string]string{
-		"name":    span.Name,
-		"service": span.Service,
-		"error":   "false",
+		"span_name": span.Name,
+		"service":   span.Service,
+		"error":     "false",
 	}
 	if span.Error {
 		tags["error"] = "true"

--- a/sinks/metrics/metrics_test.go
+++ b/sinks/metrics/metrics_test.go
@@ -75,7 +75,7 @@ func TestIndicatorMetricExtractor(t *testing.T) {
 		for m := range worker.PacketChan {
 			hasP := false
 			for _, tag := range m.Tags {
-				hasP = (tag == "service:indicator_testing")
+				hasP = hasP || (tag == "service:indicator_testing")
 			}
 			if !hasP {
 				t.Logf("Received unexpected additional metric %#v", m)


### PR DESCRIPTION
#### Summary

Following up from https://github.com/stripe/veneur/pull/340. Let's use `span_name` instead of `name`, since the latter is more common and is already overloaded.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @cory-stripe 
cc @stripe/observability 