### PR TITLE
Locking in 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.0.0, in progress
+# 2.0.0, 2018-01-09
 
 ## Incompatible changes
 * The semantics around `veneur-emit` command timing have changed: `-shellCommand` argument has been renamed to `-command`, and `-command` is now gone. The only way to time a command is to provide the command and its arguments as separate arguments, the method of passing in a shell-escaped string is no longer supported.


### PR DESCRIPTION
#### Summary
Datestamps changelog.md, pretty much.

#### Motivation
It's release day!


#### Test plan
No code was harmed in the construction of this PR

#### Rollout/monitoring/revert plan
N/A

R? @gphat cc @ChimeraCoder
  