### PR TITLE
Add an e2e forwarding/proxying/aggregation test for indicator spans

### DIFF
--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -28,7 +28,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error reading config file")
 	}
 
-	proxy, err := veneur.NewProxyFromConfig(conf)
+	logger := logrus.StandardLogger()
+	proxy, err := veneur.NewProxyFromConfig(logger, conf)
+	veneur.SetLogger(logger)
 
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not initialize proxy")

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -31,7 +31,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error reading config file")
 	}
 
-	server, err := veneur.NewFromConfig(conf)
+	logger := logrus.StandardLogger()
+	server, err := veneur.NewFromConfig(logger, conf)
+	veneur.SetLogger(logger)
 	if err != nil {
 		e := err
 

--- a/consul_discovery_test.go
+++ b/consul_discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,7 +63,7 @@ func (rt *ConsulChangingRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 func TestConsulOneHost(t *testing.T) {
 	config := generateProxyConfig()
 	transport := &ConsulOneRoundTripper{}
-	server, _ := NewProxyFromConfig(config)
+	server, _ := NewProxyFromConfig(logrus.New(), config)
 
 	server.HTTPClient.Transport = transport
 
@@ -77,7 +78,7 @@ func TestConsulOneHost(t *testing.T) {
 func TestConsulChangingHosts(t *testing.T) {
 	config := generateProxyConfig()
 	transport := &ConsulChangingRoundTripper{}
-	server, _ := NewProxyFromConfig(config)
+	server, _ := NewProxyFromConfig(logrus.New(), config)
 
 	server.HTTPClient.Transport = transport
 

--- a/forward_test.go
+++ b/forward_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/samplers"
@@ -43,7 +44,7 @@ func newForwardingFixture(t testing.TB, localConfig Config, transport http.Round
 	proxyCfg.ForwardAddress = ff.globalTS.URL
 	proxyCfg.ConsulTraceServiceName = ""
 	proxyCfg.ConsulForwardServiceName = ""
-	proxy, err := NewProxyFromConfig(proxyCfg)
+	proxy, err := NewProxyFromConfig(logrus.New(), proxyCfg)
 	require.NoError(t, err)
 	ff.proxy = &proxy
 

--- a/forward_test.go
+++ b/forward_test.go
@@ -1,0 +1,126 @@
+package veneur
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+)
+
+type forwardFixture struct {
+	t      testing.TB
+	proxy  *Proxy
+	global *Server
+
+	globalTS *httptest.Server
+	proxyTS  *httptest.Server
+	server   *Server
+}
+
+// newForwardingFixture constructs and returns a chain of veneur
+// servers that represent a fairly typical metrics pipeline:
+//     [local veneur] -> [veneur proxy] -> [global veneur]
+//
+// The globalSink argument is the global veneur's metric sink, and the
+// localConfig argument is the local veneur agent's config, which will
+// be amended to include the forwarder and proxy addresses.
+func newForwardingFixture(t testing.TB, localConfig Config, transport http.RoundTripper, globalSink sinks.MetricSink) *forwardFixture {
+	ff := &forwardFixture{t: t}
+
+	// Make the global veneur:
+	ff.global = setupVeneurServer(t, globalConfig(), transport, globalSink, nil)
+	ff.globalTS = httptest.NewServer(handleImport(ff.global))
+
+	// Make the proxy that sends to the global veneur:
+	proxyCfg := generateProxyConfig()
+	proxyCfg.ForwardAddress = ff.globalTS.URL
+	proxyCfg.ConsulTraceServiceName = ""
+	proxyCfg.ConsulForwardServiceName = ""
+	proxy, err := NewProxyFromConfig(proxyCfg)
+	require.NoError(t, err)
+	ff.proxy = &proxy
+
+	ff.proxy.Start()
+	ff.proxyTS = httptest.NewServer(ff.proxy.Handler())
+
+	// Now make the local server, have it forward to the proxy:
+	localConfig.ForwardAddress = ff.proxyTS.URL
+	ff.server = setupVeneurServer(t, localConfig, transport, nil, nil)
+
+	return ff
+}
+
+// Close shuts down the chain of veneur servers.
+func (ff *forwardFixture) Close() {
+	ff.proxy.Shutdown()
+	ff.proxyTS.Close()
+	ff.global.Shutdown()
+	ff.globalTS.Close()
+	ff.server.Shutdown()
+}
+
+// Flush synchronously waits until all metrics have been flushed along
+// the chain of veneur servers.
+func (ff *forwardFixture) Flush(ctx context.Context) {
+	ff.server.Flush(ctx)
+	// The proxy proxies synchronously, so when the local server
+	// returns, we assume it has proxied everything to the global
+	// veneur.
+	ff.global.Flush(ctx)
+}
+
+// TestForwardingIndicatorMetrics ensures that the metrics extracted
+// from indicator spans make it across the entire chain, from a local
+// veneur, through a proxy, to a global veneur & get reported
+// on the global veneur.
+func TestForwardingIndicatorMetrics(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan []samplers.InterMetric)
+	sink, _ := NewChannelMetricSink(ch)
+	cfg := localConfig()
+	cfg.IndicatorSpanTimerName = "indicator.span.timer"
+	ffx := newForwardingFixture(t, cfg, nil, sink)
+	defer ffx.Close()
+
+	start := time.Now()
+	end := start.Add(5 * time.Second)
+	span := &ssf.SSFSpan{
+		Id:             5,
+		TraceId:        5,
+		Service:        "indicator_testing",
+		StartTimestamp: start.UnixNano(),
+		EndTimestamp:   end.UnixNano(),
+		Indicator:      true,
+	}
+	ffx.server.SpanWorker.SpanChan <- span
+	done := make(chan struct{})
+	go func() {
+		metrics := <-ch
+		require.Equal(t, 3, len(metrics), "metrics:\n%#v", metrics)
+		for _, suffix := range []string{".50percentile", ".75percentile", ".99percentile"} {
+			mName := "indicator.span.timer" + suffix
+			found := false
+			for _, m := range metrics {
+				if m.Name == mName {
+					found = true
+				}
+			}
+			assert.True(t, found, "Metric named %s missing", mName)
+		}
+		close(done)
+	}()
+	ffx.Flush(context.TODO())
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timed out waiting for a metric after 5 seconds")
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/samplers"
 )
@@ -291,7 +292,7 @@ func TestNoTracingConfiguredTraceHealthCheck(t *testing.T) {
 	config := localConfig()
 
 	config.SsfListenAddresses = []string{}
-	server, _ := NewFromConfig(config)
+	server, _ := NewFromConfig(logrus.New(), config)
 	server.Start()
 	defer server.Shutdown()
 

--- a/http_test.go
+++ b/http_test.go
@@ -276,7 +276,6 @@ func TestOkTraceHealthCheck(t *testing.T) {
 	config.TraceLightstepAccessToken = "farts"
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
-	HTTPAddrPort++
 
 	w := httptest.NewRecorder()
 
@@ -296,8 +295,6 @@ func TestNoTracingConfiguredTraceHealthCheck(t *testing.T) {
 	server.Start()
 	defer server.Shutdown()
 
-	HTTPAddrPort++
-
 	w := httptest.NewRecorder()
 
 	handler := server.Handler()
@@ -313,7 +310,6 @@ func TestBuildDate(t *testing.T) {
 	config.SsfListenAddresses = []string{}
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
-	HTTPAddrPort++
 
 	w := httptest.NewRecorder()
 
@@ -346,7 +342,6 @@ func TestVersion(t *testing.T) {
 	config.SsfListenAddresses = []string{}
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
-	HTTPAddrPort++
 
 	w := httptest.NewRecorder()
 
@@ -372,7 +367,6 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	config := localConfig()
 	s := setupVeneurServer(t, config, nil, nil, nil)
 	defer s.Shutdown()
-	HTTPAddrPort++
 
 	handler := handleImport(s)
 	handler.ServeHTTP(w, r)

--- a/networking_test.go
+++ b/networking_test.go
@@ -27,7 +27,7 @@ func TestMultipleListeners(t *testing.T) {
 	addr, ok := addrNet.(*net.UnixAddr)
 	require.True(t, ok)
 
-	done := startSSFUnix(srv, addr)
+	done, _ := startSSFUnix(srv, addr)
 	assert.Panics(t, func() {
 		srv2 := &Server{}
 		startSSFUnix(srv2, addr)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -91,7 +91,7 @@ func TestLocalFilePluginRegister(t *testing.T) {
 	config := globalConfig()
 	config.FlushFile = "/dev/null"
 
-	server, err := NewFromConfig(config)
+	server, err := NewFromConfig(logrus.New(), config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/samplers"
 )
@@ -91,7 +92,7 @@ func TestAllowStaticServices(t *testing.T) {
 	proxyConfig.ForwardAddress = "localhost:1234"
 	proxyConfig.TraceAddress = "localhost:1234"
 
-	server, error := NewProxyFromConfig(proxyConfig)
+	server, error := NewProxyFromConfig(logrus.New(), proxyConfig)
 	assert.NoError(t, error, "Should start with just static services")
 	assert.False(t, server.usingConsul, "Server isn't using consul")
 }
@@ -103,7 +104,7 @@ func TestMissingServices(t *testing.T) {
 	proxyConfig.ConsulForwardServiceName = ""
 	proxyConfig.ConsulTraceServiceName = ""
 
-	_, error := NewProxyFromConfig(proxyConfig)
+	_, error := NewProxyFromConfig(logrus.New(), proxyConfig)
 	assert.Error(t, error, "No consul services means Proxy won't start")
 }
 
@@ -112,7 +113,7 @@ func TestAcceptingBooleans(t *testing.T) {
 	proxyConfig.ConsulTraceServiceName = ""
 	proxyConfig.TraceAddress = ""
 
-	server, _ := NewProxyFromConfig(proxyConfig)
+	server, _ := NewProxyFromConfig(logrus.New(), proxyConfig)
 	assert.True(t, server.AcceptingForwards, "Server accepts forwards")
 	assert.False(t, server.AcceptingTraces, "Server does not forward traces")
 }
@@ -134,7 +135,7 @@ func TestConsistentForward(t *testing.T) {
 		t:  t,
 		wg: &wg,
 	}
-	server, _ := NewProxyFromConfig(proxyConfig)
+	server, _ := NewProxyFromConfig(logrus.New(), proxyConfig)
 
 	server.HTTPClient.Transport = transport
 	defer server.Shutdown()

--- a/server.go
+++ b/server.go
@@ -119,12 +119,15 @@ type Server struct {
 	traceBackend *internalTraceBackend
 }
 
-// NewFromConfig creates a new veneur server from a configuration specification.
-func NewFromConfig(conf Config) (*Server, error) {
-	return newFromConfig(log, conf)
+// SetLogger sets the default logger in veneur to the passed value.
+func SetLogger(logger *logrus.Logger) {
+	log = logger
 }
 
-func newFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
+// NewFromConfig creates a new veneur server from a configuration
+// specification and sets up the passed logger according to the
+// configuration.
+func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	ret := &Server{}
 
 	ret.Hostname = conf.Hostname

--- a/server.go
+++ b/server.go
@@ -535,17 +535,21 @@ func (s *Server) Start() {
 	}
 
 	// Read Metrics Forever!
+	concreteAddrs := make([]net.Addr, 0, len(s.StatsdListenAddrs))
 	for _, addr := range s.StatsdListenAddrs {
-		StartStatsd(s, addr, statsdPool)
+		concreteAddrs = append(concreteAddrs, StartStatsd(s, addr, statsdPool))
 	}
+	s.StatsdListenAddrs = concreteAddrs
 
 	// Read Traces Forever!
 	if len(s.SSFListenAddrs) > 0 {
+		concreteAddrs := make([]net.Addr, 0, len(s.StatsdListenAddrs))
 		for _, addr := range s.SSFListenAddrs {
-			StartSSF(s, addr, tracePool)
+			concreteAddrs = append(concreteAddrs, StartSSF(s, addr, tracePool))
 		}
+		s.SSFListenAddrs = concreteAddrs
 	} else {
-		logrus.Info("Tracing sockets are configured - not reading trace socket")
+		logrus.Info("Tracing sockets are not configured - not reading trace socket")
 	}
 
 	// Flush every Interval forever!

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -150,7 +150,7 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	server, err := NewFromConfig(config)
+	server, err := NewFromConfig(logrus.New(), config)
 
 	if err != nil {
 		t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -170,8 +170,6 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 	server.spanSinks = append(server.spanSinks, sSink)
 
 	server.Start()
-
-	go server.HTTPServe()
 	return server
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -129,7 +129,7 @@ func generateMetrics() (metricValues []float64, expectedMetrics map[string]float
 // so that flushes to these sinks do "nothing".
 func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink sinks.MetricSink, sSink sinks.SpanSink) *Server {
 	logger := logrus.New()
-	server, err := newFromConfig(logger, config)
+	server, err := NewFromConfig(logger, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,9 +478,10 @@ func readTestKeysCerts() (map[string]string, error) {
 // TestTCPConfig checks that invalid configurations are errors
 func TestTCPConfig(t *testing.T) {
 	config := localConfig()
+	logger := logrus.New()
 
 	config.StatsdListenAddresses = []string{"tcp://invalid:invalid"}
-	_, err := NewFromConfig(config)
+	_, err := NewFromConfig(logger, config)
 	if err == nil {
 		t.Error("invalid TCP address is a config error")
 	}
@@ -488,7 +489,7 @@ func TestTCPConfig(t *testing.T) {
 	config.StatsdListenAddresses = []string{"tcp://localhost:8129"}
 	config.TLSKey = "somekey"
 	config.TLSCertificate = ""
-	_, err = NewFromConfig(config)
+	_, err = NewFromConfig(logger, config)
 	if err == nil {
 		t.Error("key without certificate is a config error")
 	}
@@ -499,14 +500,14 @@ func TestTCPConfig(t *testing.T) {
 	}
 	config.TLSKey = pems["serverkey.pem"]
 	config.TLSCertificate = "somecert"
-	_, err = NewFromConfig(config)
+	_, err = NewFromConfig(logger, config)
 	if err == nil {
 		t.Error("invalid key and certificate is a config error")
 	}
 
 	config.TLSKey = pems["serverkey.pem"]
 	config.TLSCertificate = pems["servercert.pem"]
-	_, err = NewFromConfig(config)
+	_, err = NewFromConfig(logger, config)
 	if err != nil {
 		t.Error("expected valid config")
 	}
@@ -881,7 +882,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	s, err := NewFromConfig(config)
+	s, err := NewFromConfig(logrus.New(), config)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -943,7 +944,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	s, err := NewFromConfig(config)
+	s, err := NewFromConfig(logrus.New(), config)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -142,12 +142,13 @@ func generateMetrics() (metricValues []float64, expectedMetrics map[string]float
 // If no metricSink or spanSink are provided then a `black hole` sink be used
 // so that flushes to these sinks do "nothing".
 func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink sinks.MetricSink, sSink sinks.SpanSink) *Server {
-	server, err := NewFromConfig(config)
-	if transport != nil {
-		server.HTTPClient.Transport = transport
-	}
+	logger := logrus.New()
+	server, err := newFromConfig(logger, config)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if transport != nil {
+		server.HTTPClient.Transport = transport
 	}
 
 	if transport != nil {


### PR DESCRIPTION
#### Summary
This PR adds code to set up a veneur forwarding chain (local->proxy->global veneur), that should demonstrate that we can indeed ingest metrics and forward them across the network properly.

This PR also removes `HTTPAddrPort` and instead makes tests listen on `127.0.0.1:0` instead, then pull the concrete port from the listening socket (which guarantees us a free port, without having to make guesses).

#### Motivation
After #340, I was very worried that we don't have a proper forwarding/aggregation test that I could have used for this. Well, now we do (:

#### Test plan
This is the test plan ((:


#### Rollout/monitoring/revert plan
Just merge, I don't think this needs a changelog entry.
