### PR TITLE
Local veneur server: Add timeouts for forwarding, make events flushes parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.0, in development
+
+## Added
+* `veneur` has new configuration options `forward_timeout`, `metrics_flush_timeout`, and `span_flush_timeout`. They control how long veneur will allow for each flush operation to take and report an error if the flush takes longer than expected. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 # 5.0.0, 2018-05-17
 
 ## Added

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FlushFile                    string    `yaml:"flush_file"`
 	FlushMaxPerBody              int       `yaml:"flush_max_per_body"`
 	ForwardAddress               string    `yaml:"forward_address"`
+	ForwardTimeout               string    `yaml:"forward_timeout"`
 	Hostname                     string    `yaml:"hostname"`
 	HTTPAddress                  string    `yaml:"http_address"`
 	IndicatorSpanTimerName       string    `yaml:"indicator_span_timer_name"`
@@ -46,6 +47,7 @@ type Config struct {
 	LightstepNumClients          int       `yaml:"lightstep_num_clients"`
 	LightstepReconnectPeriod     string    `yaml:"lightstep_reconnect_period"`
 	MetricMaxLength              int       `yaml:"metric_max_length"`
+	MetricsFlushTimeout          string    `yaml:"metrics_flush_timeout"`
 	MutexProfileFraction         int       `yaml:"mutex_profile_fraction"`
 	NumReaders                   int       `yaml:"num_readers"`
 	NumSpanWorkers               int       `yaml:"num_span_workers"`
@@ -63,6 +65,7 @@ type Config struct {
 	} `yaml:"signalfx_per_tag_api_keys"`
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
+	SpanFlushTimeout              string   `yaml:"span_flush_timeout"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string   `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -162,6 +162,24 @@ trace_max_length_bytes: 16384
 # you think Veneur needs more room to keep up with all packets.
 read_buffer_size_bytes: 2097152
 
+# Time out forwarding metrics to a global veneur and report an error
+# after this much time has elapsed. If you run veneur-proxy servers,
+# the forward_timeout on veneur servers should be slightly longer than
+# the proxies', to avoid duplicate errors for the same issue being
+# reported.
+forward_timeout: "15s"
+
+# Time out and report an error if flushing all metric sinks to storage
+# (this happens in parallel) does not complete before this time has
+# elapsed.
+metrics_flush_timeout: "10s"
+
+# Time out and report an error if flushing span sinks does not
+# complete in this time.
+span_flush_timeout: "10s"
+
+
+
 # == DIAGNOSTICS ==
 
 # Sets the log level to DEBUG

--- a/flusher.go
+++ b/flusher.go
@@ -20,6 +20,26 @@ import (
 	"github.com/stripe/veneur/trace/metrics"
 )
 
+func (s *Server) flushMetricSinks(ctx context.Context, finalMetrics []samplers.InterMetric) {
+	if s.MetricFlushTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, s.MetricFlushTimeout)
+		defer cancel()
+	}
+	wg := sync.WaitGroup{}
+	for _, sink := range s.metricSinks {
+		wg.Add(1)
+		go func(ms sinks.MetricSink) {
+			err := ms.Flush(ctx, finalMetrics)
+			if err != nil {
+				log.WithError(err).WithField("sink", ms.Name()).Warn("Error flushing sink")
+			}
+			wg.Done()
+		}(sink)
+	}
+	wg.Wait()
+}
+
 // Flush collects sampler's metrics and passes them to sinks.
 func (s *Server) Flush(ctx context.Context) {
 	span := tracer.StartSpan("flush").(*trace.Span)
@@ -72,18 +92,7 @@ func (s *Server) Flush(ctx context.Context) {
 		return
 	}
 
-	wg := sync.WaitGroup{}
-	for _, sink := range s.metricSinks {
-		wg.Add(1)
-		go func(ms sinks.MetricSink) {
-			err := ms.Flush(span.Attach(ctx), finalMetrics)
-			if err != nil {
-				log.WithError(err).WithField("sink", ms.Name()).Warn("Error flushing sink")
-			}
-			wg.Done()
-		}(sink)
-	}
-	wg.Wait()
+	s.flushMetricSinks(span.Attach(ctx), finalMetrics)
 
 	go func() {
 		samples := &ssf.Samples{}
@@ -283,6 +292,12 @@ func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
 }
 
 func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
+	if s.ForwardTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, s.ForwardTimeout)
+		defer cancel()
+	}
+
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.ClientFinish(s.TraceClient)
 	jmLength := 0
