### PR TITLE
Do less CPU-intensive work in histogram tests

### DIFF
--- a/tdigest/histo_test.go
+++ b/tdigest/histo_test.go
@@ -13,7 +13,7 @@ func TestMergingDigest(t *testing.T) {
 
 	td := NewMerging(1000, false)
 
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 100000; i++ {
 		td.Add(rand.Float64(), 1.0)
 	}
 	validateMergingDigest(t, td)


### PR DESCRIPTION


<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Since we run tests with -race, adding a million entries to a histogram takes 13+ seconds. That's simply too long. Let's reduce this by an order of magnitude (histogram tests with the race detector on now take ~2.5 seconds on my laptop instead of 20).

I don't believe this will affect the quality of this test significantly - all assertions still hold, at least.

#### Test plan
I ran the tests! (:


#### Rollout/monitoring/revert plan
Merge & be happy that `go test -race -timeout 5s` now works (:
