### PR TITLE
Update dependency axiomhq/hyperloglog for threadsafe initialization

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,10 +50,9 @@
   version = "v1.10.17"
 
 [[projects]]
-  branch = "master"
   name = "github.com/axiomhq/hyperloglog"
   packages = ["."]
-  revision = "67c63c1769669ed114425d82cc7a91af4ce24f8b"
+  revision = "8300947202c9fbce15a5a299b27c8b0f5092a520"
 
 [[projects]]
   name = "github.com/certifi/gocertifi"
@@ -71,7 +70,7 @@
   branch = "master"
   name = "github.com/dgryski/go-bits"
   packages = ["."]
-  revision = "2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef"
+  revision = "bd8a69a71dc203aa976f9d918b428db9ac605f57"
 
 [[projects]]
   branch = "master"
@@ -419,6 +418,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "49121eeb9b7987b7822c95f96d7504350bdd2b35cc93cbedece9487057620e09"
+  inputs-digest = "fbda2ecf429907b688360535a87949393e5e6ab91b3d4ea4ef684519eb74709c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,8 +37,8 @@
   version = "1.10.16"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/clarkduvall/hyperloglog"
+  name = "github.com/axiomhq/hyperloglog"
+  revision = "8300947202c9fbce15a5a299b27c8b0f5092a520"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/axiomhq/hyperloglog/hyperloglog.go
+++ b/vendor/github.com/axiomhq/hyperloglog/hyperloglog.go
@@ -41,13 +41,12 @@ func New14() *Sketch {
 
 //New16 returns a HyperLogLog Sketch with 2^16 registers (precision 16)
 func New16() *Sketch {
-	sk, _ := new(14)
+	sk, _ := new(16)
 	return sk
 }
 
 // New returns a HyperLogLog Sketch with 2^precision registers
 func new(precision uint8) (*Sketch, error) {
-	hash = hashFunc
 	if precision < 4 || precision > 18 {
 		return nil, fmt.Errorf("p has to be >= 4 and <= 18")
 	}
@@ -185,6 +184,11 @@ func (sk *Sketch) insert(i uint32, r uint8) {
 // Insert adds element e to sketch
 func (sk *Sketch) Insert(e []byte) {
 	x := hash(e)
+	sk.InsertHash(x)
+}
+
+// InsertHash adds hash x to sketch
+func (sk *Sketch) InsertHash(x uint64) {
 	if sk.sparse {
 		sk.tmpSet.add(encodeHash(x, sk.p, pp))
 		if uint32(len(sk.tmpSet))*100 > sk.m {

--- a/vendor/github.com/axiomhq/hyperloglog/utils.go
+++ b/vendor/github.com/axiomhq/hyperloglog/utils.go
@@ -7,6 +7,8 @@ import (
 	metro "github.com/dgryski/go-metro"
 )
 
+var hash = hashFunc
+
 func beta14(ez float64) float64 {
 	zl := math.Log(ez + 1)
 	return -0.370393911*ez +
@@ -66,5 +68,3 @@ func bextr32(v uint32, start, length uint8) uint32 {
 func hashFunc(e []byte) uint64 {
 	return metro.Hash64(e, 1337)
 }
-
-var hash func(buf []byte) uint64

--- a/vendor/github.com/dgryski/go-bits/README
+++ b/vendor/github.com/dgryski/go-bits/README
@@ -1,1 +1,3 @@
+You should probably use https://golang.org/pkg/math/bits/ instead.
+
 godoc: https://godoc.org/github.com/dgryski/go-bits

--- a/vendor/github.com/dgryski/go-bits/clz.go
+++ b/vendor/github.com/dgryski/go-bits/clz.go
@@ -1,4 +1,4 @@
-// +build !amd64 appengine
+// +build gccgo !amd64 appengine
 
 package bits
 

--- a/vendor/github.com/dgryski/go-bits/clz_amd64.s
+++ b/vendor/github.com/dgryski/go-bits/clz_amd64.s
@@ -1,4 +1,4 @@
-// +build amd64,!appengine
+// +build !gccgo,!appengine
 
 // func Clz(x uint64) uint64
 TEXT ·Clz(SB),4,$0-16

--- a/vendor/github.com/dgryski/go-bits/clz_asm.go
+++ b/vendor/github.com/dgryski/go-bits/clz_asm.go
@@ -1,4 +1,4 @@
-// +build amd64,!appengine
+// +build !gccgo,amd64,!appengine
 
 package bits
 

--- a/vendor/github.com/dgryski/go-bits/ctz.go
+++ b/vendor/github.com/dgryski/go-bits/ctz.go
@@ -1,4 +1,4 @@
-// +build !amd64 appengine
+// +build gccgo !amd64 appengine
 
 package bits
 

--- a/vendor/github.com/dgryski/go-bits/ctz_amd64.s
+++ b/vendor/github.com/dgryski/go-bits/ctz_amd64.s
@@ -1,4 +1,4 @@
-// +build amd64,!appengine
+// +build !gccgo,!appengine
 
 // func Ctz(x uint64) uint64
 TEXT ·Ctz(SB),4,$0-16

--- a/vendor/github.com/dgryski/go-bits/ctz_asm.go
+++ b/vendor/github.com/dgryski/go-bits/ctz_asm.go
@@ -1,4 +1,4 @@
-// +build amd64,!appengine
+// +build !gccgo,amd64,!appengine
 
 package bits
 

--- a/vendor/github.com/dgryski/go-bits/popcnt.go
+++ b/vendor/github.com/dgryski/go-bits/popcnt.go
@@ -1,4 +1,4 @@
-// +build !amd64 appengine popcntgo
+// +build gccgo !amd64 appengine popcntgo
 
 package bits
 

--- a/vendor/github.com/dgryski/go-bits/popcnt_amd64.s
+++ b/vendor/github.com/dgryski/go-bits/popcnt_amd64.s
@@ -1,4 +1,4 @@
-// +build amd64,!appengine,!popcntgo
+// +build !gccgo,!appengine,!popcntgo
 
 #define POPCNTQ_DX_DX BYTE $0xf3; BYTE $0x48; BYTE $0x0f; BYTE $0xb8; BYTE $0xd2
 

--- a/vendor/github.com/dgryski/go-bits/popcnt_asm.go
+++ b/vendor/github.com/dgryski/go-bits/popcnt_asm.go
@@ -1,4 +1,4 @@
-// +build amd64,!appengine,!popcntgo
+// +build !gccgo,amd64,!appengine,!popcntgo
 
 package bits
 


### PR DESCRIPTION
#### Summary
This updates hyperloglog to baba800be098d9f4303352fa6214a933e371e3da which introduces the following changes:

* Remove race-detector triggering hash function initialization code (https://github.com/axiomhq/hyperloglog/pull/10)

* Fix for New16 to create a hash with 2^16 registers (typo'd as 2^14 before) (https://github.com/axiomhq/hyperloglog/pull/5)

All these seem reasonable to pull in, and should improve our tests' reliability.

#### Motivation
#338 is currently failing


#### Test plan
Pushing and hoping for the best!


#### Rollout/monitoring/revert plan
Merge and hopefully continue with non-racy tests!
