### PR TITLE
Fix common tags in SignalFx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * The semantics around `veneur-emit` command timing have changed: `-shellCommand` argument has been renamed to `-command`, and `-command` is now gone. The only way to time a command is to provide the command and its arguments as separate arguments, the method of passing in a shell-escaped string is no longer supported.
 
 ## Added
-* A [SignalFX sink](https://github.com/stripe/veneur/tree/master/sinks/signalfx) has been added for flushing metrics to [SignalFX](https://signalfx.com/). Thanks, [gphat](https://github.com/gphat)!
+* A [SignalFx sink](https://github.com/stripe/veneur/tree/master/sinks/signalfx) has been added for flushing metrics to [SignalFx](https://signalfx.com/). Thanks, [gphat](https://github.com/gphat)!
 * A [Kafka sink](https://github.com/stripe/veneur/tree/master/sinks/kafka) has been added for publishing spans or metrics. Thanks, [parabuzzle](https://github.com/parabuzzle) and [gphat](https://github.com/gphat)!
 * Buffered trace clients in `github.com/stripe/veneur/trace` now have a new option to automatically flush them in a periodic interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Gauges can now be marked as `veneurglobalonly` to be globally "last write wins". Thanks [gphat](https://github.com/gphat)!

--- a/config.go
+++ b/config.go
@@ -44,7 +44,8 @@ type Config struct {
 	ReadBufferSizeBytes           int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn                     string    `yaml:"sentry_dsn"`
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
-	SignalfxHostname              string    `yaml:"signalfx_hostname"`
+	SignalfxEndpoint              string    `yaml:"signalfx_endpoint"`
+	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
 	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string  `yaml:"ssf_listen_addresses"`

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	ReadBufferSizeBytes           int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn                     string    `yaml:"sentry_dsn"`
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
-	SignalfxEndpoint              string    `yaml:"signalfx_endpoint"`
+	SignalfxEndpointBase          string    `yaml:"signalfx_endpoint_base"`
 	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
 	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`

--- a/example.yaml
+++ b/example.yaml
@@ -164,8 +164,8 @@ datadog_api_key: "farts"
 # Hostname to send Datadog trace data to.
 datadog_trace_api_address: "http://localhost:7777"
 
-# == SignalFX ==
-# SignalFX can be a sink for metrics.
+# == SignalFx ==
+# SignalFx can be a sink for metrics.
 signalfx_api_key: "abc123"
 
 # Where to send metrics

--- a/example.yaml
+++ b/example.yaml
@@ -169,7 +169,10 @@ datadog_trace_api_address: "http://localhost:7777"
 signalfx_api_key: "abc123"
 
 # Where to send metrics
-signalfx_hostname: "https://ingest.signalfx.com"
+signalfx_endpoint: "https://ingest.signalfx.com"
+
+# The tag we'll add to each metric that contains the hostname we came from
+signalfx_hostname_tag: "host"
 
 # == LightStep ==
 # LightStep can be a sink for trace spans.

--- a/example.yaml
+++ b/example.yaml
@@ -169,7 +169,7 @@ datadog_trace_api_address: "http://localhost:7777"
 signalfx_api_key: "abc123"
 
 # Where to send metrics
-signalfx_endpoint: "https://ingest.signalfx.com"
+signalfx_endpoint_base: "https://ingest.signalfx.com"
 
 # The tag we'll add to each metric that contains the hostname we came from
 signalfx_hostname_tag: "host"

--- a/server.go
+++ b/server.go
@@ -301,7 +301,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 	}
 
 	if conf.SignalfxAPIKey != "" {
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxAPIKey, conf.SignalfxEndpoint, conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, ret.Statsd, log, nil)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxAPIKey, conf.SignalfxEndpointBase, conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, ret.Statsd, log, nil)
 		if err != nil {
 			return ret, err
 		}

--- a/server.go
+++ b/server.go
@@ -301,7 +301,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 	}
 
 	if conf.SignalfxAPIKey != "" {
-		sfxSink, err := signalfx.NewSignalFXSink(conf.SignalfxAPIKey, conf.SignalfxHostname, ret.Statsd, log, nil)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxAPIKey, conf.SignalfxHostname, ret.Statsd, log, nil)
 		if err != nil {
 			return ret, err
 		}

--- a/server.go
+++ b/server.go
@@ -301,7 +301,7 @@ func NewFromConfig(conf Config) (*Server, error) {
 	}
 
 	if conf.SignalfxAPIKey != "" {
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxAPIKey, conf.SignalfxHostname, ret.Statsd, log, nil)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxAPIKey, conf.SignalfxEndpoint, conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, ret.Statsd, log, nil)
 		if err != nil {
 			return ret, err
 		}

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -72,6 +72,8 @@ func (sfx *SignalFxSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 			continue
 		}
 		dims := map[string]string{}
+		// Set the hostname as a tag, since SFx doesn't have a first-class hostname field
+		dims[sfx.hostnameTag] = sfx.hostname
 		for _, tag := range metric.Tags {
 			kv := strings.SplitN(tag, ":", 2)
 			if len(kv) == 1 {
@@ -114,6 +116,8 @@ func (sfx *SignalFxSink) FlushEventsChecks(ctx context.Context, events []sampler
 		// getting []string. We should fix this, as it feels less icky for sinks to
 		// get `map[string]string`.
 		dims := map[string]string{}
+		// Set the hostname as a tag, since SFx doesn't have a first-class hostname field
+		dims[sfx.hostnameTag] = sfx.hostname
 		for _, tag := range udpEvent.Tags {
 			parts := strings.SplitN(tag, ":", 2)
 			if len(parts) == 1 {

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
-type SignalFXSink struct {
+type SignalFxSink struct {
 	client           dpsink.Sink
 	endpoint         string
 	hostnameTag      string
@@ -28,8 +28,8 @@ type SignalFXSink struct {
 	traceClient      *trace.Client
 }
 
-// NewSignalFXSink creates a new SignalFX sink for metrics.
-func NewSignalFXSink(apiKey string, endpoint string, hostnameTag string, hostname string, commonDimensions map[string]string, stats *statsd.Client, log *logrus.Logger, client dpsink.Sink) (*SignalFXSink, error) {
+// NewSignalFxSink creates a new SignalFx sink for metrics.
+func NewSignalFxSink(apiKey string, endpoint string, hostnameTag string, hostname string, commonDimensions map[string]string, stats *statsd.Client, log *logrus.Logger, client dpsink.Sink) (*SignalFxSink, error) {
 	if client == nil {
 		httpSink := sfxclient.NewHTTPSink()
 		httpSink.AuthToken = apiKey
@@ -38,7 +38,7 @@ func NewSignalFXSink(apiKey string, endpoint string, hostnameTag string, hostnam
 		client = httpSink
 	}
 
-	return &SignalFXSink{
+	return &SignalFxSink{
 		client:           client,
 		endpoint:         endpoint,
 		hostnameTag:      hostnameTag,
@@ -50,18 +50,18 @@ func NewSignalFXSink(apiKey string, endpoint string, hostnameTag string, hostnam
 }
 
 // Name returns the name of this sink.
-func (sfx *SignalFXSink) Name() string {
+func (sfx *SignalFxSink) Name() string {
 	return "signalfx"
 }
 
 // Start begins the sink. For SignalFx this is a noop.
-func (sfx *SignalFXSink) Start(traceClient *trace.Client) error {
+func (sfx *SignalFxSink) Start(traceClient *trace.Client) error {
 	sfx.traceClient = traceClient
 	return nil
 }
 
 // Flush sends metrics to SignalFx
-func (sfx *SignalFXSink) Flush(ctx context.Context, interMetrics []samplers.InterMetric) error {
+func (sfx *SignalFxSink) Flush(ctx context.Context, interMetrics []samplers.InterMetric) error {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.ClientFinish(sfx.traceClient)
 
@@ -98,13 +98,13 @@ func (sfx *SignalFXSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 	}
 	sfx.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"plugin:signalfx"}, 1.0)
 	// TODO Fix these metrics to be per-metric sink
-	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFX")
+	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFx")
 
 	return err
 }
 
 // FlushEventsChecks sends events to SignalFx. It does not support checks. It is also currently disabled.
-func (sfx *SignalFXSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+func (sfx *SignalFxSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.ClientFinish(sfx.traceClient)
 

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -19,25 +19,25 @@ import (
 
 type SignalFXSink struct {
 	client      dpsink.Sink
-	hostname    string
+	endpoint    string
 	statsd      *statsd.Client
 	log         *logrus.Logger
 	traceClient *trace.Client
 }
 
 // NewSignalFXSink creates a new SignalFX sink for metrics.
-func NewSignalFXSink(apiKey string, hostname string, stats *statsd.Client, log *logrus.Logger, client dpsink.Sink) (*SignalFXSink, error) {
+func NewSignalFXSink(apiKey string, endpoint string, stats *statsd.Client, log *logrus.Logger, client dpsink.Sink) (*SignalFXSink, error) {
 	if client == nil {
 		httpSink := sfxclient.NewHTTPSink()
 		httpSink.AuthToken = apiKey
-		httpSink.DatapointEndpoint = fmt.Sprintf("%s/v2/datapoint", hostname)
-		httpSink.EventEndpoint = fmt.Sprintf("%s/v2/event", hostname)
+		httpSink.DatapointEndpoint = fmt.Sprintf("%s/v2/datapoint", endpoint)
+		httpSink.EventEndpoint = fmt.Sprintf("%s/v2/event", endpoint)
 		client = httpSink
 	}
 
 	return &SignalFXSink{
 		client:   client,
-		hostname: hostname,
+		endpoint: endpoint,
 		statsd:   stats,
 		log:      log,
 	}, nil

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -55,7 +55,7 @@ func TestNewSignalFxSink(t *testing.T) {
 	assert.Equal(t, "http://www.example.com/v2/datapoint", httpsink.DatapointEndpoint)
 	assert.Equal(t, "http://www.example.com/v2/event", httpsink.EventEndpoint)
 
-	assert.Equal(t, "http://www.example.com", sink.hostname)
+	assert.Equal(t, "http://www.example.com", sink.endpoint)
 	assert.Equal(t, "signalfx", sink.Name())
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -39,7 +39,7 @@ func (fs *FakeSink) AddEvents(ctx context.Context, events []*event.Event) (err e
 func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := NewSignalFXSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), nil)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestNewSignalFxSink(t *testing.T) {
 
 	httpsink, ok := sink.client.(*sfxclient.HTTPSink)
 	if !ok {
-		assert.Fail(t, "SignalFX sink isn't the correct type")
+		assert.Fail(t, "SignalFx sink isn't the correct type")
 	}
 	assert.Equal(t, "http://www.example.com/v2/datapoint", httpsink.DatapointEndpoint)
 	assert.Equal(t, "http://www.example.com/v2/event", httpsink.EventEndpoint)
@@ -65,7 +65,7 @@ func TestNewSignalFxSink(t *testing.T) {
 func TestSignalFxFlushRouting(t *testing.T) {
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFXSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestSignalFxFlushRouting(t *testing.T) {
 func TestSignalFxFlushGauge(t *testing.T) {
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFXSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestSignalFxFlushGauge(t *testing.T) {
 func TestSignalFxFlushCounter(t *testing.T) {
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFXSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestSignalFxFlushCounter(t *testing.T) {
 func TestSignalFxEventFlush(t *testing.T) {
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFXSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
+	sink, err := NewSignalFxSink("secret", "http://www.example.com", "host", "glooblestoots", map[string]string{"yay": "pie"}, stats, logrus.New(), fakeSink)
 
 	assert.NoError(t, err)
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -141,10 +141,11 @@ func TestSignalFxFlushGauge(t *testing.T) {
 	assert.Equal(t, "a.b.c", point.Metric, "Metric has wrong name")
 	assert.Equal(t, datapoint.Gauge, point.MetricType, "Metric has wrong type")
 	dims := point.Dimensions
-	assert.Equal(t, 3, len(dims), "Metric has incorrect tag count")
+	assert.Equal(t, 4, len(dims), "Metric has incorrect tag count")
 	assert.Equal(t, "bar", dims["foo"], "Metric has a busted tag")
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing common tag")
+	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
 }
 
 func TestSignalFxFlushCounter(t *testing.T) {
@@ -173,11 +174,12 @@ func TestSignalFxFlushCounter(t *testing.T) {
 	assert.Equal(t, "a.b.c", point.Metric, "Metric has wrong name")
 	assert.Equal(t, datapoint.Count, point.MetricType, "Metric has wrong type")
 	dims := point.Dimensions
-	assert.Equal(t, 4, len(dims), "Metric has incorrect tag count")
+	assert.Equal(t, 5, len(dims), "Metric has incorrect tag count")
 	assert.Equal(t, "bar", dims["foo"], "Metric has a busted tag")
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "", dims["novalue"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing a common tag")
+	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
 }
 
 func TestSignalFxEventFlush(t *testing.T) {
@@ -198,9 +200,10 @@ func TestSignalFxEventFlush(t *testing.T) {
 	event := fakeSink.events[0]
 	assert.Equal(t, ev.Title, event.EventType)
 	dims := event.Dimensions
-	assert.Equal(t, 4, len(dims), "Event has incorrect tag count")
+	assert.Equal(t, 5, len(dims), "Event has incorrect tag count")
 	assert.Equal(t, "bar", dims["foo"], "Event has a busted tag")
 	assert.Equal(t, "gorch", dims["baz"], "Event has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Event missing a common tag")
 	assert.Equal(t, "", dims["novalue"], "Event has a busted tag")
+	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
 }


### PR DESCRIPTION
#### Summary
Adds "common" tags and a configurable hostname tag to SignalFx sink.

#### Motivation
When we merged the SignalFx sink there was an oversight that the sink didn't handle the "common" tags from `Server`. As such we emit a lot of metrics that don't match config.

This fixes that, adds a configurable host tag — as unlike Datadog there is no first-class understanding of hosts in SignalFx — and fixes some oversights in casing. :)

#### Test plan
Existing tests and some additional asserts therein.

r? @stripe/observability 