### PR TITLE
Routing to metric sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 * `veneur-emit -command` now streams output from the invoked program's stdout/stderr to its own stdout/stderr. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Veneur now supports the tag `veneursinkonly:<sink_name>` on metrics, which routes the metric to only the sink specified. See [the docs](README.md#routing-metrics) here. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Improvements
 * Veneur now emits a timer metric giving the duration (in nanoseconds) of every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ Relatedly, if you want to forward a counter or gauge to the global Veneur instan
 
 Veneur also honors the same "magic" tags that the dogstatsd daemon includes in the datadog agent. The tag `host` will override `Hostname` in the metric and `device` will override `DeviceName`.
 
+#### Routing metrics
+
+Veneur supports specifying that metrics should only be routed to a specific metric sink, with the `veneursinkonly:<sink_name>` tag. The `<sink_name>` value can be any configured metric sink. Currently, that's `datadog`, `kafka`, `signalfx`. It's possible to specify multiple sink destination tags on a metric, which will cause the metric to be routed to each sink specified.
+
 # Configuration
 
 Veneur expects to have a config file supplied via `-f PATH`. The included `example.yaml` outlines the options:

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -135,6 +135,7 @@ func (c *Counter) Flush(interval time.Duration) []InterMetric {
 		Value:     float64(c.value),
 		Tags:      tags,
 		Type:      CounterMetric,
+		Sinks:     routeInfo(tags),
 	}}
 }
 
@@ -200,6 +201,7 @@ func (g *Gauge) Flush() []InterMetric {
 		Value:     float64(g.value),
 		Tags:      tags,
 		Type:      GaugeMetric,
+		Sinks:     routeInfo(tags),
 	}}
 }
 
@@ -278,6 +280,7 @@ func (s *Set) Flush() []InterMetric {
 		Value:     float64(s.Hll.Estimate()),
 		Tags:      tags,
 		Type:      GaugeMetric,
+		Sinks:     routeInfo(tags),
 	}}
 }
 
@@ -362,6 +365,7 @@ func NewHist(Name string, Tags []string) *Histo {
 func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates HistogramAggregates) []InterMetric {
 	now := time.Now().Unix()
 	metrics := make([]InterMetric, 0, aggregates.Count+len(percentiles))
+	sinks := routeInfo(h.Tags)
 
 	if (aggregates.Value&AggregateMax) == AggregateMax && !math.IsInf(h.LocalMax, 0) {
 		// Defensively recopy tags to avoid aliasing bugs in case multiple InterMetrics share the same
@@ -374,6 +378,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalMax),
 			Tags:      tags,
 			Type:      GaugeMetric,
+			Sinks:     sinks,
 		})
 	}
 	if (aggregates.Value&AggregateMin) == AggregateMin && !math.IsInf(h.LocalMin, 0) {
@@ -385,6 +390,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalMin),
 			Tags:      tags,
 			Type:      GaugeMetric,
+			Sinks:     sinks,
 		})
 	}
 
@@ -397,6 +403,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalSum),
 			Tags:      tags,
 			Type:      GaugeMetric,
+			Sinks:     sinks,
 		})
 	}
 
@@ -411,6 +418,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalSum / h.LocalWeight),
 			Tags:      tags,
 			Type:      GaugeMetric,
+			Sinks:     sinks,
 		})
 	}
 
@@ -426,6 +434,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalWeight),
 			Tags:      tags,
 			Type:      CounterMetric,
+			Sinks:     sinks,
 		})
 	}
 
@@ -440,6 +449,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 				Value:     float64(h.Value.Quantile(0.5)),
 				Tags:      tags,
 				Type:      GaugeMetric,
+				Sinks:     sinks,
 			},
 		)
 	}
@@ -455,6 +465,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			Value:     float64(h.LocalWeight / h.LocalReciprocalSum),
 			Tags:      tags,
 			Type:      GaugeMetric,
+			Sinks:     sinks,
 		})
 	}
 
@@ -470,6 +481,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 				Value:     float64(h.Value.Quantile(p)),
 				Tags:      tags,
 				Type:      GaugeMetric,
+				Sinks:     sinks,
 			},
 		)
 	}

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -23,9 +23,10 @@ const (
 	GaugeMetric
 )
 
-// RouteInformation maps sink names to whether they're supposed to
-// receive a metric. A nil value corresponds to the "every sink"
-// value.
+// RouteInformation is a key-only map indicating sink names that are
+// supposed to receive a metric. A nil RouteInformation value
+// corresponds to the "every sink" value; an entry in a non-nil
+// RouteInformation means that the key should receive the metric.
 type RouteInformation map[string]struct{}
 
 // RouteTo returns true if the named sink should receive a metric
