### PR TITLE
SignalFx: Fix endpoint names, test 'em

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,6 +29,8 @@ func NewSignalFXSink(apiKey string, hostname string, stats *statsd.Client, log *
 	if client == nil {
 		httpSink := sfxclient.NewHTTPSink()
 		httpSink.AuthToken = apiKey
+		httpSink.DatapointEndpoint = fmt.Sprintf("%s/v2/datapoint", hostname)
+		httpSink.EventEndpoint = fmt.Sprintf("%s/v2/event", hostname)
 		client = httpSink
 	}
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/event"
+	"github.com/signalfx/golib/sfxclient"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/samplers"
@@ -45,6 +46,13 @@ func TestNewSignalFxSink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	httpsink, ok := sink.client.(*sfxclient.HTTPSink)
+	if !ok {
+		assert.Fail(t, "SignalFX sink isn't the correct type")
+	}
+	assert.Equal(t, "http://www.example.com/v2/datapoint", httpsink.DatapointEndpoint)
+	assert.Equal(t, "http://www.example.com/v2/event", httpsink.EventEndpoint)
 
 	assert.Equal(t, "http://www.example.com", sink.hostname)
 	assert.Equal(t, "signalfx", sink.Name())


### PR DESCRIPTION
#### Summary
Add hostname configuration for SignalFx sink and test it.

#### Motivation
Oops, I left this out.

#### Test plan
Tests included!

r? @krisreeves-stripe 