### PR TITLE
SSF sample/metrics reporting functions for Traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
 * The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
+* Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)
+** Function `ssf.Sampled` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
+** Functional parameter `ssf.Prefix` that adjusts a metric's name prefix, and `ssf.DefaultSampleOptions`, allowing client code to set a common set of options for all samples reported (such as a common metric name prefix!).
+** Package `trace/metrics`, containing functions that allow reporting metrics through a trace client.
+** Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.
 
 # 2.0.0, 2018-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
 * The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
 * Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)
-** Function `ssf.Sampled` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
+** Function `ssf.RandomlySample` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
 ** New variable `ssf.NamePrefix` that can be used to prepend a common name prefix to SSF sample names.
 ** Package `trace/metrics`, containing functions that allow reporting metrics through a trace client.
 ** Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
 * Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)
 ** Function `ssf.Sampled` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
-** Functional parameter `ssf.Prefix` that adjusts a metric's name prefix, and `ssf.DefaultSampleOptions`, allowing client code to set a common set of options for all samples reported (such as a common metric name prefix!).
+** New variable `ssf.NamePrefix` that can be used to prepend a common name prefix to SSF sample names.
 ** Package `trace/metrics`, containing functions that allow reporting metrics through a trace client.
 ** Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.
 

--- a/server.go
+++ b/server.go
@@ -39,8 +39,8 @@ import (
 	"github.com/stripe/veneur/sinks/datadog"
 	"github.com/stripe/veneur/sinks/kafka"
 	"github.com/stripe/veneur/sinks/lightstep"
-	"github.com/stripe/veneur/sinks/metrics"
 	"github.com/stripe/veneur/sinks/signalfx"
+	"github.com/stripe/veneur/sinks/ssfmetrics"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
@@ -239,11 +239,11 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 
 	// Set up a span sink that extracts metrics from SSF spans and
 	// reports them via the metric workers:
-	processors := make([]metrics.Processor, len(ret.Workers))
+	processors := make([]ssfmetrics.Processor, len(ret.Workers))
 	for i, w := range ret.Workers {
 		processors[i] = w
 	}
-	metricSink, err := metrics.NewMetricExtractionSink(processors, conf.IndicatorSpanTimerName, ret.Statsd, log)
+	metricSink, err := ssfmetrics.NewMetricExtractionSink(processors, conf.IndicatorSpanTimerName, ret.Statsd, log)
 	if err != nil {
 		return ret, err
 	}

--- a/sinks/ssfmetrics/metrics.go
+++ b/sinks/ssfmetrics/metrics.go
@@ -1,5 +1,5 @@
-// Package metrics provides sinks that are used by veneur internally.
-package metrics
+// Package ssfmetrics provides sinks that are used by veneur internally.
+package ssfmetrics
 
 import (
 	"fmt"

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -1,4 +1,4 @@
-package metrics_test
+package ssfmetrics_test
 
 import (
 	"testing"
@@ -9,16 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur"
-	"github.com/stripe/veneur/sinks/metrics"
+	"github.com/stripe/veneur/sinks/ssfmetrics"
 	"github.com/stripe/veneur/ssf"
 )
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
-	workers := []metrics.Processor{worker}
+	workers := []ssfmetrics.Processor{worker}
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo", stats, logger)
+	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", stats, logger)
 	require.NoError(t, err)
 
 	start := time.Now()
@@ -57,9 +57,9 @@ func TestMetricExtractor(t *testing.T) {
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	worker := veneur.NewWorker(0, nil, logger)
-	workers := []metrics.Processor{worker}
+	workers := []ssfmetrics.Processor{worker}
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-	sink, err := metrics.NewMetricExtractionSink(workers, "foo", stats, logger)
+	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", stats, logger)
 	require.NoError(t, err)
 
 	start := time.Now()

--- a/ssf/doc.go
+++ b/ssf/doc.go
@@ -1,0 +1,13 @@
+/*
+
+Package ssf provides an implementation of the Sensor Sensibility
+Format. It consists of two parts: One is the protobuf implementations
+of the SSF data structures SSFSpan and SSFSample, and the other is a
+set of helper routines for generating SSFSamples that can be reported
+on an SSFSpan.
+
+The types in this package is meant to be used together with the
+neighboring packages trace and trace/metrics.
+
+*/
+package ssf

--- a/ssf/example_randomly_sample_test.go
+++ b/ssf/example_randomly_sample_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/stripe/veneur/trace/metrics"
 )
 
-func ExampleSampled() {
+func ExampleRandomlySample() {
 	// Sample some metrics at 50% - each of these metrics, if it
 	// gets picked, will report with a SampleRate of 0.5:
-	samples := ssf.Sampled(0.5,
+	samples := ssf.RandomlySample(0.5,
 		ssf.Count("cheap.counter", 1, nil),
 		ssf.Timing("cheap.timer", 1*time.Second, time.Nanosecond, nil),
 	)
 
 	// Sample another metric at 1% - if included, the metric will
 	// have a SampleRate of 0.01:
-	samples = append(samples, ssf.Sampled(0.01,
+	samples = append(samples, ssf.RandomlySample(0.01,
 		ssf.Count("expensive.counter", 20, nil))...)
 
 	// Report these metrics:

--- a/ssf/example_sampled_test.go
+++ b/ssf/example_sampled_test.go
@@ -1,0 +1,27 @@
+package ssf_test
+
+import (
+	"time"
+
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
+)
+
+func ExampleSampled() {
+	// Sample some metrics at 50% - each of these metrics, if it
+	// gets picked, will report with a SampleRate of 0.5:
+	samples := ssf.Sampled(0.5,
+		ssf.Count("cheap.counter", 1, nil),
+		ssf.Timing("cheap.timer", 1*time.Second, time.Nanosecond, nil),
+	)
+
+	// Sample another metric at 1% - if included, the metric will
+	// have a SampleRate of 0.01:
+	samples = append(samples, ssf.Sampled(0.01,
+		ssf.Count("expensive.counter", 20, nil))...)
+
+	// Report these metrics:
+	metrics.Report(trace.DefaultClient, samples)
+	// Output:
+}

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+// DefaultSampleOptions is a set of SampleOptions that get applied to
+// all samples created in this package, before the more specific
+// sample options get applied. These are convenient for setting metric
+// name prefixes or process-wide sample rates.
+var DefaultSampleOptions []SampleOption
+
 // SampleOption is a functional option that can be used for less
 // commonly needed fields in sample creation helper functions.
 type SampleOption func(*SSFSample)
@@ -64,6 +70,9 @@ func TimeUnit(resolution time.Duration) SampleOption {
 }
 
 func create(base *SSFSample, opts []SampleOption) *SSFSample {
+	for _, opt := range DefaultSampleOptions {
+		opt(base)
+	}
 	for _, opt := range opts {
 		opt(base)
 	}

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -89,11 +89,12 @@ func create(base *SSFSample, opts []SampleOption) *SSFSample {
 	return base
 }
 
-// Sampled takes a rate and a set of measurements, and returns them as
-// if sampling had been performed: Each measurement gets
-// rejected/included in the result based on a random roll of the RNG
-// according to the rate, and each measurement has its SampleRate
-// field adjusted to match the existing SampleRate * rate.
+// Sampled takes a rate and a set of measurements, and returns a new
+// set of measurements as if sampling had been performed: Each
+// original measurement gets rejected/included in the result based on
+// a random roll of the RNG according to the rate, and each included
+// measurement has its SampleRate field adjusted to be its original
+// SampleRate * rate.
 func Sampled(rate float32, samples ...*SSFSample) []*SSFSample {
 	res := make([]*SSFSample, 0, len(samples))
 

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -5,14 +5,16 @@ import (
 	"time"
 )
 
-// DefaultSampleOptions is a set of SampleOptions that get applied to
-// all samples created in this package, before the more specific
-// sample options get applied. These are convenient for setting metric
-// name prefixes or process-wide sample rates.
-var DefaultSampleOptions []SampleOption
+// NamePrefix is a string prepended to every SSFSample name generated
+// by the constructors in this package. As no separator is added
+// between this prefix and the metric name, users must take care to
+// attach any separators to the prefix themselves.
+var NamePrefix string
 
 // SampleOption is a functional option that can be used for less
-// commonly needed fields in sample creation helper functions.
+// commonly needed fields in sample creation helper functions. The
+// options are applied by order of arguments (left to right), so when
+// setting multiple of the same option, the rightmost wins.
 type SampleOption func(*SSFSample)
 
 // Unit is a functional option for creating an SSFSample. It sets the
@@ -69,20 +71,8 @@ func TimeUnit(resolution time.Duration) SampleOption {
 	}
 }
 
-// Prefix prepends the given prefix to a sample. Due to the
-// by-order-of-arguments nature of applying these arguments, if more
-// than one Prefix argument is given, the leftmost Prefix argument
-// will be the rightmost name component on the final name.
-func Prefix(prefix string) SampleOption {
-	return func(s *SSFSample) {
-		s.Name = prefix + s.Name
-	}
-}
-
 func create(base *SSFSample, opts []SampleOption) *SSFSample {
-	for _, opt := range DefaultSampleOptions {
-		opt(base)
-	}
+	base.Name = NamePrefix + base.Name
 	for _, opt := range opts {
 		opt(base)
 	}

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -79,13 +79,13 @@ func create(base *SSFSample, opts []SampleOption) *SSFSample {
 	return base
 }
 
-// Sampled takes a rate and a set of measurements, and returns a new
-// set of measurements as if sampling had been performed: Each
+// RandomlySample takes a rate and a set of measurements, and returns
+// a new set of measurements as if sampling had been performed: Each
 // original measurement gets rejected/included in the result based on
 // a random roll of the RNG according to the rate, and each included
 // measurement has its SampleRate field adjusted to be its original
 // SampleRate * rate.
-func Sampled(rate float32, samples ...*SSFSample) []*SSFSample {
+func RandomlySample(rate float32, samples ...*SSFSample) []*SSFSample {
 	res := make([]*SSFSample, 0, len(samples))
 
 	for _, s := range samples {

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -69,6 +69,16 @@ func TimeUnit(resolution time.Duration) SampleOption {
 	}
 }
 
+// Prefix prepends the given prefix to a sample. Due to the
+// by-order-of-arguments nature of applying these arguments, if more
+// than one Prefix argument is given, the leftmost Prefix argument
+// will be the rightmost name component on the final name.
+func Prefix(prefix string) SampleOption {
+	return func(s *SSFSample) {
+		s.Name = prefix + s.Name
+	}
+}
+
 func create(base *SSFSample, opts []SampleOption) *SSFSample {
 	for _, opt := range DefaultSampleOptions {
 		opt(base)

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -70,13 +70,6 @@ func TestOptions(t *testing.T) {
 				assert.Equal(t, then.UnixNano(), s.Timestamp)
 			},
 		},
-		{
-			"prefix",
-			Prefix("the_prefix."),
-			func(s *SSFSample) {
-				assert.Equal(t, "the_prefix.foo", s.Name)
-			},
-		},
 	}
 	for name, elt := range testFuns {
 		test := elt
@@ -90,6 +83,18 @@ func TestOptions(t *testing.T) {
 					opt.check(sample)
 				})
 			}
+		})
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	testFuns := map[string]constructor{"count": Count, "gauge": Gauge, "histogram": Histogram}
+	NamePrefix = "testing.the.prefix."
+	for name, elt := range testFuns {
+		test := elt
+		t.Run(fmt.Sprintf("%s", name), func(t *testing.T) {
+			sample := test("foo", 1, nil)
+			assert.Equal(t, "testing.the.prefix.foo", sample.Name)
 		})
 	}
 }

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -99,11 +99,11 @@ func TestPrefix(t *testing.T) {
 	}
 }
 
-func BenchmarkSampled(b *testing.B) {
+func BenchmarkRandomlySample(b *testing.B) {
 	samples := make([]*SSFSample, 1000000)
 	for i := range samples {
 		samples[i] = Count("testing.counter", float32(i), nil)
 	}
 	b.ResetTimer()
-	samples = Sampled(0.2, samples...)
+	samples = RandomlySample(0.2, samples...)
 }

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -70,6 +70,13 @@ func TestOptions(t *testing.T) {
 				assert.Equal(t, then.UnixNano(), s.Timestamp)
 			},
 		},
+		{
+			"prefix",
+			Prefix("the_prefix."),
+			func(s *SSFSample) {
+				assert.Equal(t, "the_prefix.foo", s.Name)
+			},
+		},
 	}
 	for name, elt := range testFuns {
 		test := elt

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -93,3 +93,12 @@ func TestOptions(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSampled(b *testing.B) {
+	samples := make([]*SSFSample, 1000000)
+	for i := range samples {
+		samples[i] = Count("testing.counter", float32(i), nil)
+	}
+	b.ResetTimer()
+	samples = Sampled(0.2, samples...)
+}

--- a/trace/example_metrics_on_a_span_test.go
+++ b/trace/example_metrics_on_a_span_test.go
@@ -1,0 +1,23 @@
+package trace_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+func ExampleTrace_Add() {
+	// Create a span for testing and ensure it gets reported:
+	span, _ := trace.StartSpanFromContext(context.Background(), "an_example")
+	defer span.Finish()
+
+	// Add a counter:
+	span.Add(ssf.Count("hey.there", 1, map[string]string{
+		"a.tag": "a value",
+	}))
+	// Add a timer:
+	span.Add(ssf.Timing("some.duration", 3*time.Millisecond, time.Nanosecond, nil))
+	// Output:
+}

--- a/trace/example_test.go
+++ b/trace/example_test.go
@@ -6,7 +6,7 @@ import (
 
 // This demonstrates how to switch out an existing
 // DefaultClient, closing the existing connection correctly.
-func ExampleConnect() {
+func ExampleNewClient() {
 	// Create the new client first (we'll create one that can send
 	// 20 span packets in parallel):
 	cl, err := trace.NewClient(trace.DefaultVeneurAddress, trace.Capacity(20))

--- a/trace/metrics/client.go
+++ b/trace/metrics/client.go
@@ -1,0 +1,28 @@
+// Package metrics provides routines for conveniently reporting
+// metrics attached to SSF spans.
+package metrics
+
+import (
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+// ReportAsync sends a batch of one-off metrics to a trace client
+// asynchronously. The channel done receives an error (or nil) when
+// the span containing the batch of metrics has been sent.
+func ReportAsync(cl *trace.Client, metrics []*ssf.SSFSample, done chan<- error) error {
+	span := &ssf.SSFSpan{Metrics: metrics}
+	return trace.Record(cl, span, done)
+}
+
+// Report sends a batch of one-off metrics to a trace client without
+// waiting for a reply.
+func Report(cl *trace.Client, metrics []*ssf.SSFSample) error {
+	return ReportAsync(cl, metrics, nil)
+}
+
+// ReportOne sends a single metric to a veneur using a trace client
+// without waiting for a reply.
+func ReportOne(cl *trace.Client, metric *ssf.SSFSample) error {
+	return ReportAsync(cl, []*ssf.SSFSample{metric}, nil)
+}

--- a/trace/metrics/example_report_async_test.go
+++ b/trace/metrics/example_report_async_test.go
@@ -1,0 +1,23 @@
+package metrics_test
+
+import (
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
+)
+
+func ExampleReportAsync() {
+	// Create a slice of metrics and report them in one batch at the end of the function:
+	samples := []*ssf.SSFSample{}
+
+	// Let's add some metrics to the batch:
+	samples = append(samples, ssf.Count("a.counter", 2, nil))
+	samples = append(samples, ssf.Gauge("a.gauge", 420, nil))
+
+	// report the batch:
+	done := make(chan error)
+	metrics.ReportAsync(trace.DefaultClient, samples, done)
+	// ... and wait for it to send:
+	<-done
+	// Output:
+}

--- a/trace/metrics/example_report_one_test.go
+++ b/trace/metrics/example_report_one_test.go
@@ -1,0 +1,14 @@
+package metrics_test
+
+import (
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
+)
+
+func ExampleReportOne() {
+	// Let's report a single metric (without any batching) using
+	// the default client:
+	metrics.ReportOne(trace.DefaultClient, ssf.Count("a.oneoff.counter", 1, nil))
+	// Output:
+}

--- a/trace/metrics/example_report_test.go
+++ b/trace/metrics/example_report_test.go
@@ -1,0 +1,19 @@
+package metrics_test
+
+import (
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
+)
+
+func ExampleReport() {
+	// Create a slice of metrics and report them in one batch at the end of the function:
+	samples := []*ssf.SSFSample{}
+	defer metrics.Report(trace.DefaultClient, samples)
+
+	// Let's add some metrics to the batch:
+	samples = append(samples, ssf.Count("a.counter", 2, nil))
+	samples = append(samples, ssf.Gauge("a.gauge", 420, nil))
+
+	// Output:
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -92,6 +92,10 @@ type Trace struct {
 	// error (or nil) when the span has been serialized and sent.
 	Sent chan<- error
 
+	// Samples holds a list of samples / metrics to be reported
+	// alongside a span.
+	Samples []*ssf.SSFSample
+
 	error bool
 }
 
@@ -154,9 +158,15 @@ func (t *Trace) SSFSpan() *ssf.SSFSpan {
 		Name:           name,
 		Tags:           t.Tags,
 		Service:        Service,
+		Metrics:        t.Samples,
 	}
 
 	return span
+}
+
+// Add adds a number of metrics/samples to a Trace.
+func (t *Trace) Add(samples ...*ssf.SSFSample) {
+	t.Samples = append(t.Samples, samples...)
 }
 
 // ProtoMarshalTo writes the Trace as a protocol buffer


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds the same stats reporting functions I added in #338, namely:

* package `trace/metrics`, providing some functions that report a metric directly through a trace client.
* method `.Add` on `trace.(*Trace)`, allowing users to directly add samples to a trace span from, e.g. `SpanFromContext`
* a function `ssf.Sampled` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates.
* a functional option `Prefix` and a `DefaultSampleOptions ` array of options applied to all samples created using the sample constructors in the `ssf` package.
* Loads of examples and docs for those.

As before, these functions reflect my way of thinking about the way we oughta handle metrics reporting:

* Metrics should be reported batched.
* As part of that (but also since it's a nice conceptual fit), metrics should be tied to a span if possible.
* Consequently, client usage of metrics should happen mostly in-memory (and deterministically) up until the point where they get reported - the IO for reporting the span should be the only place where you need to consider the possibility of error!

#### Motivation

See above for some parts of the motivation (performance, clarity of metrics client code), but also we've gotten requests for some more convenient way of reporting metrics with SSF, and I think this is it (:

#### Test plan
Wrote tests and examples that get run as tests!


#### Rollout/monitoring/revert plan

Merge this into the next veneur release!