### PR TITLE
Count unique SSF span names by service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ** Datadog and LightStep sinks now emit `veneur.sink.span_flush_total_duration_ns` for span flush duration and tag it with `sink`
 ** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
 * Veneur's internal metrics are no longer tagged with `veneurlocalonly`. This means that percentile metrics (such as timers) will now be aggregated globally.
+* The `ssf.names_unique` metric counts the number of unique SSF span names per flush interval.
 
 ## Bugfixes
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!

--- a/server.go
+++ b/server.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -657,6 +658,11 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		log.WithError(err).Warn("ParseSSF")
 		return
 	}
+	setTags := []string{
+		fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
+		fmt.Sprintf("service:%s", span.Service),
+	}
+	s.Statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
 	s.handleSSF(span, []string{"ssf_format:packet"})
 }
 

--- a/server.go
+++ b/server.go
@@ -986,6 +986,11 @@ func (tb *internalTraceBackend) SendSync(ctx context.Context, span *ssf.SSFSpan)
 				fmt.Sprintf("service:%s", span.Service),
 				"ssf_format:internal",
 			}
+			setTags := []string{
+				fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
+				fmt.Sprintf("service:%s", span.Service),
+			}
+			tb.statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
 			tb.statsd.Incr("ssf.spans.received_total", tags, .1)
 			tb.statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
 		}

--- a/server.go
+++ b/server.go
@@ -658,11 +658,7 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		log.WithError(err).Warn("ParseSSF")
 		return
 	}
-	setTags := []string{
-		fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
-		fmt.Sprintf("service:%s", span.Service),
-	}
-	s.Statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
+	reportSpanName(s.Statsd, span)
 	s.handleSSF(span, []string{"ssf_format:packet"})
 }
 
@@ -986,12 +982,9 @@ func (tb *internalTraceBackend) SendSync(ctx context.Context, span *ssf.SSFSpan)
 				fmt.Sprintf("service:%s", span.Service),
 				"ssf_format:internal",
 			}
-			setTags := []string{
-				fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
-				fmt.Sprintf("service:%s", span.Service),
-			}
-			tb.statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
 			tb.statsd.Incr("ssf.spans.received_total", tags, .1)
+
+			reportSpanName(tb.statsd, span)
 			tb.statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
 		}
 		return nil
@@ -1013,4 +1006,14 @@ var _ trace.ClientBackend = &internalTraceBackend{}
 // multiple of `interval`, then adds `interval` back to find the "next" tick.
 func CalculateTickDelay(interval time.Duration, t time.Time) time.Duration {
 	return t.Truncate(interval).Add(interval).Sub(t)
+}
+
+func reportSpanName(statsd *statsd.Client, span *ssf.SSFSpan) {
+	setTags := []string{
+		fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
+		fmt.Sprintf("service:%s", span.Service),
+		fmt.Sprintf("root_span:%s", strconv.FormatBool(span.Id == span.TraceId)),
+	}
+
+	statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

Count the number of unique SSF span names that we receive each flush, by service.

This will help us understand the feasibility of autogenerating dashboards for span names.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 