### PR TITLE
Disable Kafka sink in default config

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -207,7 +207,8 @@ trace_lightstep_num_clients: 1
 # == Kafka ==
 
 # Comma-delimited list of brokers suitable for Sarama's [NewAsyncProducer](https://godoc.org/github.com/Shopify/sarama#NewAsyncProducer)
-kafka_broker: "localhost:9092"
+# in the form hostname:port, such as localhost:9092
+kafka_broker: ""
 
 # Name of the topic we'll be publishing checks to
 kafka_check_topic: "veneur_checks"


### PR DESCRIPTION
#### Summary

Disable Kafka sink in the default configuration (example.yaml).

As it stands, this currently breaks the invariant that `example.yaml` provides safe defaults. With these settings, running the example configuration on a system without Kafka will cause a runtime panic.

I didn't really dig too far into the reason for the panic, except to confirm that it would be avoided by disabling the sink.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @joshu-stripe 
cc @stripe/observability 