### PR TITLE
trace.Client stats on failed operations

### DIFF
--- a/trace/client.go
+++ b/trace/client.go
@@ -41,8 +41,10 @@ type Client struct {
 	flush   func(context.Context)
 	ops     chan op
 
-	failedFlushes int64
-	failedRecords int64
+	failedFlushes     int64
+	successfulFlushes int64
+	failedRecords     int64
+	successfulRecords int64
 }
 
 // Close tears down the entire client. It waits until the backend has
@@ -305,6 +307,7 @@ func Record(cl *Client, span *ssf.SSFSpan, done chan<- error) error {
 	}
 	select {
 	case cl.ops <- op:
+		atomic.AddInt64(&cl.successfulRecords, 1)
 		return nil
 	default:
 	}
@@ -348,6 +351,7 @@ func FlushAsync(cl *Client, ch chan<- error) error {
 	}
 	select {
 	case cl.ops <- op:
+		atomic.AddInt64(&cl.successfulFlushes, 1)
 		return nil
 	default:
 	}


### PR DESCRIPTION

#### Summary
This PR makes the `trace.Client` structure track the number of operations (recording spans, flushing buffers) that failed/succeeded on a client, and adds routines to regularly report them to a statsd server (because that's a useful escape hatch to have!)

#### Motivation
We'd like to see how many metrics/spans we lose to backpressure relief valves!


#### Test plan
I wrote a test, and we can roll this to QA. I think a good testing ground would be veneur-proxy, which I suspect is losing a few spans.


#### Rollout/monitoring/revert plan
Merge & deploy!
