### PR TITLE
Change Kafka sample configuration to use a float instead of an integer percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
-* The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
+* The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
 * Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)
 ** Function `ssf.RandomlySample` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
 ** New variable `ssf.NamePrefix` that can be used to prepend a common name prefix to SSF sample names.

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	KafkaSpanBufferFrequency      string    `yaml:"kafka_span_buffer_frequency"`
 	KafkaSpanBufferMesages        int       `yaml:"kafka_span_buffer_mesages"`
 	KafkaSpanRequireAcks          string    `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRatePercent    int       `yaml:"kafka_span_sample_rate_percent"`
+	KafkaSpanSampleRate           float64   `yaml:"kafka_span_sample_rate"`
 	KafkaSpanSampleTag            string    `yaml:"kafka_span_sample_tag"`
 	KafkaSpanSerializationFormat  string    `yaml:"kafka_span_serialization_format"`
 	KafkaSpanTopic                string    `yaml:"kafka_span_topic"`

--- a/example.yaml
+++ b/example.yaml
@@ -226,10 +226,8 @@ kafka_span_topic: "veneur_spans"
 # of traceID
 kafka_span_sample_tag: ""
 
-# Sample rate in percent (as an integer)
-# This should ideally be a floating point number, but at the time this was
-# written, gojson interpreted whole-number floats in yaml as integers.
-kafka_span_sample_rate_percent: 100
+# Sample rate in percent (as a floating-point number)
+kafka_span_sample_rate: 1.0
 
 kafka_metric_buffer_bytes: 0
 

--- a/example.yaml
+++ b/example.yaml
@@ -217,7 +217,7 @@ kafka_check_topic: "veneur_checks"
 kafka_event_topic: "veneur_events"
 
 # Name of the topic we'll be publishing metrics to
-kafka_metric_topic: ""
+kafka_metric_topic: "veneur_metrics"
 
 # Name of the topic we'll be publishing spans to
 kafka_span_topic: "veneur_spans"
@@ -226,7 +226,7 @@ kafka_span_topic: "veneur_spans"
 # of traceID
 kafka_span_sample_tag: ""
 
-# Sample rate in percent (as a floating-point number)
+# Kafka span sample rate ratio (must be > 0.0 and <= 1.0)
 kafka_span_sample_rate: 1.0
 
 kafka_metric_buffer_bytes: 0

--- a/server.go
+++ b/server.go
@@ -405,7 +405,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 				conf.KafkaPartitioner, conf.KafkaMetricRequireAcks, conf.KafkaRetryMax,
 				conf.KafkaSpanBufferBytes, conf.KafkaSpanBufferMesages,
 				conf.KafkaSpanBufferFrequency, conf.KafkaSpanSerializationFormat,
-				conf.KafkaSpanSampleTag, conf.KafkaSpanSampleRatePercent,
+				conf.KafkaSpanSampleTag, conf.KafkaSpanSampleRate,
 				ret.Statsd,
 			)
 			if err != nil {

--- a/sinks/kafka/README.md
+++ b/sinks/kafka/README.md
@@ -21,14 +21,14 @@ See the various `kafka_*` keys in [example.yaml](https://github.com/stripe/veneu
 
 ## Span Sampling
 
-The Kafka sink supports span sampling! By default, setting `kafka_span_sample_rate_percent`
-less than 100 will sample based off of traceId (meaning that if one span with a particular
+The Kafka sink supports span sampling! By default, setting `kafka_span_sample_rate`
+less than 1.0 will sample based off of traceId (meaning that if one span with a particular
 traceId is selected, all spans with that traceId will be selected), but that behavior
 can be configured to use a tag instead via `kafka_span_sample_tag`. For example,
 
 ```
 kafka_span_sample_tag: "request_id"
