### PR TITLE
Deprecate config keys for 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.0.0, in development
+
+## Incompatible changes
+* These deprecated configuration keys are no longer supported and will cause an error on startup if used in a veneur config file:
+** `api_hostname` - replaced in 1.5.0 by `datadog_api_hostname`
+** `key` - replaced in 1.5.0 by `datadog_api_key`
+** `trace_address` - replaced in 1.7.0 by `ssf_listen_addresses`
+** `trace_api_address` - replaced in 1.5.0 by `datadog_trace_api_address`
+** `ssf_address` - replaced in 1.7.0 by `ssf_listen_addresses`
+** `tcp_address` and `udp_address` - replaced in 1.7.0 by `statsd_listen_addresses`
+
 # 2.0.0, 2018-01-09
 
 ## Incompatible changes

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To clarify how each metric type behaves in Veneur, please use the following:
 veneur -f example.yaml
 ```
 
-See example.yaml for a sample config. Be sure to set your Datadog API `key`!
+See example.yaml for a sample config. Be sure to set your `datadog_api_key`!
 
 # Plugins
 
@@ -144,9 +144,8 @@ Veneur is capable of ingesting:
 
 To use clients with Veneur you need only configure your client of choice to the proper host and port combination. This port should match one of:
 
-* `udp_address` for UDP-based clients
-* `tcp_address` for TCP-based clients
-* `ssf_address` for SSF-based clients
+* `statsd_listen_addresses` for UDP- and TCP-based clients
+* `ssf_listen_addresses` for SSF-based clients using UDP or UNIX domain sockets.
 
 ## Einhorn Usage
 
@@ -180,7 +179,7 @@ See [more documentation for Proxy Veneur](https://github.com/stripe/veneur/tree/
 
 ### Static Configuration
 
-For static configuration you need one Veneur, which we'll call the _global_ instance, and one or more other Veneurs, which we'll call _local_ instances. The local instances should have their `forward_address` configured to the global instance's `http_address`. The global instance should have an empty `forward_address` (ie just don't set it). You can then report metrics to any Veneur's `udp_address` as usual.
+For static configuration you need one Veneur, which we'll call the _global_ instance, and one or more other Veneurs, which we'll call _local_ instances. The local instances should have their `forward_address` configured to the global instance's `http_address`. The global instance should have an empty `forward_address` (ie just don't set it). You can then report metrics to any Veneur's `statsd_listen_addresses` as usual.
 
 ### Magic Tag
 
@@ -386,10 +385,11 @@ openssl req -new -sha256 -key clientkey.pem -out clientkey.csr -days 1095 -subj 
 openssl x509 -req -in clientkey.csr -CA cacert.pem -CAkey cakey.pem -CAcreateserial -out clientcert.pem -days 1095
 ```
 
