### PR TITLE
make veneur-emit stream output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
+* `veneur-emit -command` now streams output from the invoked program's stdout/stderr to its own stdout/stderr. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Improvements
 * Veneur now emits a timer metric giving the duration (in nanoseconds) of every "indicator" span that it receives, if you configure the setting `indicator_span_timer_name`. Thanks, [antifuchs](https://github.com/antifuchs)!


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR makes veneur-emit stream output from subprocesses it runs when you pass `-command`. This was an oversight when we wrote this feature: `Command.Run()` swallows stderr/stdout, but people using veneur-emit want to actually see what their commands write.

#### Motivation
User feedback! Turns out that it's useful to know what long-running processes are doing! (:


#### Test plan
Tried it out on the commandline:  With this shell script:

``` sh 
#!/bin/bash

for i in `seq 1 4` ; do
    echo $i
    sleep 1
done
```

`go run cmd/veneur-emit/main.go -ssf -hostport udp://127.0.0.1:4000 -indicator -name foobar -trace_id 1 -span_service veneur_testing -debug -command ./tryout.sh` writes 1, 2, 3, 4 to stdout before exiting - current `master` branch remains silent.

#### Rollout/monitoring/revert plan
Just merge!
