### PR TITLE
Add more default config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## Bugfixes
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!
+* The Datadog sink will no longer panic if `flush_max_per_body` is not configured; a default is used instead. Thanks [silverlyra](https://github.com/silverlyra)!
+* The statsd source will no longer reject all packets if `metric_max_length` is not configured; a default is used instead. Thanks [silverlyra](https://github.com/silverlyra)!
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/config_test.go
+++ b/config_test.go
@@ -77,13 +77,30 @@ func TestHostname(t *testing.T) {
 	assert.Nil(t, err, "Should parsed valid config file: %s", noHostname)
 	currentHost, err := os.Hostname()
 	assert.Nil(t, err, "Could not get current hostname")
+	c.applyDefaults()
 	assert.Equal(t, c.Hostname, currentHost, "Should have used current hostname in Config")
 
 	const omitHostname = "omit_empty_hostname: true"
 	r = strings.NewReader(omitHostname)
 	c, err = readConfig(r)
 	assert.Nil(t, err, "Should parsed valid config file: %s", omitHostname)
+	c.applyDefaults()
 	assert.Equal(t, c.Hostname, "", "Should have respected omit_empty_hostname")
+}
+
+func TestConfigDefaults(t *testing.T) {
+	const emptyConfig = "---"
+	r := strings.NewReader(emptyConfig)
+	c, err := readConfig(r)
+	assert.Nil(t, err, "Should parsed empty config file: %s", emptyConfig)
+
+	expectedConfig := defaultConfig
+	currentHost, err := os.Hostname()
+	assert.Nil(t, err, "Could not get current hostname")
+	expectedConfig.Hostname = currentHost
+
+	c.applyDefaults()
+	assert.Equal(t, c, expectedConfig, "Should have applied all config defaults")
 }
 
 func TestVeneurExamples(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -69,8 +69,7 @@ func TestHostname(t *testing.T) {
 	r := strings.NewReader(hostnameConfig)
 	c, err := readConfig(r)
 	assert.Nil(t, err, "Should parsed valid config file: %s", hostnameConfig)
-	assert.Equal(t, c, Config{Hostname: "foo", ReadBufferSizeBytes: defaultBufferSizeBytes},
-		"Should have parsed hostname into Config")
+	assert.Equal(t, c.Hostname, "foo", "Should have parsed hostname into Config")
 
 	const noHostname = "hostname: ''"
 	r = strings.NewReader(noHostname)
@@ -78,17 +77,13 @@ func TestHostname(t *testing.T) {
 	assert.Nil(t, err, "Should parsed valid config file: %s", noHostname)
 	currentHost, err := os.Hostname()
 	assert.Nil(t, err, "Could not get current hostname")
-	assert.Equal(t, c, Config{Hostname: currentHost, ReadBufferSizeBytes: defaultBufferSizeBytes},
-		"Should have used current hostname in Config")
+	assert.Equal(t, c.Hostname, currentHost, "Should have used current hostname in Config")
 
 	const omitHostname = "omit_empty_hostname: true"
 	r = strings.NewReader(omitHostname)
 	c, err = readConfig(r)
 	assert.Nil(t, err, "Should parsed valid config file: %s", omitHostname)
-	assert.Equal(t, c, Config{
-		Hostname:            "",
-		ReadBufferSizeBytes: defaultBufferSizeBytes,
-		OmitEmptyHostname:   true})
+	assert.Equal(t, c.Hostname, "", "Should have respected omit_empty_hostname")
 }
 
 func TestVeneurExamples(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -146,19 +146,14 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 
 	ret.TagsAsMap = mappedTags
 	ret.HistogramPercentiles = conf.Percentiles
-	if len(conf.Aggregates) == 0 {
-		ret.HistogramAggregates.Value = samplers.AggregateMin + samplers.AggregateMax + samplers.AggregateCount
-		ret.HistogramAggregates.Count = 3
-	} else {
-		ret.HistogramAggregates.Value = 0
-		for _, agg := range conf.Aggregates {
-			ret.HistogramAggregates.Value += samplers.AggregatesLookup[agg]
-		}
-		ret.HistogramAggregates.Count = len(conf.Aggregates)
+	ret.HistogramAggregates.Value = 0
+	for _, agg := range conf.Aggregates {
+		ret.HistogramAggregates.Value += samplers.AggregatesLookup[agg]
 	}
+	ret.HistogramAggregates.Count = len(conf.Aggregates)
 
 	var err error
-	ret.interval, err = time.ParseDuration(conf.Interval)
+	ret.interval, err = conf.ParseInterval()
 	if err != nil {
 		return ret, err
 	}


### PR DESCRIPTION
#### Summary
Consolidates the existing code that sets defaults for `Aggregates` and `ReadBufferSizeBytes`, and adds defaults for `FlushMaxPerBody`, `Interval`, and `MetricMaxLength`.

#### Motivation
It wasn't obvious from Veneur's documentation that essentially every field in the config file is required. It took me a couple of hours to figure out why Veneur was rejecting all stats (`MetricMaxLength` defaulted to 0 with no sanity check). Once I solved that, Veneur's Datadog sink panicked because `FlushMaxPerBody` also defaulted to 0. (issue #373)

#### Test plan
I added a test that ensures all the fields set in the new `defaultConfig` struct are propagated.

#### Rollout/monitoring/revert plan
The new defaults are for fields where Veneur (or parts thereof) would not have previously worked at all if unset. Nothing to say here.
