### PR TITLE
Align sink flush metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ** `trace_api_address` - replaced in 1.5.0 by `datadog_trace_api_address`
 ** `ssf_address` - replaced in 1.7.0 by `ssf_listen_addresses`
 ** `tcp_address` and `udp_address` - replaced in 1.7.0 by `statsd_listen_addresses`
+* These metrics have changed names:
+** Datadog, MetricExtraction, and SignalFx sinks now emit `veneur.sink.metric_flush_total_duration_ns` for metric flush duration and tag it with `sink`
+** Datadog, Kafka, MetricExtraction, and SignalFx sinks now emits `sink.metrics_flushed_total` for metric flush counts and tag it with `sink`
+** Datadog and LightStep sinks now emit `veneur.sink.span_flush_total_duration_ns` for span flush duration and tag it with `sink`
+** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/server.go
+++ b/server.go
@@ -244,7 +244,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	for i, w := range ret.Workers {
 		processors[i] = w
 	}
-	metricSink, err := metrics.NewMetricExtractionSink(processors, conf.IndicatorSpanTimerName, log)
+	metricSink, err := metrics.NewMetricExtractionSink(processors, conf.IndicatorSpanTimerName, ret.Statsd, log)
 	if err != nil {
 		return ret, err
 	}

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -21,7 +21,8 @@ import (
 
 const DatadogResourceKey = "resource"
 const datadogNameKey = "name"
-const totalSpansFlushedMetricKey = "worker.spans_flushed_total"
+const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
+const totalSpansFlushedMetricKey = "sink.spans_flushed_total"
 
 type DatadogMetricSink struct {
 	HTTPClient      *http.Client
@@ -99,7 +100,8 @@ func (dd *DatadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.
 		go dd.flushPart(span.Attach(ctx), chunk, &wg)
 	}
 	wg.Wait()
-	dd.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"part:post"}, 1.0)
+	dd.statsd.TimeInMilliseconds("sink.metric_flush_total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"sink:datadog"}, 1.0)
+	dd.statsd.Count("sink.metrics_flushed_total", int64(len(metrics)), []string{"sink:datadog"}, 1.0)
 
 	dd.log.WithField("metrics", len(metrics)).Info("Completed flush to Datadog")
 	return nil

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -406,8 +406,6 @@ func (dd *DatadogSpanSink) Flush() {
 
 		if err == nil {
 			dd.log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")
-			dd.stats.Count(totalSpansFlushedMetricKey, int64(len(ssfSpans)), []string{"sink:datadog"}, 1)
-			// TODO: Per service counters?
 		} else {
 			dd.log.WithFields(logrus.Fields{
 				"traces":        len(finalTraces),

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -23,9 +23,6 @@ import (
 var _ sinks.MetricSink = &KafkaMetricSink{}
 var _ sinks.SpanSink = &KafkaSpanSink{}
 
-const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
-const totalSpansFlushedMetricKey = "sink.spans_flushed_total"
-
 type KafkaMetricSink struct {
 	logger      *logrus.Entry
 	producer    sarama.AsyncProducer
@@ -197,7 +194,7 @@ func (k *KafkaMetricSink) Flush(ctx context.Context, interMetrics []samplers.Int
 		successes++
 	}
 
-	k.statsd.Count(totalMetricsFlushedMetricKey, int64(successes), []string{fmt.Sprintf("sink:%s", k.Name())}, 1.0)
+	k.statsd.Count(sinks.MetricKeyTotalMetricsFlushed, int64(successes), []string{fmt.Sprintf("sink:%s", k.Name())}, 1.0)
 	return nil
 }
 
@@ -313,6 +310,6 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 func (k *KafkaSpanSink) Flush() {
 	// TODO We have no stuff in here for detecting failed writes from the async
 	// producer. We should add that.
-	k.statsd.Count(totalSpansFlushedMetricKey, atomic.LoadInt64(&k.spansFlushed), []string{fmt.Sprintf("sink:%s", k.Name())}, 1.0)
+	k.statsd.Count(sinks.MetricKeyTotalSpansFlushed, atomic.LoadInt64(&k.spansFlushed), []string{fmt.Sprintf("sink:%s", k.Name())}, 1.0)
 	atomic.SwapInt64(&k.spansFlushed, 0)
 }

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -195,9 +195,9 @@ func (k *KafkaMetricSink) Flush(ctx context.Context, interMetrics []samplers.Int
 		}
 		successes++
 	}
-	k.statsd.Count("kafka.metrics_success_total", successes, nil, 1.0)
-	k.statsd.TimeInMilliseconds("kafka.metrics_flush_duration_ns", float64(time.Now().Sub(sendMetricStart).Nanoseconds()), nil, 1.0)
 
+	k.statsd.TimeInMilliseconds("sink.metric_flush_total_duration_ns", float64(time.Since(sendMetricStart).Nanoseconds()), []string{"sink:kafka"}, 1.0)
+	k.statsd.Count("sink.metrics_flushed_total", int64(successes), []string{"sink:kafka"}, 1.0)
 	return nil
 }
 
@@ -313,6 +313,6 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 func (k *KafkaSpanSink) Flush() {
 	// TODO We have no stuff in here for detecting failed writes from the async
 	// producer. We should add that.
-	k.statsd.Count("kafka.spans_flushed_total", atomic.LoadInt64(&k.spansFlushed), nil, 1.0)
+	k.statsd.Count("sink.spans_flushed_total", atomic.LoadInt64(&k.spansFlushed), []string{"sink:kafka"}, 1.0)
 	atomic.SwapInt64(&k.spansFlushed, 0)
 }

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -24,7 +24,7 @@ const lightstepDefaultInterval = 5 * time.Minute
 
 const lightStepOperationKey = "name"
 
-const totalSpansFlushedMetricKey = "worker.spans_flushed_total"
+const totalSpansFlushedMetricKey = "sink.spans_flushed_total"
 
 // LightStepSpanSink is a sink for spans to be sent to the LightStep client.
 type LightStepSpanSink struct {
@@ -198,7 +198,7 @@ func (ls *LightStepSpanSink) Flush() {
 	totalCount := int64(0)
 	for service, count := range ls.serviceCount {
 		totalCount += count
-		ls.stats.Count(totalSpansFlushedMetricKey, count, []string{"sink:lightstep", fmt.Sprintf("service:%s", service)}, 1)
+		ls.stats.Count(totalSpansFlushedMetricKey, count, []string{fmt.Sprintf("sink:%s", ls.Name()), fmt.Sprintf("service:%s", service)}, 1)
 	}
 	ls.serviceCount = make(map[string]int64)
 	ls.log.WithField("total_spans", totalCount).Debug("Checkpointing flushed spans for Lightstep")

--- a/sinks/metrics/metrics.go
+++ b/sinks/metrics/metrics.go
@@ -2,6 +2,9 @@
 package metrics
 
 import (
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/samplers"
@@ -14,6 +17,9 @@ type metricExtractionSink struct {
 	workers                []Processor
 	indicatorSpanTimerName string
 	log                    *logrus.Logger
+	statsd                 *statsd.Client
+	spansProcessed         int64
+	metricsGenerated       int64
 }
 
 var _ sinks.SpanSink = &metricExtractionSink{}
@@ -27,11 +33,12 @@ type Processor interface {
 // NewMetricExtractionSink sets up and creates a span sink that
 // extracts metrics ("samples") from SSF spans and reports them to a
 // veneur's metrics workers.
-func NewMetricExtractionSink(mw []Processor, timerName string, log *logrus.Logger) (sinks.SpanSink, error) {
+func NewMetricExtractionSink(mw []Processor, timerName string, statsd *statsd.Client, log *logrus.Logger) (sinks.SpanSink, error) {
 	return &metricExtractionSink{
 		workers:                mw,
 		indicatorSpanTimerName: timerName,
-		log: log,
+		statsd:                 statsd,
+		log:                    log,
 	}, nil
 }
 
@@ -84,6 +91,8 @@ func (m metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 			return err
 		}
 	}
+	atomic.AddInt64(&m.spansProcessed, 1)
+	atomic.AddInt64(&m.metricsGenerated, int64(len(metrics)))
 	m.sendMetrics(metrics)
 
 	if err := protocol.ValidateTrace(span); err != nil {
@@ -102,5 +111,10 @@ func (m metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 }
 
 func (m metricExtractionSink) Flush() {
+	m.statsd.Count("sink.spans_processed_total", atomic.LoadInt64(&m.spansProcessed), []string{"sink:metric_extraction"}, 1.0)
+	m.statsd.Count("sink.metrics_generated_total", atomic.LoadInt64(&m.metricsGenerated), []string{"sink:metric_extraction"}, 1.0)
+
+	atomic.SwapInt64(&m.spansProcessed, 0)
+	atomic.SwapInt64(&m.metricsGenerated, 0)
 	return
 }

--- a/sinks/metrics/metrics.go
+++ b/sinks/metrics/metrics.go
@@ -14,9 +14,6 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
-const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
-const totalSpansFlushedMetricKey = "sink.spans_flushed_total"
-
 type metricExtractionSink struct {
 	workers                []Processor
 	indicatorSpanTimerName string
@@ -115,8 +112,8 @@ func (m metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 }
 
 func (m metricExtractionSink) Flush() {
-	m.statsd.Count(totalSpansFlushedMetricKey, atomic.LoadInt64(&m.spansProcessed), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
-	m.statsd.Count(totalMetricsFlushedMetricKey, atomic.LoadInt64(&m.metricsGenerated), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
+	m.statsd.Count(sinks.MetricKeyTotalSpansFlushed, atomic.LoadInt64(&m.spansProcessed), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
+	m.statsd.Count(sinks.MetricKeyTotalMetricsFlushed, atomic.LoadInt64(&m.metricsGenerated), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
 
 	atomic.SwapInt64(&m.spansProcessed, 0)
 	atomic.SwapInt64(&m.metricsGenerated, 0)

--- a/sinks/metrics/metrics.go
+++ b/sinks/metrics/metrics.go
@@ -2,6 +2,7 @@
 package metrics
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -12,6 +13,9 @@ import (
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
+
+const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
+const totalSpansFlushedMetricKey = "sink.spans_flushed_total"
 
 type metricExtractionSink struct {
 	workers                []Processor
@@ -111,8 +115,8 @@ func (m metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 }
 
 func (m metricExtractionSink) Flush() {
-	m.statsd.Count("sink.spans_processed_total", atomic.LoadInt64(&m.spansProcessed), []string{"sink:metric_extraction"}, 1.0)
-	m.statsd.Count("sink.metrics_generated_total", atomic.LoadInt64(&m.metricsGenerated), []string{"sink:metric_extraction"}, 1.0)
+	m.statsd.Count(totalSpansFlushedMetricKey, atomic.LoadInt64(&m.spansProcessed), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
+	m.statsd.Count(totalMetricsFlushedMetricKey, atomic.LoadInt64(&m.metricsGenerated), []string{fmt.Sprintf("sink:%s", m.Name())}, 1.0)
 
 	atomic.SwapInt64(&m.spansProcessed, 0)
 	atomic.SwapInt64(&m.metricsGenerated, 0)

--- a/sinks/metrics/metrics_test.go
+++ b/sinks/metrics/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,8 @@ func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []metrics.Processor{worker}
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo", logger)
+	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
+	sink, err := metrics.NewMetricExtractionSink(workers, "foo", stats, logger)
 	require.NoError(t, err)
 
 	start := time.Now()
@@ -56,7 +58,8 @@ func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
 	workers := []metrics.Processor{worker}
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo", logger)
+	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
+	sink, err := metrics.NewMetricExtractionSink(workers, "foo", stats, logger)
 	require.NoError(t, err)
 
 	start := time.Now()

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -17,6 +17,9 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
+const metricFlushDurationMetricKey = "sink.metric_flush_total_duration_ns"
+const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
+
 type SignalFxSink struct {
 	client           dpsink.Sink
 	endpoint         string
@@ -98,9 +101,8 @@ func (sfx *SignalFxSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 	if err != nil {
 		span.Error(err)
 	}
-	sfx.statsd.TimeInMilliseconds("sink.metric_flush_total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"sink:signalfx"}, 1.0)
-	sfx.statsd.Count("sink.metrics_flushed_total", int64(len(points)), []string{"sink:signalfx"}, 1.0)
-	// TODO Fix these metrics to be per-metric sink
+	sfx.statsd.TimeInMilliseconds(metricFlushDurationMetricKey, float64(time.Since(flushStart).Nanoseconds()), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
+	sfx.statsd.Count(totalMetricsFlushedMetricKey, int64(len(points)), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
 	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFx")
 
 	return err

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -17,9 +17,6 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
-const metricFlushDurationMetricKey = "sink.metric_flush_total_duration_ns"
-const totalMetricsFlushedMetricKey = "sink.metrics_flushed_total"
-
 type SignalFxSink struct {
 	client           dpsink.Sink
 	endpoint         string
@@ -101,8 +98,8 @@ func (sfx *SignalFxSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 	if err != nil {
 		span.Error(err)
 	}
-	sfx.statsd.TimeInMilliseconds(metricFlushDurationMetricKey, float64(time.Since(flushStart).Nanoseconds()), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
-	sfx.statsd.Count(totalMetricsFlushedMetricKey, int64(len(points)), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
+	sfx.statsd.TimeInMilliseconds(sinks.MetricKeyMetricFlushDuration, float64(time.Since(flushStart).Nanoseconds()), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
+	sfx.statsd.Count(sinks.MetricKeyTotalMetricsFlushed, int64(len(points)), []string{fmt.Sprintf("sink:%s", sfx.Name())}, 1.0)
 	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFx")
 
 	return err

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -98,7 +98,8 @@ func (sfx *SignalFxSink) Flush(ctx context.Context, interMetrics []samplers.Inte
 	if err != nil {
 		span.Error(err)
 	}
-	sfx.statsd.TimeInMilliseconds("flush.total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"plugin:signalfx"}, 1.0)
+	sfx.statsd.TimeInMilliseconds("sink.metric_flush_total_duration_ns", float64(time.Since(flushStart).Nanoseconds()), []string{"sink:signalfx"}, 1.0)
+	sfx.statsd.Count("sink.metrics_flushed_total", int64(len(points)), []string{"sink:signalfx"}, 1.0)
 	// TODO Fix these metrics to be per-metric sink
 	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFx")
 

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
+// MetricSinks should emit these metrics, tagged with `sink:sink.Name()`.
+const MetricKeyMetricFlushDuration = "sink.metric_flush_total_duration_ns"
+const MetricKeyTotalMetricsFlushed = "sink.metrics_flushed_total"
+
 // MetricSink is a receiver of `InterMetric`s when Veneur periodically flushes
 // it's aggregated metrics.
 type MetricSink interface {
@@ -35,6 +39,10 @@ func IsAcceptableMetric(metric samplers.InterMetric, sink MetricSink) bool {
 	}
 	return metric.Sinks.RouteTo(sink.Name())
 }
+
+// SpanSinks should emit these metrics, tagged with `sink:sink.Name()`.
+const MetricKeySpanFlushDuration = "sink.span_flush_total_duration_ns"
+const MetricKeyTotalSpansFlushed = "sink.spans_flushed_total"
 
 // SpanSink is a receiver of spans that handles sending those spans to some
 // downstream sink. Calls to `Ingest(span)` are meant to give the sink control

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -8,8 +8,14 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
-// MetricSinks should emit these metrics, tagged with `sink:sink.Name()`.
+// MetricKeyMetricFlushDuration should be emitted as a timer by a MetricSink
+// if possible. Tagged with `sink:sink.Name()`. The `Flush` function is a great
+// place to do this.
 const MetricKeyMetricFlushDuration = "sink.metric_flush_total_duration_ns"
+
+// MetricKeyTotalMetricsFlushed should be emitted as a counter by a MetricSink
+// if possible. Tagged with `sink:sink.Name()`. The `Flush` function is a great
+// place to do this.
 const MetricKeyTotalMetricsFlushed = "sink.metrics_flushed_total"
 
 // MetricSink is a receiver of `InterMetric`s when Veneur periodically flushes
@@ -40,8 +46,14 @@ func IsAcceptableMetric(metric samplers.InterMetric, sink MetricSink) bool {
 	return metric.Sinks.RouteTo(sink.Name())
 }
 
-// SpanSinks should emit these metrics, tagged with `sink:sink.Name()`.
+// MetricKeySpanFlushDuration should be emitted as a timer by a SpanSink
+// if possible. Tagged with `sink:sink.Name()`. The `Flush` function is a great
+// place to do this. If your sync does async sends, this might not be necessary.
 const MetricKeySpanFlushDuration = "sink.span_flush_total_duration_ns"
+
+// MetricKeyTotalSpansFlushed should be emitted as a counter by a SpanSink
+// if possible. Tagged with `sink:sink.Name()`. The `Flush` function is a great
+// place to do this.
 const MetricKeyTotalSpansFlushed = "sink.spans_flushed_total"
 
 // SpanSink is a receiver of spans that handles sending those spans to some


### PR DESCRIPTION
#### Summary
Rename various sink metrics for alignment.

#### Motivation
The recent routing addition by @asf-stripe means that metrics may not always have equal amounts of work to do. To that end we need to ensure everyone is using the same metrics.

* Adjusts the sinks to use a common metric naming convention and tagging. They are defined as constants to make things a bit easier.
* Uses the sink's `Name()` for tags
* Fixes a bug I noticed in an missing `Unlock` on DD's plugin mutex.

#### Test plan
Existing tests

#### Rollout/monitoring/revert plan
* Deploy to QA, shore up dashboards with compatible charts

r? @asf-stripe 