-Set `tcp_address`, `tls_key`, `tls_certificate`, and `tls_authority_certificate`:
+Set `statsd_listen_addresses`, `tls_key`, `tls_certificate`, and `tls_authority_certificate`:
 
 ```
-tcp_address: "localhost:8129"
+statsd_listen_addresses:
+  - "tcp://localhost:8129"
 tls_certificate: |
   -----BEGIN CERTIFICATE-----
   MIIC8TCCAdkCCQDc2V7P5nCDLjANBgkqhkiG9w0BAQsFADBAMRUwEwYDVQQKEwxC

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package veneur
 
 type Config struct {
 	Aggregates                    []string  `yaml:"aggregates"`
-	APIHostname                   string    `yaml:"api_hostname"`
 	AwsAccessKeyID                string    `yaml:"aws_access_key_id"`
 	AwsRegion                     string    `yaml:"aws_region"`
 	AwsS3Bucket                   string    `yaml:"aws_s3_bucket"`
@@ -35,7 +34,6 @@ type Config struct {
 	KafkaSpanRequireAcks          string    `yaml:"kafka_span_require_acks"`
 	KafkaSpanSerializationFormat  string    `yaml:"kafka_span_serialization_format"`
 	KafkaSpanTopic                string    `yaml:"kafka_span_topic"`
-	Key                           string    `yaml:"key"`
 	MetricMaxLength               int       `yaml:"metric_max_length"`
 	NumReaders                    int       `yaml:"num_readers"`
 	NumWorkers                    int       `yaml:"num_workers"`
@@ -46,24 +44,19 @@ type Config struct {
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
 	SignalfxEndpointBase          string    `yaml:"signalfx_endpoint_base"`
 	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
-	SsfAddress                    string    `yaml:"ssf_address"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string  `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string    `yaml:"stats_address"`
 	StatsdListenAddresses         []string  `yaml:"statsd_listen_addresses"`
 	SynchronizeWithInterval       bool      `yaml:"synchronize_with_interval"`
 	Tags                          []string  `yaml:"tags"`
-	TcpAddress                    string    `yaml:"tcp_address"`
 	TLSAuthorityCertificate       string    `yaml:"tls_authority_certificate"`
 	TLSCertificate                string    `yaml:"tls_certificate"`
 	TLSKey                        string    `yaml:"tls_key"`
-	TraceAddress                  string    `yaml:"trace_address"`
-	TraceAPIAddress               string    `yaml:"trace_api_address"`
 	TraceLightstepAccessToken     string    `yaml:"trace_lightstep_access_token"`
 	TraceLightstepCollectorHost   string    `yaml:"trace_lightstep_collector_host"`
 	TraceLightstepMaximumSpans    int       `yaml:"trace_lightstep_maximum_spans"`
 	TraceLightstepNumClients      int       `yaml:"trace_lightstep_num_clients"`
 	TraceLightstepReconnectPeriod string    `yaml:"trace_lightstep_reconnect_period"`
 	TraceMaxLengthBytes           int       `yaml:"trace_max_length_bytes"`
-	UdpAddress                    string    `yaml:"udp_address"`
 }

--- a/config_parse.go
+++ b/config_parse.go
@@ -1,10 +1,8 @@
 package veneur
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"time"
 
@@ -76,67 +74,6 @@ func readConfig(r io.Reader) (c Config, err error) {
 	if c.ReadBufferSizeBytes == 0 {
 		c.ReadBufferSizeBytes = defaultBufferSizeBytes
 	}
-
-	if c.Key != "" {
-		log.Warn("The config key `key` is deprecated and replaced with `datadog_api_key` and will be removed in 2.0!")
-		// If they set the DatadogAPIKey, favor it. Otherwise, replace it.
-		if c.DatadogAPIKey == "" {
-			c.DatadogAPIKey = c.Key
-		}
-	}
-
-	if c.APIHostname != "" {
-		log.Warn("The config key `api_hostname` is deprecated and replaced with `datadog_api_hostname` and will be removed in 2.0!")
-		if c.DatadogAPIHostname == "" {
-			c.DatadogAPIHostname = c.APIHostname
-		}
-	}
-
-	if c.TraceAPIAddress != "" {
-		log.Warn("The config key `trace_api_address` is deprecated and replaced with `datadog_trace_api_hostname` and will be removed in 2.0!")
-		if c.DatadogTraceAPIAddress == "" {
-			c.DatadogTraceAPIAddress = c.TraceAPIAddress
-		}
-	}
-
-	if c.TraceAddress != "" {
-		log.Warn("The config key `trace_address` is deprecated and replaced with entries in `ssf_listen_addresses` and will be removed in 2.0!")
-		if c.SsfAddress == "" {
-			c.SsfAddress = c.TraceAddress
-		}
-	}
-
-	var statsdAddrs []string
-	if c.UdpAddress != "" {
-		if len(c.StatsdListenAddresses) > 0 {
-			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `udp_address` are both present")
-			return
-		}
-		log.Warn("The config key `udp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
-		statsdAddrs = append(statsdAddrs, (&url.URL{Scheme: "udp", Host: c.UdpAddress}).String())
-	}
-
-	if c.TcpAddress != "" {
-		if len(c.StatsdListenAddresses) > 0 {
-			err = fmt.Errorf("`statsd_listen_addresses` and deprecated parameter `tcp_address` are both present")
-			return
-		}
-		log.Warn("The config key `tcp_address` is deprecated and replaced with entries in `statsd_listen_addresses` and will be removed in 2.0!")
-		statsdAddrs = append(statsdAddrs, (&url.URL{Scheme: "tcp", Host: c.TcpAddress}).String())
-	}
-	c.StatsdListenAddresses = append(c.StatsdListenAddresses, statsdAddrs...)
-
-	var ssfAddrs []string
-	if c.SsfAddress != "" {
-		if len(c.SsfListenAddresses) > 0 {
-			err = fmt.Errorf("`ssf_listen_addresses` and deprecated parameter `ssf_address` are both present")
-			return
-		}
-		log.Warn("The config key `ssf_address` is deprecated and replaced with entries in `ssf_listen_addresses` and will be removed in 2.0!")
-		ssfAddrs = append(ssfAddrs, (&url.URL{Scheme: "udp", Host: c.SsfAddress}).String())
-	}
-	c.SsfListenAddresses = append(c.SsfListenAddresses, ssfAddrs...)
-
 	return c, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -93,3 +93,30 @@ func TestHostname(t *testing.T) {
 		ReadBufferSizeBytes: defaultBufferSizeBytes,
 		OmitEmptyHostname:   true})
 }
