### PR TITLE
Toggle plaintext option based on URL scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 ** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
 * Veneur's internal metrics are no longer tagged with `veneurlocalonly`. This means that percentile metrics (such as timers) will now be aggregated globally.
 
+## Bugfixes
+* LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -84,6 +84,11 @@ func NewLightStepSpanSink(collector string, reconnectPeriod string, maximumSpans
 
 	tracers := make([]opentracing.Tracer, 0, lightstepMultiplexTracerNum)
 
+	plaintext := false
+	if host.Scheme == "http" {
+		plaintext = true
+	}
+
 	for i := 0; i < lightstepMultiplexTracerNum; i++ {
 		tracers = append(tracers, lightstep.NewTracer(lightstep.Options{
 			AccessToken:     accessToken,
@@ -91,7 +96,7 @@ func NewLightStepSpanSink(collector string, reconnectPeriod string, maximumSpans
 			Collector: lightstep.Endpoint{
 				Host:      host.Hostname(),
 				Port:      port,
-				Plaintext: true,
+				Plaintext: plaintext,
 			},
 			UseGRPC:          true,
 			MaxBufferedSpans: maximumSpans,

--- a/sinks/lightstep/lightstep_test.go
+++ b/sinks/lightstep/lightstep_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/ssf"
@@ -96,6 +98,13 @@ func (tls *testLSSpan) LogEventWithPayload(event string, payload interface{}) {
 
 func (tls *testLSSpan) Log(data opentracing.LogData) {
 	panic("not implemented")
+}
+
+func TestLSSinkConstructor(t *testing.T) {
+
+	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
+	_, err := NewLightStepSpanSink("http://example.com", "5m", 1000, 1, "secret", stats, map[string]string{"foo": "bar"}, logrus.New())
+	assert.NoError(t, err)
 }
 
 func TestLSSpanSinkIngest(t *testing.T) {


### PR DESCRIPTION
#### Summary
Don't harcode plaintext for LS

#### Motivation
If you pass a https scheme URL, it should not be plaintext.

#### Test plan
I added a constructor test, but the tracers options are not exported, so I can't dig into them and find out if I got it right. To verify, I did some local printf debugging. :/

r? @asf-stripe 