### PR TITLE
Remove veneurlocalonly tag from Veneur's internal metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ** Datadog, Kafka, MetricExtraction, and SignalFx sinks now emits `sink.metrics_flushed_total` for metric flush counts and tag it with `sink`
 ** Datadog and LightStep sinks now emit `veneur.sink.span_flush_total_duration_ns` for span flush duration and tag it with `sink`
 ** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
+* Veneur's internal metrics are no longer tagged with `veneurlocalonly`. This means that percentile metrics (such as timers) will now be aggregated globally.
+
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/server.go
+++ b/server.go
@@ -179,7 +179,6 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		return ret, err
 	}
 	ret.Statsd.Namespace = "veneur."
-	ret.Statsd.Tags = append(ret.Tags, "veneurlocalonly")
 
 	// nil is a valid sentry client that noops all methods, if there is no DSN
 	// we can just leave it as nil


### PR DESCRIPTION
#### Summary

Remove `veneurlocalonly` magic tag from Veneur's internal metrics. This will cause percentile metrics, like timers, to be aggregated globally, instead of retaining the (high-cardinality) tags of the host they originate from.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe 
cc @stripe/observability 