### PR TITLE
Disable Datadog tracing by default

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -25,9 +25,6 @@ func TestReadConfig(t *testing.T) {
 	interval, err := c.ParseInterval()
 	assert.NoError(t, err)
 	assert.Equal(t, interval, 10*time.Second)
-
-	assert.Equal(t, "http://localhost:7777", c.DatadogTraceAPIAddress)
-
 }
 
 func TestReadBadConfig(t *testing.T) {

--- a/example.yaml
+++ b/example.yaml
@@ -162,7 +162,7 @@ datadog_api_hostname: https://app.datadoghq.com
 datadog_api_key: "farts"
 
 # Hostname to send Datadog trace data to.
-datadog_trace_api_address: "http://localhost:7777"
+datadog_trace_api_address: ""
 
 # == SignalFx ==
 # SignalFx can be a sink for metrics.


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

The default config assumes that Datadog tracing is being used, and it logs an error every 10 seconds otherwise. This is backwards; we should assume no tracing setup is being used.

There's an idiom for recording `localhost:7777` as the default if we really want to, but at the moment I'm just trying to clean up the configuration, and I don't think that's a yak we really need to shave.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @cory-stripe 
cc @stripe/observability 