@@ -112,6 +113,9 @@ func routeInfo(tags []string) RouteInformation {
 		if info == nil {
 			info = make(RouteInformation)
 		}
+		// Take the tag suffix (the part after the ':' in
+		// "veneursinkonly:", and make that the key in our
+		// route information map:
 		info[tag[len(sinkPrefix):]] = struct{}{}
 	}
 	return info

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -47,7 +47,11 @@ type InterMetric struct {
 	Value     float64
 	Tags      []string
 	Type      MetricType
-	Sinks     RouteInformation
+
+	// Sinks, if non-nil, indicates which metric sinks a metric
+	// should be inserted into. If nil, that means the metric is
+	// meant to go to every sink.
+	Sinks RouteInformation
 }
 
 type Aggregate int

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -17,7 +17,7 @@ func TestRouting(t *testing.T) {
 		sinks     RouteInformation
 		sinkNames []string
 	}{
-		{"no sinks", []string{"foo:bar", "veneurlocalonly"}, nil, []string{}},
+		{"none specified", []string{"foo:bar", "veneurlocalonly"}, nil, []string{"foosink", "barsink"}},
 		{"one sink", []string{"veneursinkonly:foobar"}, map[string]struct{}{"foobar": struct{}{}}, []string{"foobar"}},
 		{
 			"multiple sinks",
@@ -34,6 +34,9 @@ func TestRouting(t *testing.T) {
 			assert.Equal(t, test.sinks, info)
 			for _, sink := range test.sinkNames {
 				assert.True(t, info.RouteTo(sink), "Should route to %q", sink)
+			}
+			if test.sinks != nil {
+				assert.False(t, info.RouteTo("never_to_this_sink"))
 			}
 		})
 	}

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRouting(t *testing.T) {
+	tests := []struct {
+		name      string
+		tags      []string
+		sinks     RouteInformation
+		sinkNames []string
+	}{
+		{"no sinks", []string{"foo:bar", "veneurlocalonly"}, nil, []string{}},
+		{"one sink", []string{"veneursinkonly:foobar"}, map[string]struct{}{"foobar": struct{}{}}, []string{"foobar"}},
+		{
+			"multiple sinks",
+			[]string{"veneursinkonly:foobar", "veneursinkonly:baz"},
+			map[string]struct{}{"foobar": struct{}{}, "baz": struct{}{}},
+			[]string{"foobar", "baz"},
+		},
+	}
+	for _, elt := range tests {
+		test := elt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			info := routeInfo(test.tags)
+			assert.Equal(t, test.sinks, info)
+			for _, sink := range test.sinkNames {
+				assert.True(t, info.RouteTo(sink), "Should route to %q", sink)
+			}
+		})
+	}
+}
+
 func TestCounterEmpty(t *testing.T) {
 	c := NewCounter("a.b.c", []string{"a:b"})
 	c.Sample(1, 1.0)

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -4,7 +4,6 @@ import (
 	"compress/zlib"
 	"context"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,11 +128,9 @@ type DatadogRoundTripper struct {
 
 func (rt *DatadogRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rec := httptest.NewRecorder()
-	log.Printf("Got a request to %v", req.URL)
 	if strings.HasPrefix(req.URL.Path, rt.Endpoint) {
 		body, _ := ioutil.ReadAll(req.Body)
 		defer req.Body.Close()
-		log.Printf("body: %v", string(body))
 		if strings.Contains(string(body), rt.Contains) {
 			rt.ThingReceived = true
 		}

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -177,6 +177,9 @@ func (k *KafkaMetricSink) Flush(ctx context.Context, interMetrics []samplers.Int
 
 	successes := int64(0)
 	for _, metric := range interMetrics {
+		if !sinks.IsAcceptableMetric(metric, k) {
+			continue
+		}
 
 		k.logger.Debug("Emitting Metric: ", metric.Name)
 		j, err := json.Marshal(metric)

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -13,6 +13,7 @@ import (
 	"github.com/signalfx/golib/sfxclient"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/trace"
 )
 
@@ -61,6 +62,9 @@ func (sfx *SignalFXSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 	flushStart := time.Now()
 	points := []*datapoint.Datapoint{}
 	for _, metric := range interMetrics {
+		if !sinks.IsAcceptableMetric(metric, sfx) {
+			continue
+		}
 		dims := map[string]string{}
 		for _, tag := range metric.Tags {
 			kv := strings.SplitN(tag, ":", 2)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds a special tag to metrics, `veneursinkonly:name`, which allows submitters to specify (multiple times) what metric sinks a metric should go into. If they leave that tag off, the metric goes to every sink veneur knows about.

Some things that we might still do:

- [x] write a changelog entry (:


#### Motivation
We wanted some finer control over where metrics go, when teeing!


#### Test plan
I wrote tests! But this will *definitely* have to live on our systems for a little while. 


#### Rollout/monitoring/revert plan

merge!