@@ -378,6 +393,11 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 }
 
 func (s *Server) flushTraces(ctx context.Context) {
+	if s.SpanFlushTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, s.SpanFlushTimeout)
+		defer cancel()
+	}
 	s.ssfInternalMetrics.Range(func(keyI, valueI interface{}) bool {
 		key, ok := keyI.(string)
 		if !ok {
@@ -410,5 +430,5 @@ func (s *Server) flushTraces(ctx context.Context) {
 		return true
 	})
 
-	s.SpanWorker.Flush()
+	s.SpanWorker.Flush(ctx)
 }

--- a/flusher.go
+++ b/flusher.go
@@ -40,6 +40,25 @@ func (s *Server) flushMetricSinks(ctx context.Context, finalMetrics []samplers.I
 	wg.Wait()
 }
 
+func (s *Server) flushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
+	span := tracer.StartSpan("flushOtherSamples").(*trace.Span)
+	defer span.ClientFinish(s.TraceClient)
+	if s.MetricFlushTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, s.MetricFlushTimeout)
+		defer cancel()
+	}
+	wg := sync.WaitGroup{}
+	for _, sink := range s.metricSinks {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			sink.FlushOtherSamples(span.Attach(ctx), samples)
+			wg.Done()
+		}(&wg)
+	}
+	wg.Wait()
+}
+
 // Flush collects sampler's metrics and passes them to sinks.
 func (s *Server) Flush(ctx context.Context) {
 	span := tracer.StartSpan("flush").(*trace.Span)
@@ -57,12 +76,7 @@ func (s *Server) Flush(ctx context.Context) {
 	s.Statsd.Gauge("gc.mallocs_objects_total", float64(mem.Mallocs), nil, 1.0)
 	s.Statsd.Gauge("mem.heap_alloc_bytes", float64(mem.HeapAlloc), nil, 1.0)
 
-	samples := s.EventWorker.Flush()
-
-	// TODO Concurrency
-	for _, sink := range s.metricSinks {
-		sink.FlushOtherSamples(span.Attach(ctx), samples)
-	}
+	s.flushOtherSamples(span.Attach(ctx), s.EventWorker.Flush())
 
 	go s.flushTraces(span.Attach(ctx))
 

--- a/proxysrv/server_test.go
+++ b/proxysrv/server_test.go
@@ -75,7 +75,7 @@ func TestUnreachableDestinations(t *testing.T) {
 	ring.Add("not-a-real-host:9001")
 	ring.Add("another-bad-host:9001")
 
-	server := newServer(t, ring)
+	server := newServer(t, ring, WithForwardTimeout(1*time.Millisecond))
 	err := server.sendMetrics(context.Background(),
 		&forwardrpc.MetricList{metrictest.RandomForwardMetrics(10)})
 	assert.Error(t, err, "sendMetrics should have returned an error when all "+

--- a/sinks/blackhole/blackhole.go
+++ b/sinks/blackhole/blackhole.go
@@ -62,6 +62,6 @@ func (b *blackholeSpanSink) Ingest(*ssf.SSFSpan) error {
 	return nil
 }
 
-func (b *blackholeSpanSink) Flush() {
+func (b *blackholeSpanSink) Flush(context.Context) {
 	return
 }

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -417,3 +417,35 @@ func TestDatadogFlushServiceCheck(t *testing.T) {
 	assert.Subset(t, ddFixtureCheck.Tags, ddChecks[0].Tags, "Check posted to DD does not have matching tags")
 
 }
+
+func TestTimeoutsOnMetrics(t *testing.T) {
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	srv, rcved := ddTestServer(t, "/api/v1/series", "never.actually.acked")
+	defer close(rcved)
+
+	ddSink := DatadogMetricSink{
+		DDHostname:      srv.URL,
+		HTTPClient:      client,
+		flushMaxPerBody: 15,
+		log:             logrus.New(),
+		tags:            []string{"a:b", "c:d"},
+		interval:        10,
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
+	defer cancel()
+
+	// A failure to consider the context should result in a test
+	// timeout:
+	ddSink.Flush(ctx, []samplers.InterMetric{
+		samplers.InterMetric{
+			Name:      "never.actually.acked",
+			Timestamp: time.Now().Unix(),
+			Value:     float64(10),
+			Tags:      []string{"gorch:frobble", "x:e"},
+			Type:      samplers.CounterMetric,
+			Sinks:     samplers.RouteInformation{},
+		},
+	})
+}

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -187,7 +187,7 @@ func TestDatadogFlushSpans(t *testing.T) {
 	err = ddSink.Ingest(testSpan)
 	assert.NoError(t, err)
 
-	ddSink.Flush()
+	ddSink.Flush(context.TODO())
 	assert.Equal(t, true, transport.GotCalled, "Did not call spans endpoint")
 }
 

--- a/sinks/grpsink/grpsink.go
+++ b/sinks/grpsink/grpsink.go
@@ -137,10 +137,7 @@ func (gs *GRPCSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 
 // Flush reports total counts of the number of sent and dropped spans since the
 // last flush.
-//
-// No data is sent to the target sink by this call, as this sink dispatches all
-// spans directly via gRPC during Ingest().
-func (gs *GRPCSpanSink) Flush() {
+func (gs *GRPCSpanSink) Flush(ctx context.Context) {
 	samples := &ssf.Samples{}
 	samples.Add(
 		ssf.Count(

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -385,7 +385,7 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 
 // Flush emits metrics, since the spans have already been ingested and are
 // sending async.
-func (k *KafkaSpanSink) Flush() {
+func (k *KafkaSpanSink) Flush(context.Context) {
 	// TODO We have no stuff in here for detecting failed writes from the async
 	// producer. We should add that.
 	metrics.ReportOne(k.traceClient, ssf.Count(sinks.MetricKeyTotalSpansFlushed, float32(atomic.LoadInt64(&k.spansFlushed)), map[string]string{"sink": k.Name()}))

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -1,6 +1,7 @@
 package lightstep
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -202,7 +203,7 @@ func (ls *LightStepSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 
 // Flush doesn't need to do anything to the LS tracer, so we emit metrics
 // instead.
-func (ls *LightStepSpanSink) Flush() {
+func (ls *LightStepSpanSink) Flush(context.Context) {
 	ls.mutex.Lock()
 	defer ls.mutex.Unlock()
 

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -93,5 +93,5 @@ type SpanSink interface {
 
 	// Invoked at the same interval as metric flushes, this can be used as a
 	// signal for the sink to write out if it was buffering or something.
-	Flush()
+	Flush(context.Context)
 }

--- a/sinks/ssfmetrics/metrics.go
+++ b/sinks/ssfmetrics/metrics.go
@@ -2,6 +2,7 @@
 package ssfmetrics
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -135,7 +136,7 @@ func (m *metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 	return nil
 }
 
-func (m *metricExtractionSink) Flush() {
+func (m *metricExtractionSink) Flush(context.Context) {
 	tags := map[string]string{"sink": m.Name()}
 	metrics.ReportBatch(m.traceClient, []*ssf.SSFSample{
 		ssf.Count(sinks.MetricKeyTotalSpansFlushed, float32(atomic.SwapInt64(&m.spansProcessed, 0)), tags),

--- a/worker.go
+++ b/worker.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -477,7 +478,7 @@ func (tw *SpanWorker) Work() {
 }
 
 // Flush invokes flush on each sink.
-func (tw *SpanWorker) Flush() {
+func (tw *SpanWorker) Flush(ctx context.Context) {
 	samples := &ssf.Samples{}
 
 	// Flush and time each sink.
@@ -487,9 +488,9 @@ func (tw *SpanWorker) Flush() {
 			tags = append(tags, fmt.Sprintf("%s:%s", k, v))
 		}
 		sinkFlushStart := time.Now()
-		s.Flush()
-		tw.statsd.Timing("worker.span.flush_duration_ns", time.Since(sinkFlushStart), tags, 1.0)
 
+		s.Flush(ctx)
+		tw.statsd.Timing("worker.span.flush_duration_ns", time.Since(sinkFlushStart), tags, 1.0)
 		// cumulative time is measured in nanoseconds
 		cumulative := time.Duration(atomic.SwapInt64(&tw.cumulativeTimes[i], 0)) * time.Nanosecond
 		tw.statsd.Timing(sinks.MetricKeySpanIngestDuration, cumulative, tags, 1.0)

--- a/worker_test.go
+++ b/worker_test.go
@@ -241,7 +241,7 @@ type fakeSpanSink struct {
 
 func (s *fakeSpanSink) Start(*trace.Client) error { return nil }
 func (s *fakeSpanSink) Name() string              { return "fake" }
-func (s *fakeSpanSink) Flush()                    {}
+func (s *fakeSpanSink) Flush(_ context.Context)   {}
 func (s *fakeSpanSink) latestSpan() *ssf.SSFSpan  { return s.spans[len(s.spans)-1] }
 func (s *fakeSpanSink) Ingest(span *ssf.SSFSpan) error {
 	s.spans = append(s.spans, span)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds config options `forward_timeout`, `metrics_flush_timeout` and `span_flush_timeout`, controlling timeouts for each of these operations. This should help veneur avoid scenarios where an inability to quickly send metric batches (either upstream or to ~any of its storage backends) causes it to accumulate spans/metrics in memory and OOM the machine.

#### Motivation
Setting timeouts is good!


#### Test plan
Added regression tests, but we should also test this in a live system to ensure it actually errors in these cases.


#### Rollout/monitoring/revert plan
Merge & run!
