### PR TITLE
Add proxy option forward_timeout, use it in trace&metric forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ** Package `trace/metrics`, containing functions that allow reporting metrics through a trace client.
 ** New type `ssf.Samples` holding a batch of samples which can be submitted conveniently through `trace/metrics`.
 ** Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.
+* `veneur-proxy` has a new configuration option `forward_timeout` which allows specifying how long forwarding a batch to global veneur servers may take in total. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 2.0.0, 2018-01-09
 

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -7,6 +7,7 @@ type ProxyConfig struct {
 	Debug                    bool   `yaml:"debug"`
 	EnableProfiling          bool   `yaml:"enable_profiling"`
 	ForwardAddress           string `yaml:"forward_address"`
+	ForwardTimeout           string `yaml:"forward_timeout"`
 	HTTPAddress              string `yaml:"http_address"`
 	SentryDsn                string `yaml:"sentry_dsn"`
 	StatsAddress             string `yaml:"stats_address"`

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -14,6 +14,12 @@ forward_address: "http://veneur.example.com"
 # Or use a consul service for consistent forwarding.
 consul_forward_service_name: "forwardServiceName"
 
+# Maximum time that forwarding each batch of metrics can take;
+# note that forwarding to multiple global veneur servers happens in
+# parallel, so every forwarding operation is expected to complete
+# within this time.
+forward_timeout: 10s
+
 ### TRACING
 # The address on which we will listen for trace data
 trace_address: "127.0.0.1:8128"

--- a/http/http.go
+++ b/http/http.go
@@ -154,6 +154,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, stats *statsd.Clie
 	stats.Histogram(action+".content_length_bytes", float64(bodyLength), nil, 1.0)
 
 	req, err := http.NewRequest(http.MethodPost, endpoint, &bodyBuffer)
+	req = req.WithContext(ctx)
 
 	if err != nil {
 		stats.Count(action+".error_total", 1, []string{"cause:construct"}, 1.0)


### PR DESCRIPTION
#### Summary
This change allows veneur-proxy to notice when its forwards aren't making it across to global veneurs & provides operators some insight into whether metrics are being forwarded correctly in the face of tarpit-like network outages (where the upstream does not answer in time, or only a fraction of TCP packets makes it).

One thing to note here is that because we now set the request context to be the one passed to `PostHelper`, real-world posts might actually (correctly) fail with "deadline exceeded" if handlers that are async like the proxy's pass their request context through. Just one thing to be mindful of if we roll this out: It might cause errors.

#### Motivation

In a recent networking incident, we noticed that veneur-proxy holds on to its proxied metrics for far longer than is useful, and doesn't provide us with an idea that network connections are disrupted: If there's packet loss between the proxy and the global veneur servers, TCP connections will take a long time to complete. Due to the asynchronous nature of the proxying endpoint (it accepts metrics and then just tries to deliver them), it it experienced a tarpit scenario like that, its memory usage would grow until it OOM'ed (accepting more and more metrics that it could not forward to its upstreams in time to release that memory).

This isn't very useful behavior - veneur-proxy should instead allow a reasonable timeout (I imagine `n`*the local veneurs' metrics flush interval, possibly even `n=1` - this means a fleet of `m` nodes could send `m/n` hosts' metrics into a veneur-proxy fleet that is experiencing networking troubles).


#### Test plan
I wrote a test for this behavior.

Ultimately though, I think this will need a gameday with some iptables magic to have it drop TCP packets on qa global veneurs.

Also, I believe we'll have to make sure the context-threading change I made to PostHelper does not otherwise affect the rest of http POSTing.

#### Rollout/monitoring/revert plan
Merge & deploy the proxy service.
