### PR TITLE
veneur-emit: keep trace&parent span ID on the environment for spawned processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
 * `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_span_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
+* Additionally, `veneur-emit` infers parent and trace IDs from the environment (environment variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees. Thanks, [antifuchs](https://github.com/antifuchs)
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 * `veneur-emit -command` now streams output from the invoked program's stdout/stderr to its own stdout/stderr. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ** `ssf_address` - replaced in 1.7.0 by `ssf_listen_addresses`
 ** `tcp_address` and `udp_address` - replaced in 1.7.0 by `statsd_listen_addresses`
 
+## Added
+* `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
+
 # 2.0.0, 2018-01-09
 
 ## Incompatible changes
@@ -20,7 +23,6 @@
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
 * `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_span_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
-* Additionally, `veneur-emit` infers parent and trace IDs from the environment (environment variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees. Thanks, [antifuchs](https://github.com/antifuchs)
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 * `veneur-emit -command` now streams output from the invoked program's stdout/stderr to its own stdout/stderr. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * A [Kafka sink](https://github.com/stripe/veneur/tree/master/sinks/kafka) has been added for publishing spans or metrics. Thanks, [parabuzzle](https://github.com/parabuzzle) and [gphat](https://github.com/gphat)!
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!
-* `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
+* `veneur-emit` now takes `-span_service`, `-trace_id`, `-parent_span_id`, and `-indicator` arguments. These (combined with `-ssf`) allow submitting spans for tracing when recording timing data for commands. In addition, `-timing` with `-ssf` now works, too.
 * The `github.com/stripe/veneur/ssf` package now has a few helper functions to create samples that can be attached to spans: `Count`, `Gauge`, `Histogram`, `Timing`. In addition, veneur now has a span sink that extracts these samples and treats them as metrics. Thanks, [antifuchs](https://github.com/antifuchs)
 * Spans sent to Lightstep now have an `indicator` tag set, indicating whether the span is an indicator span or not. Thanks, [aditya](https://github.com/chimeracoder)!
 * `veneur-emit -command` now streams output from the invoked program's stdout/stderr to its own stdout/stderr. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -69,6 +69,11 @@ var (
 	indicator = flag.Bool("indicator", false, "Mark the reported span as an indicator span")
 )
 
+const (
+	envTraceID = "VENEUR_EMIT_TRACE_ID"
+	envSpanID  = "VENEUR_EMIT_PARENT_SPAN_ID"
+)
+
 // MinimalClient represents the functions that we call on Clients in veneur-emit.
 type MinimalClient interface {
 	Gauge(name string, value float64, tags []string, rate float64) error
@@ -258,10 +263,17 @@ func streamOutput(wg *sync.WaitGroup, in io.Reader, out io.Writer) {
 	}()
 }
 
-func timeCommand(command []string) (exitStatus int, start time.Time, ended time.Time, err error) {
+func timeCommand(span *ssf.SSFSpan, command []string) (exitStatus int, start time.Time, ended time.Time, err error) {
 	logrus.Debugf("Timing %q...", command)
 	cmd := exec.Command(command[0], command[1:]...)
-	start = time.Now()
+
+	// pass span IDs through on the environment so veneur-emits
+	// further down the line can pick them up and construct a tree:
+	cmd.Env = os.Environ()
+	if span.TraceId != 0 {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", envTraceID, span.TraceId))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", envSpanID, span.Id))
+	}
 	var wg sync.WaitGroup
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -271,6 +283,7 @@ func timeCommand(command []string) (exitStatus int, start time.Time, ended time.
 	if err != nil {
 		logrus.WithError(err).Warn("Could not get stderr pipe from command")
 	}
+	start = time.Now()
 	err = cmd.Start()
 	if err != nil {
 		logrus.WithError(err).WithField("command", command).Error("Could not start command")
@@ -311,7 +324,7 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 		if *command {
 			var start, ended time.Time
 
-			status, start, ended, err = timeCommand(flag.Args())
+			status, start, ended, err = timeCommand(span, flag.Args())
 			if err != nil {
 				return status, err
 			}

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -229,15 +229,15 @@ func TestInferID(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			env := newEnvID()
 			if test.env != "" {
-				os.Setenv(env, test.env)
+				require.NoError(t, os.Setenv(env, test.env))
 			}
-			err := inferTraceIDInt(&test.parameter, env)
+			id, err := inferTraceIDInt(test.parameter, env)
 			if test.error {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, test.expected, test.parameter)
+			assert.Equal(t, test.expected, id)
 		})
 	}
 }

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 func TestTimeCommand(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		command := []string{"true"}
-		st, start, ended, err := timeCommand(command)
+		st, start, ended, err := timeCommand(&ssf.SSFSpan{}, command)
 
 		assert.NoError(t, err, "timeCommand had an error")
 		assert.NotZero(t, start)
@@ -67,7 +67,7 @@ func TestTimeCommand(t *testing.T) {
 
 	t.Run("badCall", func(t *testing.T) {
 		command := []string{"false"}
-		st, _, _, err := timeCommand(command)
+		st, _, _, err := timeCommand(&ssf.SSFSpan{}, command)
 		assert.Error(t, err, "timeCommand did not throw error.")
 		assert.NotZero(t, st)
 	})


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR changes veneur-emit to (when tracing) place a spawned process's trace and span ID on the environment, so that it's easier to build trace trees.


#### Motivation
Ergonomics! Users told us that some of their program invocations traced with veneur-emit need to invoke other programs.


#### Test plan
Wrote a unit test for the env var inference, and tried it out on the command line


#### Rollout/monitoring/revert plan
This would be great to merge before 2.0!