-kafka_span_sample_rate_percent: 75
+kafka_span_sample_rate: 0.75
 ```
 
 With this configuration, spans _without_ the `"request_id"` tag will be rejected,

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -209,7 +209,7 @@ func (k *KafkaMetricSink) FlushEventsChecks(ctx context.Context, events []sample
 }
 
 // NewKafkaSpanSink creates a new Kafka Plugin.
-func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, partitioner string, ackRequirement string, retries int, bufferBytes int, bufferMessages int, bufferDuration string, serializationFormat string, sampleTag string, sampleRatePercentage int, stats *statsd.Client) (*KafkaSpanSink, error) {
+func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, partitioner string, ackRequirement string, retries int, bufferBytes int, bufferMessages int, bufferDuration string, serializationFormat string, sampleTag string, sampleRate float64, stats *statsd.Client) (*KafkaSpanSink, error) {
 
 	if logger == nil {
 		logger = &logrus.Logger{Out: ioutil.Discard}
@@ -228,14 +228,14 @@ func NewKafkaSpanSink(logger *logrus.Logger, brokers string, topic string, parti
 	}
 
 	var sampleThreshold uint32
-	if sampleRatePercentage <= 0 || sampleRatePercentage > 100 {
-		return nil, errors.New("Span sample rate percentage must be greater than 0%% and less than or equal to 100%%")
+	if sampleRate <= 0 || sampleRate > 1.0 {
+		return nil, errors.New("Span sample rate percentage must be greater than 0 and less than or equal to 1.0")
 	}
 
 	// Set the sample threshold to (sample rate) * (maximum value of uint32), so that
 	// we can store it as a uint32 instead of a float64 and compare apples-to-apples
 	// with the output of our hashing algorithm.
-	sampleThreshold = uint32(sampleRatePercentage * math.MaxUint32 / 100)
+	sampleThreshold = uint32(sampleRate * math.MaxUint32)
 
 	var finalBufferDuration time.Duration
 	if bufferDuration != "" {

--- a/sinks/kafka/kafka_test.go
+++ b/sinks/kafka/kafka_test.go
@@ -188,15 +188,15 @@ func TestSpanInstantiateFailure(t *testing.T) {
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
 	// Busted duration
-	_, err := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "farts", "", "", 100, stats)
+	_, err := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "farts", "", "", 1.0, stats)
 	assert.Error(t, err)
 
 	// Missing topic
-	_, err2 := NewKafkaSpanSink(logger, "testing", "", "hash", "all", 1, 2, 3, "farts", "", "", 100, stats)
+	_, err2 := NewKafkaSpanSink(logger, "testing", "", "hash", "all", 1, 2, 3, "farts", "", "", 1.0, stats)
 	assert.Error(t, err2)
 
 	// Missing brokers
-	_, err3 := NewKafkaSpanSink(logger, "", "farts", "hash", "all", 1, 2, 3, "farts", "", "", 100, stats)
+	_, err3 := NewKafkaSpanSink(logger, "", "farts", "hash", "all", 1, 2, 3, "farts", "", "", 1.0, stats)
 	assert.Error(t, err3)
 
 	// Sampling rate set <= 0%
@@ -204,7 +204,7 @@ func TestSpanInstantiateFailure(t *testing.T) {
 	assert.Error(t, err4)
 
 	// Sampling rate set > 100%
-	_, err5 := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "10s", "", "", 101, stats)
+	_, err5 := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "10s", "", "", 1.01, stats)
 	assert.Error(t, err5)
 }
 
@@ -212,13 +212,13 @@ func TestSpanConstructorAck(t *testing.T) {
 	logger := logrus.StandardLogger()
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink1, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "none", 1, 2, 3, "10s", "", "", 100, stats)
+	sink1, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "none", 1, 2, 3, "10s", "", "", 1.0, stats)
 	assert.Equal(t, sarama.NoResponse, sink1.config.Producer.RequiredAcks, "ack did not set correctly")
 
-	sink2, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "local", 1, 2, 3, "10s", "", "", 100, stats)
+	sink2, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "local", 1, 2, 3, "10s", "", "", 1.0, stats)
 	assert.Equal(t, sarama.WaitForLocal, sink2.config.Producer.RequiredAcks, "ack did not set correctly")
 
-	sink3, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "random", "farts", 1, 2, 3, "10s", "", "", 100, stats)
+	sink3, _ := NewKafkaSpanSink(logger, "testing", "veneur_spans", "random", "farts", 1, 2, 3, "10s", "", "", 1.0, stats)
 	assert.Equal(t, sarama.WaitForAll, sink3.config.Producer.RequiredAcks, "ack did not default correctly")
 }
 
@@ -226,7 +226,7 @@ func TestSpanConstructor(t *testing.T) {
 	logger := logrus.StandardLogger()
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "10s", "", "foo", 100, stats)
+	sink, err := NewKafkaSpanSink(logger, "testing", "veneur_spans", "hash", "all", 1, 2, 3, "10s", "", "foo", 1.0, stats)
 	assert.NoError(t, err)
 	assert.Equal(t, "kafka", sink.Name())
 
@@ -257,7 +257,7 @@ func TestSpanTraceIdSampling(t *testing.T) {
 	logger.SetLevel(logrus.DebugLevel)
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "", 50, stats)
+	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "", 0.5, stats)
 	assert.NoError(t, err)
 
 	sink.producer = producerMock
@@ -318,7 +318,7 @@ func TestSpanTagSampling(t *testing.T) {
 	logger.SetLevel(logrus.DebugLevel)
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "baz", 50, stats)
+	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "baz", 0.5, stats)
 	assert.NoError(t, err)
 
 	sink.producer = producerMock
@@ -404,7 +404,7 @@ func TestBadDuration(t *testing.T) {
 	logger := logrus.StandardLogger()
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	_, err := NewKafkaSpanSink(logger, "testing", "", "hash", "all", 0, 0, 0, "pthbbbbbt", "", "", 100, stats)
+	_, err := NewKafkaSpanSink(logger, "testing", "", "hash", "all", 0, 0, 0, "pthbbbbbt", "", "", 1.0, stats)
 	assert.Error(t, err)
 }
 
@@ -421,7 +421,7 @@ func TestSpanFlushJson(t *testing.T) {
 	logger := logrus.StandardLogger()
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "", 100, stats)
+	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "json", "", 1.0, stats)
 	assert.NoError(t, err)
 
 	sink.producer = producerMock
@@ -465,7 +465,7 @@ func TestSpanFlushProtobuf(t *testing.T) {
 	logger := logrus.StandardLogger()
 	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "protobuf", "", 100, stats)
+	sink, err := NewKafkaSpanSink(logger, "testing", "testSpanTopic", "hash", "all", 0, 0, 0, "", "protobuf", "", 1.0, stats)
 	assert.NoError(t, err)
 
 	sink.producer = producerMock


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
- Changes the `kafka_span_sample_rate_percent` (integer) to be a `kafka_span_sample_rate` (float), and updates documentation to match.
<!-- Simple summary of what the code does or what you have changed. -->


#### Motivation
- limiting ourselves artificially to 1% as the lowest sampling rate seems unnecessary, and was a workaround while we waited for gojson’s handling of YAML to change.
<!-- Why are you making this change? -->


#### Test plan
Updated existing tests.
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

r? @cory-stripe 