### PR TITLE
First pass at adding span sampling for Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
+* The Kafka sink for spans can now sample spans based off of a tag and its values (configurable via `kafka_span_sample_tag` and `kafka_span_sample_rate_percent`) to consistently pick off spans with relevant information. Thanks, [rhwlo](https://github.com/rhwlo)!
 
 # 2.0.0, 2018-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
-* The Kafka sink for spans can now sample spans based off of a tag and its values (configurable via `kafka_span_sample_tag` and `kafka_span_sample_rate_percent`) to consistently pick off spans with relevant information. Thanks, [rhwlo](https://github.com/rhwlo)!
+* The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
 
 # 2.0.0, 2018-01-09
 

--- a/config.go
+++ b/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	KafkaSpanBufferFrequency      string    `yaml:"kafka_span_buffer_frequency"`
 	KafkaSpanBufferMesages        int       `yaml:"kafka_span_buffer_mesages"`
 	KafkaSpanRequireAcks          string    `yaml:"kafka_span_require_acks"`
+	KafkaSpanSampleRate           float64   `yaml:"kafka_span_sample_rate"`
+	KafkaSpanSampleTag            string    `yaml:"kafka_span_sample_tag"`
 	KafkaSpanSerializationFormat  string    `yaml:"kafka_span_serialization_format"`
 	KafkaSpanTopic                string    `yaml:"kafka_span_topic"`
 	MetricMaxLength               int       `yaml:"metric_max_length"`

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	KafkaSpanBufferFrequency      string    `yaml:"kafka_span_buffer_frequency"`
 	KafkaSpanBufferMesages        int       `yaml:"kafka_span_buffer_mesages"`
 	KafkaSpanRequireAcks          string    `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRate           float64   `yaml:"kafka_span_sample_rate"`
+	KafkaSpanSampleRatePercent    int       `yaml:"kafka_span_sample_rate_percent"`
 	KafkaSpanSampleTag            string    `yaml:"kafka_span_sample_tag"`
 	KafkaSpanSerializationFormat  string    `yaml:"kafka_span_serialization_format"`
 	KafkaSpanTopic                string    `yaml:"kafka_span_topic"`

--- a/example.yaml
+++ b/example.yaml
@@ -221,7 +221,8 @@ kafka_metric_topic: ""
 # Name of the topic we'll be publishing spans to
 kafka_span_topic: "veneur_spans"
 
-# Name of a tag to hash on for sampling; if empty, all spans are sampled
+# Name of a tag to hash on for sampling; if empty, spans are sampled based off
+# of traceID
 kafka_span_sample_tag: ""
 
 # Sample rate in percent (as an integer)

--- a/example.yaml
+++ b/example.yaml
@@ -79,7 +79,7 @@ omit_empty_hostname: false
 tags:
   - ""
 
-# Set to floating point values that you'd like to putput percentiles for from
+# Set to floating point values that you'd like to output percentiles for from
 # histograms.
 percentiles:
   - 0.5
@@ -220,6 +220,13 @@ kafka_metric_topic: ""
 
 # Name of the topic we'll be publishing spans to
 kafka_span_topic: "veneur_spans"
+
+# Name of a tag to hash on for sampling; if empty, all spans are sampled
+kafka_span_sample_tag: ""
+
+# Set to the floating point sampling rate on a particular tag.
+# If set above 1.0, this will default to 1.0
+kafka_span_sample_rate: 1.1
 
 kafka_metric_buffer_bytes: 0
 

--- a/example.yaml
+++ b/example.yaml
@@ -224,9 +224,10 @@ kafka_span_topic: "veneur_spans"
 # Name of a tag to hash on for sampling; if empty, all spans are sampled
 kafka_span_sample_tag: ""
 
-# Set to the floating point sampling rate on a particular tag.
-# If set above 1.0, this will default to 1.0
-kafka_span_sample_rate: 1.1
+# Sample rate in percent (as an integer)
+# This should ideally be a floating point number, but at the time this was
+# written, gojson interpreted whole-number floats in yaml as integers.
+kafka_span_sample_rate_percent: 100
 
 kafka_metric_buffer_bytes: 0
 

--- a/server.go
+++ b/server.go
@@ -406,6 +406,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 				conf.KafkaPartitioner, conf.KafkaMetricRequireAcks, conf.KafkaRetryMax,
 				conf.KafkaSpanBufferBytes, conf.KafkaSpanBufferMesages,
 				conf.KafkaSpanBufferFrequency, conf.KafkaSpanSerializationFormat,
+				conf.KafkaSpanSampleTag, conf.KafkaSpanSampleRate,
 				ret.Statsd,
 			)
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -406,7 +406,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 				conf.KafkaPartitioner, conf.KafkaMetricRequireAcks, conf.KafkaRetryMax,
 				conf.KafkaSpanBufferBytes, conf.KafkaSpanBufferMesages,
 				conf.KafkaSpanBufferFrequency, conf.KafkaSpanSerializationFormat,
-				conf.KafkaSpanSampleTag, conf.KafkaSpanSampleRate,
+				conf.KafkaSpanSampleTag, conf.KafkaSpanSampleRatePercent,
 				ret.Statsd,
 			)
 			if err != nil {

--- a/sinks/kafka/README.md
+++ b/sinks/kafka/README.md
@@ -21,8 +21,10 @@ See the various `kafka_*` keys in [example.yaml](https://github.com/stripe/veneu
 
 ## Span Sampling
 
-The Kafka sink supports span sampling: configurable by `kafka_span_sample_tag` and
-`kafka_span_sample_rate_percent`. For example, imagine the following configuration:
+The Kafka sink supports span sampling! By default, setting `kafka_span_sample_rate_percent`
+less than 100 will sample based off of traceId (meaning that if one span with a particular
+traceId is selected, all spans with that traceId will be selected), but that behavior
+can be configured to use a tag instead via `kafka_span_sample_tag`. For example,
 
 ```
 kafka_span_sample_tag: "request_id"

--- a/sinks/kafka/README.md
+++ b/sinks/kafka/README.md
@@ -19,6 +19,21 @@ See the various `kafka_*` keys in [example.yaml](https://github.com/stripe/veneu
 * ack requirements
 * publishing of Protobuf or JSON formatted messages
 
+## Span Sampling
+
+The Kafka sink supports span sampling: configurable by `kafka_span_sample_tag` and
+`kafka_span_sample_rate_percent`. For example, imagine the following configuration:
+
+```
+kafka_span_sample_tag: "request_id"
+kafka_span_sample_rate_percent: 75
+```
+
+With this configuration, spans _without_ the `"request_id"` tag will be rejected,
+and spans _with_ the `"request_id"` will be sampled at 75%, based off of a hash
+of their `"request_id"` value; in this way, you can sample all values relevant to
+a particular tag value.
+
 # Format
 
 Metrics are published in JSON in the form of:

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -211,7 +211,7 @@ func (k *KafkaMetricSink) FlushEventsChecks(ctx context.Context, events []sample
 }
 
 // NewKafkaSpanSink creates a new Kafka Plugin.
-func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, partitioner string, ackRequirement string, retries int, bufferBytes int, bufferMessages int, bufferDuration string, serializationFormat string, sampleTag string, sampleRate float64, stats *statsd.Client) (*KafkaSpanSink, error) {
+func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, partitioner string, ackRequirement string, retries int, bufferBytes int, bufferMessages int, bufferDuration string, serializationFormat string, sampleTag string, sampleRatePercentage int, stats *statsd.Client) (*KafkaSpanSink, error) {
 
 	if logger == nil {
 		logger = &logrus.Logger{Out: ioutil.Discard}
@@ -230,17 +230,14 @@ func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, parti
 	}
 
 	var sampleThreshold uint32
-	if sampleRate <= 0.0 {
-		return nil, errors.New("Span sample rate must be greater than 0.0")
-	} else if sampleRate > 1.0 {
-		ll.WithField("sampleRate", sampleRate).Warn("Span sample rate is set greater than 1.0; using 1.0 instead")
-		sampleThreshold = math.MaxUint32
-	} else {
-		// Set the sample threshold to (sample rate) * (maximum value of uint32), so that
-		// we can store it as a uint32 instead of a float64 and compare apples-to-apples
-		// with the output of our hashing algorithm.
-		sampleThreshold = uint32(sampleRate * float64(math.MaxUint32))
+	if sampleRatePercentage <= 0 || sampleRatePercentage > 100 {
+		return nil, errors.New("Span sample rate percentage must be greater than 0%% and less than or equal to 100%%")
 	}
+
+	// Set the sample threshold to (sample rate) * (maximum value of uint32), so that
+	// we can store it as a uint32 instead of a float64 and compare apples-to-apples
+	// with the output of our hashing algorithm.
+	sampleThreshold = uint32(sampleRatePercentage * math.MaxUint32 / 100)
 
 	var finalBufferDuration time.Duration
 	if bufferDuration != "" {

--- a/sinks/kafka/kafka_test.go
+++ b/sinks/kafka/kafka_test.go
@@ -233,6 +233,9 @@ func TestSpanConstructor(t *testing.T) {
 	assert.Equal(t, "protobuf", sink.serializer, "Serializer did not default correctly")
 	assert.Equal(t, "veneur_spans", sink.topic, "Topic did not set correctly")
 
+	assert.Equal(t, uint32(math.MaxUint32), sink.sampleThreshold, "Sample threshold did not set correctly")
+	assert.Equal(t, "foo", sink.sampleTag, "Sample tag did not set correctly")
+
 	assert.Equal(t, sarama.WaitForAll, sink.config.Producer.RequiredAcks, "ack did not set correctly")
 	assert.Equal(t, 1, sink.config.Producer.Retry.Max, "retries did not set correctly")
 	assert.Equal(t, 2, sink.config.Producer.Flush.Bytes, "buffer bytes did not set correctly")


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->

#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
I added an option for us to sample spans going to Kafka based off of some particular tag. I also added an option for us to sample some percentage of those spans.

#### Motivation
<!-- Why are you making this change? -->
When writing spans to a Kafka cluster, we may not want to report all of them. This gives us that option!

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Added new unit tests.

#### Notes
~This also makes the example config file emit a warning line by defaulting the sampling rate to `1.1` because https://github.com/ChimeraCoder/gojson/issues/44 means that the default sampling rate of `1.0` would be parsed as an integer via gojson.~

So that we don’t have to manage a weird edge case, I used an integer for the percent of sampling rate (defaulted to `100`) instead of using a float for the moment. I can change this one https://github.com/ChimeraCoder/gojson/pull/59 or something similar is shipped.