### PR TITLE
Revert "Count unique SSF span names by service"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 ** Datadog and LightStep sinks now emit `veneur.sink.span_flush_total_duration_ns` for span flush duration and tag it with `sink`
 ** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
 * Veneur's internal metrics are no longer tagged with `veneurlocalonly`. This means that percentile metrics (such as timers) will now be aggregated globally.
-* The `ssf.names_unique` metric counts the number of unique SSF span names per flush interval.
 
 ## Bugfixes
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -658,7 +657,6 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		log.WithError(err).Warn("ParseSSF")
 		return
 	}
-	reportSpanName(s.Statsd, span)
 	s.handleSSF(span, []string{"ssf_format:packet"})
 }
 
@@ -983,8 +981,6 @@ func (tb *internalTraceBackend) SendSync(ctx context.Context, span *ssf.SSFSpan)
 				"ssf_format:internal",
 			}
 			tb.statsd.Incr("ssf.spans.received_total", tags, .1)
-
-			reportSpanName(tb.statsd, span)
 			tb.statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
 		}
 		return nil
@@ -1006,14 +1002,4 @@ var _ trace.ClientBackend = &internalTraceBackend{}
 // multiple of `interval`, then adds `interval` back to find the "next" tick.
 func CalculateTickDelay(interval time.Duration, t time.Time) time.Duration {
 	return t.Truncate(interval).Add(interval).Sub(t)
-}
-
-func reportSpanName(statsd *statsd.Client, span *ssf.SSFSpan) {
-	setTags := []string{
-		fmt.Sprintf("indicator:%s", strconv.FormatBool(span.Indicator)),
-		fmt.Sprintf("service:%s", span.Service),
-		fmt.Sprintf("root_span:%s", strconv.FormatBool(span.Id == span.TraceId)),
-	}
-
-	statsd.Set("ssf.names_unique", span.Name, setTags, 0.1)
 }


### PR DESCRIPTION
Reverts stripe/veneur#371.


This generates too much UDP traffic at the moment, so we'll revert it until we switch to using the internal, domain-socket-based client.


r? @joshu-stripe 
cc @stripe/observability 