+
+func TestVeneurExamples(t *testing.T) {
+	tests := []string{
+		"example.yaml",
+		"example_host.yaml",
+	}
+	for _, elt := range tests {
+		test := elt
+		t.Run(test, func(t *testing.T) {
+			t.Parallel()
+			_, err := ReadConfig(test)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestProxyExamples(t *testing.T) {
+	tests := []string{"example_proxy.yaml"}
+	for _, elt := range tests {
+		test := elt
+		t.Run(test, func(t *testing.T) {
+			t.Parallel()
+			_, err := ReadProxyConfig(test)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -39,6 +39,34 @@ func TestReadBadConfig(t *testing.T) {
 	assert.Equal(t, c, Config{}, "Parsing invalid config file should return zero struct")
 }
 
+func TestReadUnknownKeysConfig(t *testing.T) {
+	const config = `---
+no_such_key: 1
+hostname: foobar
+`
+	r := strings.NewReader(config)
+	c, err := readConfig(r)
+	assert.Error(t, err)
+	_, ok := err.(*UnknownConfigKeys)
+	t.Log(err)
+	assert.True(t, ok, "Returned error should indicate a strictness error")
+	assert.Equal(t, "foobar", c.Hostname)
+}
+
+func TestReadUnknownKeysProxyConfig(t *testing.T) {
+	const config = `---
+no_such_key: 1
+debug: true
+`
+	r := strings.NewReader(config)
+	c, err := readProxyConfig(r)
+	assert.Error(t, err)
+	_, ok := err.(*UnknownConfigKeys)
+	t.Log(err)
+	assert.True(t, ok, "Returned error should indicate a strictness error")
+	assert.Equal(t, true, c.Debug)
+}
+
 func TestHostname(t *testing.T) {
 	const hostnameConfig = "hostname: foo"
 	r := strings.NewReader(hostnameConfig)

--- a/config_test.go
+++ b/config_test.go
@@ -39,46 +39,6 @@ func TestReadBadConfig(t *testing.T) {
 	assert.Equal(t, c, Config{}, "Parsing invalid config file should return zero struct")
 }
 
-func TestReadConfigBackwardsCompatible(t *testing.T) {
-	// set the deprecated config options
-	const config = `
-api_hostname: "http://api"
-key: apikey
-trace_api_address: http://trace_api
-trace_address: trace_address:12345
-udp_address: 127.0.0.1:8002
-tcp_address: 127.0.0.1:8003
-`
-	c, err := readConfig(strings.NewReader(config))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// they should get copied to the new config options
-	assert.Equal(t, "http://api", c.DatadogAPIHostname)
-	assert.Equal(t, "apikey", c.DatadogAPIKey)
-	assert.Equal(t, "http://trace_api", c.DatadogTraceAPIAddress)
-	assert.Equal(t, "trace_address:12345", c.SsfAddress)
-	assert.Contains(t, c.StatsdListenAddresses, "udp://127.0.0.1:8002")
-	assert.Contains(t, c.StatsdListenAddresses, "tcp://127.0.0.1:8003")
-	assert.Contains(t, c.SsfListenAddresses, "udp://trace_address:12345")
-}
-
-func TestReadSSFConfigBackwardsCompatible(t *testing.T) {
-	// set the deprecated config options
-	const config = `
-trace_api_address: http://trace_api
-ssf_address: trace_address:12345
-`
-	c, err := readConfig(strings.NewReader(config))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// they should get copied to the new config options
-	assert.Equal(t, c.SsfListenAddresses, []string{"udp://trace_address:12345"})
-}
-
 func TestHostname(t *testing.T) {
 	const hostnameConfig = "hostname: foo"
 	r := strings.NewReader(hostnameConfig)

--- a/example.yaml
+++ b/example.yaml
@@ -259,34 +259,3 @@ aws_s3_bucket: ""
 # == LocalFile Output ==
 # Include this if you want to archive data to a local file (which should then be rotated/cleaned)
 flush_file: ""
-
-
-# == DEPRECATED FIELDS ==
-# The options below here have newer analogs above. They are listed here for the
-# sake of documentation and code-generation.
-
-# The address on which to listen for metrics sent to this instance over UDP,
-# leave empty to disable.
-# This option is deprecated. Use statsd_listen_addresses instead.
-udp_address: ""
-
-# The address on which to listen for metrics sent to this instance over TCP,
-# leave empty to disable.
-# This option is deprecated. Use statsd_listen_addresses instead.
-tcp_address: ""
-
-# The address on which we will listen for SSF packets via UDP
-# This option is deprecated. Use ssf_listen_addresses instead.
-ssf_address: ""
-
-# This is deprecated and will be removed in 2.0; use datadog_api_key
-key: ""
-
-# This is deprecated and will be removed in 2.0; use datadog_api_hostname
-api_hostname: ""
-
-# This is deprecated and will be removed in 2.0; use datadog_trace_api_address
-trace_api_address: ""
-
-# The address on which we will listen for UDP trace data
-trace_address: ""

--- a/example_host.yaml
+++ b/example_host.yaml
@@ -1,12 +1,12 @@
 ---
-api_hostname: https://app.datadoghq.com
+datadog_api_hostname: https://app.datadoghq.com
+datadog_api_key: "farts"
 metric_max_length: 4096
 trace_max_length_bytes: 16384
 flush_max_per_body: 25000
 debug: true
 enable_profiling: true
 interval: "10s"
-key: "farts"
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
 num_workers: 96
@@ -24,7 +24,8 @@ stats_address: "localhost:8125"
 tags:
  - "foo:bar"
  - "baz:quz"
-udp_address: "localhost:8126"
+statsd_listen_addresses:
+  - "udp://localhost:8126"
 #http_address: "einhorn@0"
 http_address: ""
 

--- a/server.go
+++ b/server.go
@@ -460,7 +460,6 @@ func NewFromConfig(conf Config) (*Server, error) {
 	ret.shutdown = make(chan struct{})
 
 	// Don't emit keys into logs now that we're done with them.
-	conf.Key = REDACTED
 	conf.SentryDsn = REDACTED
 	conf.TLSKey = REDACTED
 	conf.DatadogAPIKey = REDACTED

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -144,7 +144,7 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		DatadogAPIKey:          "apikey",
 		DatadogAPIHostname:     "http://api",
 		DatadogTraceAPIAddress: "http://trace",
-		SsfAddress:             "127.0.0.1:99",
+		SsfListenAddresses:     []string{"udp://127.0.0.1:99"},
 
 		// required or NewFromConfig fails
 		Interval:     "10s",

--- a/server_test.go
+++ b/server_test.go
@@ -88,7 +88,7 @@ func generateConfig(forwardAddr string) Config {
 
 		// Use a shorter interval for tests
 		Interval:              DefaultFlushInterval.String(),
-		Key:                   "",
+		DatadogAPIKey:         "",
 		MetricMaxLength:       4096,
 		Percentiles:           []float64{.5, .75, .99},
 		Aggregates:            []string{"min", "max", "count"},


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR removes deprecated config keys, updates examples and the README, and introduces tests that read the provided example config files and check them for deprecated keys.

#### Motivation
These keys should have been dropped in 2.0, plus we ought to make sure the examples we provide are super excellent & uppest to date.


#### Test plan
Wrote tests!


#### Rollout/monitoring/revert plan
Just needs a merge before the next release.
