### PR TITLE
Fix bugs in metrics-in-spans interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)
 * The Kafka sink for spans can now sample spans (at a rate determined by `kafka_span_sample_rate_percent`) based off of traceIDs (by default) or a tag's values (configurable via `kafka_span_sample_tag`) to consistently sample spans related to each other. Thanks, [rhwlo](https://github.com/rhwlo)!
-* Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)
+* Improvements in SSF metrics reporting - thanks, [antifuchs](https://github.com/antifuchs)!
 ** Function `ssf.RandomlySample` that takes an array of samples and a sample rate and randomly drops those samples, adjusting the kept samples' rates
 ** New variable `ssf.NamePrefix` that can be used to prepend a common name prefix to SSF sample names.
 ** Package `trace/metrics`, containing functions that allow reporting metrics through a trace client.
+** New type `ssf.Samples` holding a batch of samples which can be submitted conveniently through `trace/metrics`.
 ** Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.
 
 # 2.0.0, 2018-01-09

--- a/ssf/example_randomly_sample_test.go
+++ b/ssf/example_randomly_sample_test.go
@@ -9,16 +9,17 @@ import (
 )
 
 func ExampleRandomlySample() {
+	samples := &ssf.Samples{}
 	// Sample some metrics at 50% - each of these metrics, if it
 	// gets picked, will report with a SampleRate of 0.5:
-	samples := ssf.RandomlySample(0.5,
+	samples.Add(ssf.RandomlySample(0.5,
 		ssf.Count("cheap.counter", 1, nil),
 		ssf.Timing("cheap.timer", 1*time.Second, time.Nanosecond, nil),
-	)
+	)...)
 
 	// Sample another metric at 1% - if included, the metric will
 	// have a SampleRate of 0.01:
-	samples = append(samples, ssf.RandomlySample(0.01,
+	samples.Add(ssf.RandomlySample(0.01,
 		ssf.Count("expensive.counter", 20, nil))...)
 
 	// Report these metrics:

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+// Samples is a batch of SSFSamples, not attached to an SSF span, that
+// can be submitted with package metrics's Report function.
+type Samples struct {
+	Batch []*SSFSample
+}
+
+// Add appends a sample to the batch of samples.
+func (s *Samples) Add(sample ...*SSFSample) {
+	if s.Batch == nil {
+		s.Batch = []*SSFSample{}
+	}
+	s.Batch = append(s.Batch, sample...)
+}
+
 // NamePrefix is a string prepended to every SSFSample name generated
 // by the constructors in this package. As no separator is added
 // between this prefix and the metric name, users must take care to

--- a/trace/metrics/client.go
+++ b/trace/metrics/client.go
@@ -15,6 +15,20 @@ func (nm NoMetrics) Error() string {
 	return "No metrics to send."
 }
 
+// Report sends one-off metric samples encapsulated in a Samples
+// structure to a trace client without waiting for a reply.  If the
+// batch of metrics is empty, an error NoMetrics is returned.
+func Report(cl *trace.Client, samples *ssf.Samples) error {
+	return ReportBatch(cl, samples.Batch)
+}
+
+// ReportBatch sends a batch of one-off metrics to a trace client without
+// waiting for a reply.  If the batch of metrics is empty, an error
+// NoMetrics is returned.
+func ReportBatch(cl *trace.Client, samples []*ssf.SSFSample) error {
+	return ReportAsync(cl, samples, nil)
+}
+
 // ReportAsync sends a batch of one-off metrics to a trace client
 // asynchronously. The channel done receives an error (or nil) when
 // the span containing the batch of metrics has been sent.
@@ -22,18 +36,11 @@ func (nm NoMetrics) Error() string {
 // If metrics is empty, an error NoMetrics is returned and done does
 // not receive any data.
 func ReportAsync(cl *trace.Client, metrics []*ssf.SSFSample, done chan<- error) error {
-	if len(metrics) == 0 {
+	if metrics == nil || len(metrics) == 0 {
 		return NoMetrics{}
 	}
 	span := &ssf.SSFSpan{Metrics: metrics}
 	return trace.Record(cl, span, done)
-}
-
-// Report sends a batch of one-off metrics to a trace client without
-// waiting for a reply.  If metrics is empty, an error NoMetrics is
-// returned
-func Report(cl *trace.Client, metrics []*ssf.SSFSample) error {
-	return ReportAsync(cl, metrics, nil)
 }
 
 // ReportOne sends a single metric to a veneur using a trace client

--- a/trace/metrics/client.go
+++ b/trace/metrics/client.go
@@ -7,16 +7,31 @@ import (
 	"github.com/stripe/veneur/trace"
 )
 
+// NoMetrics indicates that no metrics were included in the batch of
+// metrics to submit.
+type NoMetrics struct{}
+
+func (nm NoMetrics) Error() string {
+	return "No metrics to send."
+}
+
 // ReportAsync sends a batch of one-off metrics to a trace client
 // asynchronously. The channel done receives an error (or nil) when
 // the span containing the batch of metrics has been sent.
+//
+// If metrics is empty, an error NoMetrics is returned and done does
+// not receive any data.
 func ReportAsync(cl *trace.Client, metrics []*ssf.SSFSample, done chan<- error) error {
+	if len(metrics) == 0 {
+		return NoMetrics{}
+	}
 	span := &ssf.SSFSpan{Metrics: metrics}
 	return trace.Record(cl, span, done)
 }
 
 // Report sends a batch of one-off metrics to a trace client without
-// waiting for a reply.
+// waiting for a reply.  If metrics is empty, an error NoMetrics is
+// returned
 func Report(cl *trace.Client, metrics []*ssf.SSFSample) error {
 	return ReportAsync(cl, metrics, nil)
 }

--- a/trace/metrics/client_test.go
+++ b/trace/metrics/client_test.go
@@ -1,0 +1,19 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+func TestEmptyMetrics(t *testing.T) {
+	err := Report(trace.DefaultClient, []*ssf.SSFSample{})
+	assert.Error(t, err)
+	assert.IsType(t, NoMetrics{}, err)
+
+	assert.Error(t, ReportAsync(trace.DefaultClient, []*ssf.SSFSample{}, nil))
+	assert.Error(t, err)
+	assert.IsType(t, NoMetrics{}, err)
+}

--- a/trace/metrics/client_test.go
+++ b/trace/metrics/client_test.go
@@ -1,19 +1,64 @@
 package metrics
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 )
 
 func TestEmptyMetrics(t *testing.T) {
-	err := Report(trace.DefaultClient, []*ssf.SSFSample{})
+	err := Report(trace.DefaultClient, &ssf.Samples{})
+	assert.Error(t, err)
+	assert.IsType(t, NoMetrics{}, err)
+
+	assert.Error(t, ReportBatch(trace.DefaultClient, []*ssf.SSFSample{}))
 	assert.Error(t, err)
 	assert.IsType(t, NoMetrics{}, err)
 
 	assert.Error(t, ReportAsync(trace.DefaultClient, []*ssf.SSFSample{}, nil))
 	assert.Error(t, err)
 	assert.IsType(t, NoMetrics{}, err)
+}
+
+type testBackend struct {
+	ch chan *ssf.SSFSpan
+}
+
+func (be *testBackend) Close() error {
+	return nil
+}
+
+func (be *testBackend) SendSync(ctx context.Context, span *ssf.SSFSpan) error {
+	be.ch <- span
+	return nil
+}
+
+func (be *testBackend) FlushSync(ctx context.Context) error {
+	return nil
+}
+
+func newClient(t *testing.T) (*trace.Client, chan *ssf.SSFSpan) {
+	ch := make(chan *ssf.SSFSpan, 1)
+	cl, err := trace.NewBackendClient(&testBackend{ch})
+	require.NoError(t, err)
+	return cl, ch
+}
+
+func TestDeferring(t *testing.T) {
+	client, ch := newClient(t)
+	defer func() {
+		span := <-ch
+		assert.Equal(t, 3, len(span.Metrics))
+	}()
+
+	samples := &ssf.Samples{}
+	defer Report(client, samples)
+
+	samples.Add(ssf.Count("foo", 1, nil))
+	samples.Add(ssf.Count("bar", 2, nil),
+		ssf.Gauge("baz", 3, nil))
 }

--- a/trace/metrics/example_report_test.go
+++ b/trace/metrics/example_report_test.go
@@ -8,12 +8,12 @@ import (
 
 func ExampleReport() {
 	// Create a slice of metrics and report them in one batch at the end of the function:
-	samples := []*ssf.SSFSample{}
+	samples := &ssf.Samples{}
 	defer metrics.Report(trace.DefaultClient, samples)
 
 	// Let's add some metrics to the batch:
-	samples = append(samples, ssf.Count("a.counter", 2, nil))
-	samples = append(samples, ssf.Gauge("a.gauge", 420, nil))
+	samples.Add(ssf.Count("a.counter", 2, nil))
+	samples.Add(ssf.Gauge("a.gauge", 420, nil))
 
 	// Output:
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -141,7 +141,7 @@ func (t *Trace) Duration() time.Duration {
 	return t.End.Sub(t.Start)
 }
 
-// SSFSample converts the Trace to an SSFSpan type.
+// SSFSpan converts the Trace to an SSFSpan type.
 // It sets the duration, so it assumes the span has already ended.
 // (It is safe to call on a span that has not ended, but the duration
 // field will be invalid)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR addresses some bugs that using #338 in a live environment raised:

* Sending an empty batch of metrics should not send a trace span through the client - since veneur internally reports metrics, this is a super classic case of write amplification.
* Adds a new wrapper struct `ssf.Samples` that allows easy batching of SSFSamples and, most importantly, sending them off with `defer` (because appending to a plain array changes the identity, and defer evaluates arguments early, this meant that metrics appended wouldn't be sent through the client... boo!)

#### Motivation
Bugs from rolling #338 out onto actual machines.


#### Test plan
Wrote tests for these two.


#### Rollout/monitoring/revert plan
Merge before #338.
