### PR TITLE
Count the timeseries imported at the proxy per-host only

### DIFF
--- a/handlers_global.go
+++ b/handlers_global.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -31,7 +32,7 @@ func handleProxy(p *Proxy) http.Handler {
 		}
 		// the server usually waits for this to return before finalizing the
 		// response, so this part must be done asynchronously
-		go p.ProxyMetrics(span.Attach(ctx), jsonMetrics, r.RemoteAddr)
+		go p.ProxyMetrics(span.Attach(ctx), jsonMetrics, strings.SplitN(r.RemoteAddr, ":", 2)[0])
 	})
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -327,7 +327,10 @@ func (p *Proxy) ProxyMetrics(ctx context.Context, jsonMetrics []samplers.JSONMet
 	span, _ := trace.StartSpanFromContext(ctx, "veneur.opentracing.proxy.proxy_metrics")
 	defer span.ClientFinish(p.traceClient)
 
-	p.Statsd.Count("import.metrics_total", int64(len(jsonMetrics)), []string{"remote_addr:" + origin, "veneurglobalonly"}, 1.0)
+	p.Statsd.Count("import.metrics_total", int64(len(jsonMetrics)), []string{
+		"remote_addr:" + origin,
+		"veneurglobalonly",
+	}, 1.0)
 
 	jsonMetricsByDestination := make(map[string][]samplers.JSONMetric)
 	for _, h := range p.ForwardDestinations.Members() {


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary&motivation
The go http library returns host:port, of which port is very
useless. So let's strip the port away.

#### Test plan
We gotta run this /:

#### Rollout/monitoring/revert plan
Merge & deploy once we know the metric is of a shape we want.
