### PR TITLE
Passing intervals to s3 and localfile plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ## Bugfixes
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!
+* S3 bucket name was hardcoded, now uses the configuration setting. Thanks, [andreiko](https://github.com/andreiko)!
+* S3 and localfile plugins were reporting all count metrics as +Inf due to zero interval. Thanks, [andreiko](https://github.com/andreiko)! 
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/plugins/localfile/localfile.go
+++ b/plugins/localfile/localfile.go
@@ -22,7 +22,7 @@ type Plugin struct {
 	FilePath string
 	Logger   *logrus.Logger
 	hostname string
-	interval int
+	Interval float64
 }
 
 // Delimiter defines what kind of delimiter we'll use in the CSV format -- in this case, we want TSV
@@ -36,11 +36,11 @@ func (p *Plugin) Flush(ctx context.Context, metrics []samplers.InterMetric) erro
 	if err != nil {
 		return fmt.Errorf("couldn't open %s for appending: %s", p.FilePath, err)
 	}
-	appendToWriter(f, metrics, p.hostname, p.interval)
+	appendToWriter(f, metrics, p.hostname, p.Interval)
 	return nil
 }
 
-func appendToWriter(appender io.Writer, metrics []samplers.InterMetric, hostname string, interval int) error {
+func appendToWriter(appender io.Writer, metrics []samplers.InterMetric, hostname string, interval float64) error {
 	gzW := gzip.NewWriter(appender)
 	csvW := csv.NewWriter(gzW)
 	csvW.Comma = Delimiter

--- a/plugins/s3/csv.go
+++ b/plugins/s3/csv.go
@@ -53,7 +53,7 @@ var tsvSchema = [...]string{
 // The caller is responsible for setting w.Comma as the appropriate delimiter.
 // For performance, encodeCSV does not flush after every call; the caller is
 // expected to flush at the end of the operation cycle
-func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *time.Time, hostName string, interval int) error {
+func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *time.Time, hostName string, interval float64) error {
 	// TODO(aditya) some better error handling for this
 	// to guarantee that the result is proper JSON
 	tags := "{" + strings.Join(d.Tags, ",") + "}"
@@ -62,7 +62,7 @@ func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *
 	metricValue := d.Value
 	switch d.Type {
 	case samplers.CounterMetric:
-		metricValue = d.Value / float64(interval)
+		metricValue = d.Value / interval
 		metricType = "rate"
 
 	case samplers.GaugeMetric:
@@ -77,7 +77,7 @@ func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *
 		TsvName:           d.Name,
 		TsvTags:           tags,
 		TsvMetricType:     metricType,
-		TsvInterval:       strconv.Itoa(interval),
+		TsvInterval:       strconv.FormatFloat(interval, 'f', -1, 64),
 		TsvVeneurHostname: hostName,
 		TsvValue:          strconv.FormatFloat(metricValue, 'f', -1, 64),
 

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -29,7 +29,7 @@ type S3Plugin struct {
 	Svc      s3iface.S3API
 	S3Bucket string
 	Hostname string
-	Interval int
+	Interval float64
 }
 
 func (p *S3Plugin) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
@@ -71,8 +71,6 @@ const (
 	tsvGzFt          = "tsv.gz"
 )
 
-var S3Bucket = "stripe-veneur"
-
 var S3ClientUninitializedError = errors.New("s3 client has not been initialized")
 
 func (p *S3Plugin) S3Post(hostname string, data io.ReadSeeker, ft filetype) error {
@@ -80,7 +78,7 @@ func (p *S3Plugin) S3Post(hostname string, data io.ReadSeeker, ft filetype) erro
 		return S3ClientUninitializedError
 	}
 	params := &s3.PutObjectInput{
-		Bucket: aws.String(S3Bucket),
+		Bucket: aws.String(p.S3Bucket),
 		Key:    S3Path(hostname, ft),
 		Body:   data,
 	}
@@ -98,7 +96,7 @@ func S3Path(hostname string, ft filetype) *string {
 // EncodeInterMetricsCSV returns a reader containing the gzipped CSV representation of the
 // InterMetric data, one row per InterMetric.
 // the AWS sdk requires seekable input, so we return a ReadSeeker here
-func EncodeInterMetricsCSV(metrics []samplers.InterMetric, delimiter rune, includeHeaders bool, hostname string, interval int) (io.ReadSeeker, error) {
+func EncodeInterMetricsCSV(metrics []samplers.InterMetric, delimiter rune, includeHeaders bool, hostname string, interval float64) (io.ReadSeeker, error) {
 	b := &bytes.Buffer{}
 	gzw := gzip.NewWriter(b)
 	w := csv.NewWriter(gzw)

--- a/plugins/s3/s3_test.go
+++ b/plugins/s3/s3_test.go
@@ -23,7 +23,7 @@ const DefaultServerTimeout = 100 * time.Millisecond
 
 var log = logrus.New()
 
-const S3TestBucket = "stripe-test-veneur"
+const s3TestBucket = "stripe-test-veneur"
 
 // stubS3 sets svc to a s3Mock.MockS3Client that will return 200 for all responses
 // useful for avoiding erroneous error log lines when testing things that aren't
@@ -58,6 +58,7 @@ func TestS3Post(t *testing.T) {
 	defer f.Close()
 
 	client.SetPutObject(func(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+		assert.Equal(t, s3TestBucket, *input.Bucket)
 		// The data should be a gzipped TSV
 		gzr, err := gzip.NewReader(input.Body)
 		assert.NoError(t, err)
@@ -72,7 +73,7 @@ func TestS3Post(t *testing.T) {
 		return &s3.PutObjectOutput{ETag: aws.String("912ec803b2ce49e4a541068d495ab570")}, nil
 	})
 
-	s3p := &S3Plugin{Logger: log, Svc: client}
+	s3p := &S3Plugin{Logger: log, Svc: client, S3Bucket: s3TestBucket}
 
 	err = s3p.S3Post("testbox", f, tsvFt)
 	assert.NoError(t, err)

--- a/server.go
+++ b/server.go
@@ -442,6 +442,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 				Svc:      svc,
 				S3Bucket: conf.AwsS3Bucket,
 				Hostname: ret.Hostname,
+				Interval: ret.interval.Seconds(),
 			}
 			ret.registerPlugin(plugin)
 		}
@@ -459,6 +460,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		localFilePlugin := &localfilep.Plugin{
 			FilePath: conf.FlushFile,
 			Logger:   log,
+			Interval: ret.interval.Seconds(),
 		}
 		ret.registerPlugin(localFilePlugin)
 		logger.Info(fmt.Sprintf("Local file logging to %s", conf.FlushFile))


### PR DESCRIPTION
#### Summary
Fixed 2 bugs affecting S3 and localfile plugins:
- S3 plugin was using a hard-coded bucket name
- Both plugins didn't receive an interval value which was leading to division by zero and reporting all counter metrics as `+Inf`

#### Motivation
To fix the S3 plugin which is currently broken

#### Test plan
Modified a test to verify that a configured bucket name is used in S3Post()
