### PR TITLE
Bump Veneur to Go 1.10rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,20 @@ ADD . /go/src/github.com/stripe/veneur
 # the last commit
 RUN git reset --hard HEAD && git status
 
+# After 1.9 hits stable, delete this section
+# It is only used for gofmt
+RUN wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+RUN tar -C /tmp -xvf go1.9.linux-amd64.tar.gz go/bin/gofmt
+RUN mv /tmp/go/bin/gofmt /go/bin/gofmt
+RUN rm go1.9.linux-amd64.tar.gz
+
 # Unlike the travis build file, we do NOT need to
 # ignore changes to protobuf-generated output
 # because we are guaranteed only one version of Go
 # used to build protoc-gen-go
 RUN go generate
 RUN dep ensure -v
+
 RUN gofmt -w .
 
 # Stage any changes caused by go generate and gofmt,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.10rc1-stretch
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Bumps our top-level Dockerfile to use Go 1.10rc1. This does *not* yet affect the version of Go used to build our public Docker images.

I probably will either not merge this or update this to use the non-RC version when that hits stable.

#### Motivation

The first release candidate of Go 1.10 is out!

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 