### PR TITLE
Listen for HTTP traffic on all network interfaces

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -56,7 +56,7 @@ stats_address: "localhost:8126"
 
 # The address on which to listen for HTTP imports and/or healthchecks.
 # http_address: "einhorn@0"
-http_address: "localhost:8127"
+http_address: "0.0.0.0:8127"
 
 # The name of timer metrics that "indicator" spans should be tracked
 # under. If this is unset, veneur doesn't report an additional timer


### PR DESCRIPTION
#### Summary

The example config demonstrates using `localhost`, but this isn't actually what we want to recommend, because it will break in containerized workflows. Instead, we should default to listening on all available network interfaces.

We could replace all usages of `localhost` in the example file if we need to, but I believe this is the only one at the moment that will actively break with the current form.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 