### PR TITLE
Correctly store the commonTags in for later use in Lightstep span sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!
 * The Datadog sink will no longer panic if `flush_max_per_body` is not configured; a default is used instead. Thanks [silverlyra](https://github.com/silverlyra)!
 * The statsd source will no longer reject all packets if `metric_max_length` is not configured; a default is used instead. Thanks [silverlyra](https://github.com/silverlyra)!
+* LightStep sink was not applying common tags to outgoing spans. Thanks [sdboyer](https://github.com/sdboyer)!
 
 ## Added
 * `veneur-emit` now infers parent and trace IDs from the environment (using the variables `VENEUR_EMIT_TRACE_ID` and `VENEUR_EMIT_PARENT_SPAN_ID`) and sets these environment variables from its `-trace_id` and `parent_span_id` when timing commands, allowing for convenient construction of trace trees if traced programs call `veneur-emit` themselves. Thanks, [antifuchs](https://github.com/antifuchs)

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -105,6 +105,7 @@ func NewLightStepSpanSink(collector string, reconnectPeriod string, maximumSpans
 	return &LightStepSpanSink{
 		tracers:      tracers,
 		serviceCount: make(map[string]int64),
+		commonTags:   commonTags,
 		mutex:        &sync.Mutex{},
 		log:          log,
 	}, nil

--- a/sinks/lightstep/lightstep_test.go
+++ b/sinks/lightstep/lightstep_test.go
@@ -100,9 +100,10 @@ func (tls *testLSSpan) Log(data opentracing.LogData) {
 }
 
 func TestLSSinkConstructor(t *testing.T) {
-
-	_, err := NewLightStepSpanSink("http://example.com", "5m", 1000, 1, "secret", map[string]string{"foo": "bar"}, logrus.New())
+	tags := map[string]string{"foo": "bar"}
+	sink, err := NewLightStepSpanSink("http://example.com", "5m", 1000, 1, "secret", tags, logrus.New())
 	assert.NoError(t, err)
+	assert.Equal(t, tags, sink.commonTags)
 }
 
 func TestLSSpanSinkIngest(t *testing.T) {


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

A set of commonTags were provided to the Lightstep span sink, but they
were not permanently recorded into the struct; as such, no common tags
were ever applied to outgoing spans.

#### Motivation
<!-- Why are you making this change? -->

Seems like a pretty clear bug?

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Simple addition to a relevant test.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
