### PR TITLE
Parallelize SpanWorkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 4.0.0, in development
+
+## Added
+* The SSF client now defaults to opening 8 connections in parallel to avoid blocking client code. Thanks, [antifuchs](https://github.com/antifuchs)!
+* New config settings `num_span_workers` and `span_channel_capacity` that allow you to customize the parallelism of span ingestion. Thanks, [antifuchs](https://github.com/antifuchs)!
+* New span sink utilization metrics - Thanks, [antifuchs](https://github.com/antifuchs):
+** `veneur.sink.span_ingest_total_duration_ns` gives the total time per `sink` spent ingesting spans
+** `veneur.worker.span_chan.total_elements` over `veneur.worker.span_chan.total_capacity` gives the utilization of the sink ingestion channel.
+
 # 3.0.0, 2018-02-27
 
 ## Incompatible changes

--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	LightstepReconnectPeriod      string    `yaml:"lightstep_reconnect_period"`
 	MetricMaxLength               int       `yaml:"metric_max_length"`
 	NumReaders                    int       `yaml:"num_readers"`
+	NumSpanWorkers                int       `yaml:"num_span_workers"`
 	NumWorkers                    int       `yaml:"num_workers"`
 	OmitEmptyHostname             bool      `yaml:"omit_empty_hostname"`
 	Percentiles                   []float64 `yaml:"percentiles"`

--- a/config.go
+++ b/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
 	SignalfxEndpointBase          string    `yaml:"signalfx_endpoint_base"`
 	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
+	SpanChannelCapacity           int       `yaml:"span_channel_capacity"`
 	SsfBufferSize                 int       `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string  `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string    `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -134,8 +134,9 @@ num_span_workers: 10
 
 # Adjusts the number of spans that can be accomodated before the span
 # ingestion buffer blocks. This is good to tweak when you're seeing
-# spiky span ingestion patterns and a lot of spans get dropped. The
-# default for this is no channel capacity.
+# spiky span ingestion patterns and a lot of spans get dropped. This
+# corresponds directly to a Go channel's capacity, for which the
+# default is zero (unbuffered).
 span_channel_capacity: 100
 
 # == LIMITS ==

--- a/example.yaml
+++ b/example.yaml
@@ -117,15 +117,19 @@ trace_lightstep_num_clients: 0
 
 # == PERFORMANCE ==
 
-# Adjusts the number of workers Veneur will distribute aggregation across.
-# More decreases contention but has diminishing returns.
+# Adjusts the number of metrics workers Veneur will distribute
+# aggregation across.  More decreases contention but has diminishing
+# returns.
 num_workers: 96
 
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
 num_readers: 1
 
-
+# Adjusts the number of span workers Veneur will distribute span
+# ingestion across. The default value is 1, no parallel ingestion of
+# spans.
+num_span_workers: 10
 
 # == LIMITS ==
 

--- a/example.yaml
+++ b/example.yaml
@@ -117,18 +117,19 @@ trace_lightstep_num_clients: 0
 
 # == PERFORMANCE ==
 
-# Adjusts the number of metrics workers Veneur will distribute
-# aggregation across.  More decreases contention but has diminishing
-# returns.
+# Adjusts the number of metrics workers across which Veneur will
+# distribute aggregation.  More decreases contention but has
+# diminishing returns. The default value is 1, no parallel ingestion
+# of metrics.
 num_workers: 96
 
 # Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
 # this is supported on your platform!
 num_readers: 1
 
-# Adjusts the number of span workers Veneur will distribute span
-# ingestion across. The default value is 1, no parallel ingestion of
-# spans.
+# Adjusts the number of span workers across which Veneur will
+# distribute span ingestion. The default value is 1, no parallel
+# ingestion of spans.
 num_span_workers: 10
 
 # Adjusts the number of spans that can be accomodated before the span

--- a/example.yaml
+++ b/example.yaml
@@ -131,6 +131,12 @@ num_readers: 1
 # spans.
 num_span_workers: 10
 
+# Adjusts the number of spans that can be accomodated before the span
+# ingestion buffer blocks. This is good to tweak when you're seeing
+# spiky span ingestion patterns and a lot of spans get dropped. The
+# default for this is no channel capacity.
+span_channel_capacity: 100
+
 # == LIMITS ==
 
 # How big of a buffer to allocate for incoming metrics. Metrics longer than this

--- a/flusher.go
+++ b/flusher.go
@@ -27,7 +27,10 @@ func (s *Server) Flush(ctx context.Context) {
 
 	span.Add(ssf.Gauge("mem.heap_alloc_bytes", float32(mem.HeapAlloc), nil),
 		ssf.Gauge("gc.number", float32(mem.NumGC), nil),
-		ssf.Gauge("gc.pause_total_ns", float32(mem.PauseTotalNs), nil))
+		ssf.Gauge("gc.pause_total_ns", float32(mem.PauseTotalNs), nil),
+		ssf.Gauge("worker.span_chan.total_elements", float32(len(s.SpanChan)), nil),
+		ssf.Gauge("worker.span_chan.total_capacity", float32(cap(s.SpanChan)), nil),
+	)
 
 	// TODO Why is this not in the worker the way the trace worker is set up?
 	events, checks := s.EventWorker.Flush()

--- a/flusher.go
+++ b/flusher.go
@@ -368,5 +368,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 }
 
 func (s *Server) flushTraces(ctx context.Context) {
-	s.SpanWorker.Flush()
+	for _, w := range s.SpanWorkers {
+		w.Flush()
+	}
 }

--- a/forward_test.go
+++ b/forward_test.go
@@ -82,7 +82,7 @@ func (ff *forwardFixture) Flush(ctx context.Context) {
 // (*forwardFixture).Flush method so the ingestion effects can be
 // observed.
 func (ff *forwardFixture) IngestSpan(span *ssf.SSFSpan) {
-	ff.server.SpanWorker.SpanChan <- span
+	ff.server.SpanChan <- span
 }
 
 // IngestMetric synchronously writes a metric to the forwarding

--- a/handlers_global.go
+++ b/handlers_global.go
@@ -185,11 +185,12 @@ func unmarshalMetricsFromHTTP(ctx context.Context, client *trace.Client, w http.
 	}
 
 	w.WriteHeader(http.StatusAccepted)
-	span.Add(ssf.Timing("import.response_duration_ns", time.Since(span.Start),
-		time.Nanosecond, map[string]string{
-			"part":     "request",
-			"encoding": encoding,
-		}))
+	span.Add(ssf.RandomlySample(0.1,
+		ssf.Timing("import.response_duration_ns", time.Since(span.Start),
+			time.Nanosecond, map[string]string{
+				"part":     "request",
+				"encoding": encoding,
+			}))...)
 	return span, jsonMetrics, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -759,7 +759,8 @@ func (s *Server) ReadSSFStreamSocket(serverConn net.Conn) {
 			metrics.ReportOne(s.TraceClient, sample)
 			continue
 		}
-		metrics.ReportOne(s.TraceClient, ssf.Count("ssf.received_total", 1, tags))
+		metrics.ReportBatch(s.TraceClient,
+			ssf.RandomlySample(0.01, ssf.Count("ssf.received_total", 1, tags)))
 		s.handleSSF(msg, tags)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -217,9 +217,13 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	// found during setup we should use logger.Fatal or
 	// logger.Panic, because that will give us breakage monitoring
 	// through Sentry.
-	logger.WithField("number", conf.NumWorkers).Info("Preparing workers")
+	numWorkers := 1
+	if conf.NumWorkers > 1 {
+		numWorkers = conf.NumWorkers
+	}
+	logger.WithField("number", numWorkers).Info("Preparing workers")
 	// Allocate the slice, we'll fill it with workers later.
-	ret.Workers = make([]*Worker, conf.NumWorkers)
+	ret.Workers = make([]*Worker, numWorkers)
 	ret.numReaders = conf.NumReaders
 
 	// Use the pre-allocated Workers slice to know how many to start.

--- a/server.go
+++ b/server.go
@@ -171,7 +171,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	}
 	stats.Namespace = "veneur."
 
-	ret.SpanChan = make(chan *ssf.SSFSpan)
+	ret.SpanChan = make(chan *ssf.SSFSpan, conf.SpanChannelCapacity)
 	ret.TraceClient, err = trace.NewChannelClient(ret.SpanChan,
 		trace.ReportStatistics(stats, 1*time.Second, []string{"ssf_format:internal"}),
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -88,7 +88,8 @@ func generateConfig(forwardAddr string) Config {
 
 		// Use only one reader, so that we can run tests
 		// on platforms which do not support SO_REUSEPORT
-		NumReaders: 1,
+		NumReaders:     1,
+		NumSpanWorkers: 2,
 
 		// Currently this points nowhere, which is intentional.
 		// We don't need internal metrics for the tests, and they make testing
@@ -1171,7 +1172,7 @@ func TestInternalSSFMetricsEndToEnd(t *testing.T) {
 	f := newFixture(t, config, cms, nil)
 	defer f.Close()
 
-	backend := &internalTraceBackend{spanWorker: f.server.SpanWorker}
+	backend := &internalTraceBackend{spanChan: f.server.SpanChan}
 	client, err := trace.NewBackendClient(backend, trace.Capacity(20))
 	require.NoError(t, err)
 

--- a/server_test.go
+++ b/server_test.go
@@ -143,8 +143,8 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 	}
 
 	// Make sure we don't send internal metrics when testing:
+	trace.NeutralizeClient(server.TraceClient)
 	server.TraceClient = nil
-	server.traceBackend = nil
 
 	if mSink == nil {
 		// Install a blackhole sink if we have no other sinks
@@ -1172,8 +1172,7 @@ func TestInternalSSFMetricsEndToEnd(t *testing.T) {
 	f := newFixture(t, config, cms, nil)
 	defer f.Close()
 
-	backend := &internalTraceBackend{spanChan: f.server.SpanChan}
-	client, err := trace.NewBackendClient(backend, trace.Capacity(20))
+	client, err := trace.NewChannelClient(f.server.SpanChan)
 	require.NoError(t, err)
 
 	done := make(chan error)

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -56,6 +56,8 @@ const MetricKeySpanFlushDuration = "sink.span_flush_total_duration_ns"
 // place to do this.
 const MetricKeyTotalSpansFlushed = "sink.spans_flushed_total"
 
+const MetricKeySpanIngestDuration = "sink.span_ingest_total_duration_ns"
+
 // SpanSink is a receiver of spans that handles sending those spans to some
 // downstream sink. Calls to `Ingest(span)` are meant to give the sink control
 // of the span, with periodic calls to flush as a signal for sinks that don't

--- a/sinks/ssfmetrics/metrics.go
+++ b/sinks/ssfmetrics/metrics.go
@@ -117,7 +117,7 @@ func (m *metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 	}
 	metricsCount += len(indicatorMetrics)
 
-	spanMetrics, err := samplers.ConvertSpanUniquenessMetrics(span, 0.1)
+	spanMetrics, err := samplers.ConvertSpanUniquenessMetrics(span, 0.01)
 	if err != nil {
 		m.log.WithError(err).
 			WithField("span_name", span.Name).

--- a/trace/backend_test.go
+++ b/trace/backend_test.go
@@ -1,0 +1,145 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/ssf"
+)
+
+func benchmarkPlainCombination(backend ClientBackend, span *ssf.SSFSpan) func(*testing.B) {
+	ctx := context.TODO()
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assert.NoError(b, backend.SendSync(ctx, span))
+		}
+	}
+}
+
+func benchmarkFlushingCombination(backend FlushableClientBackend, span *ssf.SSFSpan, every time.Duration) func(*testing.B) {
+	return func(b *testing.B) {
+		ctx := context.TODO()
+		tick := time.NewTicker(every)
+		defer tick.Stop()
+		for i := 0; i < b.N; i++ {
+			select {
+			case <-tick.C:
+				assert.NoError(b, backend.FlushSync(ctx))
+			default:
+				assert.NoError(b, backend.SendSync(ctx, span))
+			}
+		}
+		assert.NoError(b, backend.FlushSync(ctx))
+	}
+}
+
+// BenchmarkSerialization tests how long the serialization of a span
+// over each kind of network link can take: UNIX with no buffer, UNIX
+// with a buffer, UDP (only unbuffered); combined with the kinds of
+// spans we send: spans with metrics attached, spans with no metrics
+// attached, and empty spans with only metrics.
+//
+// The counterpart is either a fresh UDP port with nothing reading
+// packets, or a network reader that discards every byte read.
+func BenchmarkSerialization(b *testing.B) {
+	dir, err := ioutil.TempDir("", "test_unix")
+	require.NoError(b, err)
+	defer os.RemoveAll(dir)
+
+	sockName := filepath.Join(dir, "sock")
+	laddr, err := net.ResolveUnixAddr("unix", sockName)
+	require.NoError(b, err)
+	cleanup := serveUNIX(b, laddr, func(conn net.Conn) {
+		io.Copy(ioutil.Discard, conn)
+	})
+	defer cleanup()
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.NoError(b, err)
+	defer udpConn.Close()
+
+	unixBackend := &streamBackend{
+		backendParams: backendParams{
+			addr: laddr,
+		},
+	}
+	flushyUnixBackend := &streamBackend{
+		backendParams: backendParams{
+			addr:       laddr,
+			bufferSize: uint(BufferSize),
+		},
+	}
+	udpBackend := &packetBackend{
+		backendParams: backendParams{
+			addr: udpConn.LocalAddr(),
+		},
+	}
+
+	spanWithMetrics := &ssf.SSFSpan{
+		Name:     "realistic_span",
+		Service:  "hi-there-srv",
+		Id:       1,
+		ParentId: 2,
+		TraceId:  3,
+		Error:    false,
+		Tags: map[string]string{
+			"span_purpose": "testing",
+		},
+		Metrics: []*ssf.SSFSample{
+			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
+			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}, ssf.Unit("absolute")),
+		},
+	}
+
+	spanNoMetrics := &ssf.SSFSpan{
+		Name:     "realistic_span",
+		Service:  "hi-there-srv",
+		Id:       1,
+		ParentId: 2,
+		TraceId:  3,
+		Error:    false,
+		Tags: map[string]string{
+			"span_purpose": "testing",
+		},
+	}
+
+	emptySpanWithMetrics := &ssf.SSFSpan{
+		Metrics: []*ssf.SSFSample{
+			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
+			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}, ssf.Unit("lad")),
+		},
+	}
+
+	// Warm up things:
+	connect(context.TODO(), unixBackend)
+	_ = flushyUnixBackend.FlushSync(context.TODO())
+	connect(context.TODO(), udpBackend)
+	b.ResetTimer()
+
+	// Start benchmarking:
+	for _, every := range []int{10, 50, 100} {
+		b.Run(fmt.Sprintf("UNIX_flush_span_with_metrics_%dms", every),
+			benchmarkFlushingCombination(flushyUnixBackend, spanWithMetrics, time.Duration(every)*time.Millisecond))
+		b.Run(fmt.Sprintf("UNIX_flush_span_no_metrics_%dms", every),
+			benchmarkFlushingCombination(flushyUnixBackend, spanNoMetrics, time.Duration(every)*time.Millisecond))
+		b.Run(fmt.Sprintf("UNIX_flush_empty_span_with_metrics_%dms", every),
+			benchmarkFlushingCombination(flushyUnixBackend, emptySpanWithMetrics, time.Duration(every)*time.Millisecond))
+	}
+
+	b.Run("UNIX_plain_span_with_metrics", benchmarkPlainCombination(unixBackend, spanWithMetrics))
+	b.Run("UNIX_plain_span_no_metrics", benchmarkPlainCombination(unixBackend, spanNoMetrics))
+	b.Run("UNIX_plain_empty_span_with_metrics", benchmarkPlainCombination(unixBackend, emptySpanWithMetrics))
+
+	b.Run("UDP_plain_span_with_metrics", benchmarkPlainCombination(udpBackend, spanWithMetrics))
+	b.Run("UDP_plain_span_no_metrics", benchmarkPlainCombination(udpBackend, spanNoMetrics))
+	b.Run("UDP_plain_empty_span_with_metrics", benchmarkPlainCombination(udpBackend, emptySpanWithMetrics))
+}

--- a/trace/client.go
+++ b/trace/client.go
@@ -50,8 +50,7 @@ type flushNotifier struct {
 type Client struct {
 	flushBackends []flushNotifier
 
-	// Parameters adjusted by initialization / used to build a
-	// running client:
+	// Parameters adjusted by client initialization:
 	backendParams *backendParams
 	nBackends     uint
 	cap           uint

--- a/trace/client.go
+++ b/trace/client.go
@@ -26,6 +26,18 @@ func init() {
 // synchronously, flushing the backend buffer, or closing the backend.
 type op func(context.Context, ClientBackend)
 
+type sendOp struct {
+	span   *ssf.SSFSpan
+	result chan<- error
+}
+
+// flushNotifier holds a channel that lets the client notify a
+// backend to flush.
+type flushNotifier struct {
+	backend ClientBackend
+	notify  chan chan<- error
+}
+
 // Client is a Client that sends traces to Veneur over the network. It
 // represents a pump for span packets from user code to the network
 // (whether it be UDP or streaming sockets, with or without buffers).
@@ -36,13 +48,20 @@ type op func(context.Context, ClientBackend)
 // serialization part providing backpressure (the front end) and a
 // backend (which is called on a single goroutine).
 type Client struct {
-	backend ClientBackend
-	cap     uint
-	cancel  context.CancelFunc
-	flush   func(context.Context)
-	report  func(context.Context)
-	ops     chan op
+	flushBackends []flushNotifier
 
+	// Parameters adjusted by initialization / used to build a
+	// running client:
+	backendParams *backendParams
+	nBackends     uint
+	cap           uint
+	cancel        context.CancelFunc
+	flush         func(context.Context)
+	report        func(context.Context)
+	records       chan *sendOp
+	spans         chan<- *ssf.SSFSpan
+
+	// statistics:
 	failedFlushes     int64
 	successfulFlushes int64
 	failedRecords     int64
@@ -53,13 +72,11 @@ type Client struct {
 // closed the network connection (if one was established) and returns
 // any error from closing the connection.
 func (c *Client) Close() error {
-	ch := make(chan error)
 	c.cancel()
-	c.ops <- func(ctx context.Context, s ClientBackend) {
-		ch <- s.Close()
+	if c.records != nil {
+		close(c.records)
 	}
-	close(c.ops)
-	return <-ch
+	return nil
 }
 
 func (c *Client) run(ctx context.Context) {
@@ -69,12 +86,33 @@ func (c *Client) run(ctx context.Context) {
 	if c.report != nil {
 		go c.report(ctx)
 	}
+
+	for _, b := range c.flushBackends {
+		go runFlushableBackend(ctx, c.records, b.backend, b.notify)
+	}
+}
+
+func runFlushableBackend(ctx context.Context, spans chan *sendOp, backend ClientBackend, flushNotify chan chan<- error) {
+	defer backend.Close()
+
 	for {
-		do, ok := <-c.ops
-		if !ok {
-			return
+		select {
+		case op, ok := <-spans:
+			if !ok {
+				return
+			}
+			err := backend.SendSync(ctx, op.span)
+			if op.result != nil {
+				op.result <- err
+			}
+		case errChan := <-flushNotify:
+			switch backend := backend.(type) {
+			case FlushableClientBackend:
+				errChan <- backend.FlushSync(ctx)
+			default:
+				errChan <- nil
+			}
 		}
-		do(ctx, c.backend)
 	}
 }
 
@@ -123,8 +161,8 @@ func Buffered(cl *Client) error {
 // buffer.
 func BufferedSize(size uint) ClientParam {
 	return func(cl *Client) error {
-		if nb, ok := cl.backend.(networkBackend); ok {
-			nb.params().bufferSize = size
+		if cl.backendParams != nil {
+			cl.backendParams.bufferSize = size
 			return nil
 		}
 		return ErrClientNotNetworked
@@ -152,7 +190,7 @@ func FlushInterval(interval time.Duration) ClientParam {
 // time.Ticker is set up to deal with slow flushes.
 func FlushChannel(ch <-chan time.Time, stop func()) ClientParam {
 	return func(cl *Client) error {
-		if _, ok := cl.backend.(networkBackend); !ok {
+		if cl.backendParams == nil {
 			return ErrClientNotNetworked
 		}
 		cl.flush = func(ctx context.Context) {
@@ -175,8 +213,8 @@ func FlushChannel(ch <-chan time.Time, stop func()) ClientParam {
 // this option is not used, the backend uses DefaultBackoff.
 func BackoffTime(t time.Duration) ClientParam {
 	return func(cl *Client) error {
-		if nb, ok := cl.backend.(networkBackend); ok {
-			nb.params().backoff = t
+		if cl.backendParams != nil {
+			cl.backendParams.backoff = t
 			return nil
 		}
 		return ErrClientNotNetworked
@@ -188,8 +226,8 @@ func BackoffTime(t time.Duration) ClientParam {
 // DefaultMaxBackoff.
 func MaxBackoffTime(t time.Duration) ClientParam {
 	return func(cl *Client) error {
-		if nb, ok := cl.backend.(networkBackend); ok {
-			nb.params().maxBackoff = t
+		if cl.backendParams != nil {
+			cl.backendParams.maxBackoff = t
 			return nil
 		}
 		return ErrClientNotNetworked
@@ -204,8 +242,8 @@ func MaxBackoffTime(t time.Duration) ClientParam {
 // DefaultConnectTimeout.
 func ConnectTimeout(t time.Duration) ClientParam {
 	return func(cl *Client) error {
-		if nb, ok := cl.backend.(networkBackend); ok {
-			nb.params().connectTimeout = t
+		if cl.backendParams != nil {
+			cl.backendParams.connectTimeout = t
 			return nil
 		}
 		return ErrClientNotNetworked
@@ -233,6 +271,27 @@ func ReportStatistics(stats *statsd.Client, interval time.Duration, tags []strin
 	}
 }
 
+// ParallelBackends sets the number of parallel network backend
+// connections to send spans with. Each backend holds a connection to
+// an SSF receiver open.
+func ParallelBackends(nBackends uint) ClientParam {
+	return func(cl *Client) error {
+		if cl.backendParams == nil {
+			return ErrClientNotNetworked
+		}
+		cl.nBackends = nBackends
+		return nil
+	}
+}
+
+func newFlushNofifier(backend ClientBackend) flushNotifier {
+	fb := flushNotifier{backend: backend}
+	if _, ok := backend.(FlushableClientBackend); ok {
+		fb.notify = make(chan chan<- error)
+	}
+	return fb
+}
+
 // NewClient constructs a new client that will attempt to connect
 // to addrStr (an address in veneur URL format) using the parameters
 // in opts. It returns the constructed client or an error.
@@ -242,29 +301,36 @@ func NewClient(addrStr string, opts ...ClientParam) (*Client, error) {
 		return nil, err
 	}
 	cl := &Client{}
-	var nb networkBackend
-	switch addr := addr.(type) {
-	case *net.UDPAddr:
-		nb = &packetBackend{}
-	case *net.UnixAddr:
-		nb = &streamBackend{}
-	default:
-		return nil, fmt.Errorf("can not connect to %v addresses", addr.Network())
-	}
-	cl.backend = nb
-	params := nb.params()
-	params.addr = addr
+	cl.backendParams = &backendParams{}
+	cl.backendParams.addr = addr
 	cl.cap = DefaultCapacity
+	cl.nBackends = DefaultParallelism
 	for _, opt := range opts {
 		if err = opt(cl); err != nil {
 			return nil, err
 		}
 	}
-	ch := make(chan op, cl.cap)
-	cl.ops = ch
+	ch := make(chan *sendOp, cl.cap)
+	cl.records = ch
 	ctx := context.Background()
 	ctx, cl.cancel = context.WithCancel(ctx)
-	go cl.run(ctx)
+
+	fb := []flushNotifier{}
+	for i := uint(0); i < cl.nBackends; i++ {
+		switch addr := addr.(type) {
+		case *net.UDPAddr:
+			be := &packetBackend{backendParams: *cl.backendParams}
+			fb = append(fb, newFlushNofifier(be))
+		case *net.UnixAddr:
+			be := &streamBackend{backendParams: *cl.backendParams}
+			fb = append(fb, newFlushNofifier(be))
+		default:
+			return nil, fmt.Errorf("can not connect to %v addresses", addr.Network())
+		}
+	}
+	cl.flushBackends = fb
+	cl.run(ctx)
+
 	return cl, nil
 }
 
@@ -275,7 +341,7 @@ func NewClient(addrStr string, opts ...ClientParam) (*Client, error) {
 // trips over the network.
 func NewBackendClient(b ClientBackend, opts ...ClientParam) (*Client, error) {
 	cl := &Client{}
-	cl.backend = b
+	cl.flushBackends = []flushNotifier{newFlushNofifier(b)}
 	cl.cap = 1
 
 	for _, opt := range opts {
@@ -283,11 +349,45 @@ func NewBackendClient(b ClientBackend, opts ...ClientParam) (*Client, error) {
 			return nil, err
 		}
 	}
-	cl.ops = make(chan op, cl.cap)
+	cl.records = make(chan *sendOp, cl.cap)
 	ctx := context.Background()
 	ctx, cl.cancel = context.WithCancel(ctx)
-	go cl.run(ctx)
+
+	cl.run(ctx)
 	return cl, nil
+}
+
+// NewChannelClient constructs and returns a Client that can send
+// directly into a span receiver channel. It provides an alternative
+// interface to NewBackendClient for constructing internal and
+// test-only clients.
+func NewChannelClient(spanChan chan<- *ssf.SSFSpan, opts ...ClientParam) (*Client, error) {
+	cl := &Client{}
+	cl.flushBackends = []flushNotifier{}
+	cl.spans = spanChan
+
+	for _, opt := range opts {
+		if err := opt(cl); err != nil {
+			return nil, err
+		}
+	}
+
+	ctx := context.Background()
+	ctx, cl.cancel = context.WithCancel(ctx)
+
+	cl.run(ctx)
+	return cl, nil
+}
+
+// NeutralizeClient sets up a client such that all Record or Flush
+// operations result in ErrWouldBlock. It dashes all hope of a Client
+// ever successfully recording or flushing spans, and is mostly useful
+// in tests.
+func NeutralizeClient(client *Client) {
+	client.Close()
+	client.records = nil
+	client.spans = nil
+	client.flushBackends = []flushNotifier{}
 }
 
 // DefaultClient is the client that trace recording happens on by
@@ -301,6 +401,10 @@ var DefaultClient *Client
 // DefaultCapacity is the capacity of the span submission queue in a
 // veneur client.
 const DefaultCapacity = 64
+
+// DefaultParallelism is the number of span submission goroutines a
+// veneur client runs in parallel.
+const DefaultParallelism = 8
 
 // DefaultVeneurAddress is the address that a reasonable veneur should
 // listen on. Currently it defaults to UDP port 8128.
@@ -336,14 +440,15 @@ func Record(cl *Client, span *ssf.SSFSpan, done chan<- error) error {
 		return ErrNoClient
 	}
 
-	op := func(ctx context.Context, s ClientBackend) {
-		err := s.SendSync(ctx, span)
-		if done != nil {
-			done <- err
-		}
-	}
+	op := &sendOp{span: span, result: done}
 	select {
-	case cl.ops <- op:
+	case cl.spans <- span:
+		atomic.AddInt64(&cl.successfulRecords, 1)
+		if done != nil {
+			go func() { done <- nil }()
+		}
+		return nil
+	case cl.records <- op:
 		atomic.AddInt64(&cl.successfulRecords, 1)
 		return nil
 	default:
@@ -369,29 +474,49 @@ func Flush(cl *Client) error {
 	return <-ch
 }
 
+// FlushError is an aggregate error type indicating that one or more
+// backends failed to flush.
+type FlushError struct {
+	Errors []error
+}
+
+func (fe *FlushError) Error() string {
+	return fmt.Sprintf("Errors encountered flushing backends: %v", fe.Errors)
+}
+
 // FlushAsync instructs a buffered client to flush to the upstream
 // veneur all the spans that were serialized up until the moment that
 // the flush was received. Once the client has completed the flush,
 // any error (or nil) is sent down the error channel.
 //
-// FlushAsync returns ErrNoClient if client is nil and ErrWouldBlock
-// if the client is not able to take more requests.
+// FlushAsync returns ErrNoClient if client is nil.
 func FlushAsync(cl *Client, ch chan<- error) error {
 	if cl == nil {
 		return ErrNoClient
 	}
-	op := func(ctx context.Context, s ClientBackend) {
-		err := s.FlushSync(ctx)
-		if ch != nil {
-			ch <- err
+	go func() {
+		errors := []error{}
+		oneCh := make(chan error)
+		for _, fb := range cl.flushBackends {
+			if fb.notify == nil {
+				continue
+			}
+			select {
+			case fb.notify <- oneCh:
+				if err := <-oneCh; err != nil {
+					errors = append(errors, err)
+				}
+			default:
+				errors = append(errors, ErrWouldBlock)
+			}
 		}
-	}
-	select {
-	case cl.ops <- op:
+		if len(errors) > 0 {
+			atomic.AddInt64(&cl.failedFlushes, 1)
+			ch <- &FlushError{errors}
+			return
+		}
 		atomic.AddInt64(&cl.successfulFlushes, 1)
-		return nil
-	default:
-	}
-	atomic.AddInt64(&cl.failedFlushes, 1)
-	return ErrWouldBlock
+		ch <- nil
+	}()
+	return nil
 }

--- a/trace/client.go
+++ b/trace/client.go
@@ -312,8 +312,9 @@ func NewClient(addrStr string, opts ...ClientParam) (*Client, error) {
 	}
 	ch := make(chan *sendOp, cl.cap)
 	cl.records = ch
-	ctx := context.Background()
-	ctx, cl.cancel = context.WithCancel(ctx)
+
+	var ctx context.Context
+	ctx, cl.cancel = context.WithCancel(context.Background())
 
 	fb := []flushNotifier{}
 	for i := uint(0); i < cl.nBackends; i++ {

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -171,7 +171,7 @@ func TestUNIXBuffered(t *testing.T) {
 	}
 }
 
-func serveUNIX(t *testing.T, laddr *net.UnixAddr, onconnect func(conn net.Conn)) (cleanup func() error) {
+func serveUNIX(t testing.TB, laddr *net.UnixAddr, onconnect func(conn net.Conn)) (cleanup func() error) {
 	srv, err := net.ListenUnix(laddr.Network(), laddr)
 	require.NoError(t, err)
 	cleanup = srv.Close

--- a/worker.go
+++ b/worker.go
@@ -392,10 +392,6 @@ func (tw *SpanWorker) Work() {
 			wg.Add(1)
 			go func(i int, sink sinks.SpanSink, span *ssf.SSFSpan, wg *sync.WaitGroup) {
 				start := time.Now()
-				defer func() {
-					atomic.AddInt64(&tw.cumulativeTimes[i],
-						int64(time.Since(start)/time.Nanosecond))
-				}()
 				// Give each sink a change to ingest.
 				err := sink.Ingest(span)
 				if err != nil {
@@ -407,6 +403,8 @@ func (tw *SpanWorker) Work() {
 							ssf.Count("worker.span.ingest_error_total", 1, tags))
 					}
 				}
+				atomic.AddInt64(&tw.cumulativeTimes[i],
+					int64(time.Since(start)/time.Nanosecond))
 				wg.Done()
 			}(i, s, m, &wg)
 		}


### PR DESCRIPTION
#### Summary
This PR does the span worker quite a refactor:

* makes it possible to run multiple span workers - `num_span_workers`, all ingesting into the same sinks.
* makes these span workers consume spans off a single channel with capacity `span_channel_capacity` (to account for bursty span submissions), fill grade tracked by the metric `veneur.worker.span_chan.total_elements`.
* samples a bunch of veneur&veneur-proxy internal metrics at 1-10%, to reduce the chance of write amplification
* Refactors the veneur span client in multiple ways & speeds that up, too:
  * The internal client now feeds the `SpanChan` directly (using the new `NewChannelClient` constructor), which reduces the amount of spans dropped from internal reporting due to channel blockage down to ~0%.
  * External (network) clients now connect 8 parallel connections; they buffer and submit spans through those in parallel.
* A bunch of fixes to tests to make them more deterministic: client tests now retry submissions if they receive `ErrWouldBlock`.

#### Motivation
We've seen spans getting dropped from internal and external reporting because veneur can't process them fast enough, especially with metrics going over the internal trace client now.


#### Test plan
- I set tests to spawn multiple span workers so we can see any potential data races
- In our QA system, with the right amount of parallelism, this leads to a reduction in internally-reported spans/metrics dropped to 0% - success!
- Also in QA, this speeds up `veneur-proxy`'s external client by a bunch: It still drops spans, but it's successful at reporting them much more often now.

#### Rollout/monitoring/revert plan
Merge & roll!
