### PR TITLE
Submit histogram aggregates globally when "veneurglobalonly" is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ** Datadog and LightStep sinks now emit `veneur.sink.span_flush_total_duration_ns` for span flush duration and tag it with `sink`
 ** Datadog, Kafka, MetricExtraction, and LightStep sinks now emit `sink.spans_flushed_total` for metric flush counts and tag it with `sink`
 * Veneur's internal metrics are no longer tagged with `veneurlocalonly`. This means that percentile metrics (such as timers) will now be aggregated globally.
+* Histograms tagged with `veneurglobalonly` will only output global aggregates, rather than sending them locally.  Aggregations such as "sum", "min", or "max" will be submitted from the global Veneur without a host tag.
 
 ## Bugfixes
 * LightStep sink was hardcoded to use plaintext, now adjusts based on URL scheme (http versus https). Thanks [gphat](https://github.com/gphat)!
@@ -34,6 +35,7 @@
 
 ## Improvements
 * Updated Datadog span sink to latest version in Datadog tracing agent. Thanks, [gphat](https://github.com/gphat)!
+* Histograms tagged with `veneurglobalonly` submit agregates from the global Veneur rather than flushing locally to Datadog (fixes #155).  Thanks, [noahgoldman](https://github.com/noahgoldman)!
 
 # 2.0.0, 2018-01-09
 

--- a/flusher.go
+++ b/flusher.go
@@ -51,7 +51,6 @@ func (s *Server) Flush(ctx context.Context) {
 		aggregates = samplers.HistogramAggregates{}
 	}
 
-	// TODO input aggregates here?
 	tempMetrics, ms := s.tallyMetrics(percentiles)
 
 	finalMetrics := s.generateInterMetrics(span.Attach(ctx), percentiles, aggregates, tempMetrics, ms)
@@ -285,8 +284,10 @@ func (s *Server) computeGlobalMetricsFlushCounts(ms metricsSummary) []*ssf.SSFSa
 		ssf.Count(flushTotalMetric, float32(ms.totalGlobalCounters), map[string]string{"metric_type": "global_counter"}),
 		ssf.Count(flushTotalMetric, float32(ms.totalGlobalGauges), map[string]string{"metric_type": "global_gauge"}),
 		ssf.Count(flushTotalMetric, float32(ms.totalHistograms), map[string]string{"metric_type": "histogram"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalGlobalHistograms), map[string]string{"metric_type": "histogram"}),
 		ssf.Count(flushTotalMetric, float32(ms.totalSets), map[string]string{"metric_type": "set"}),
 		ssf.Count(flushTotalMetric, float32(ms.totalTimers), map[string]string{"metric_type": "timer"}),
+		ssf.Count(flushTotalMetric, float32(ms.totalGlobalTimers), map[string]string{"metric_type": "timer"}),
 	}
 }
 

--- a/flusher.go
+++ b/flusher.go
@@ -239,10 +239,11 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 
 			// If this is global, always submit both percentiles and
 			// aggregates for "global" histogram types
-			for _, histos := range []histoMap{wm.globalHistograms, wm.globalTimers} {
-				for _, h := range histos {
-					finalMetrics = append(finalMetrics, h.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates)...)
-				}
+			for _, gh := range wm.globalHistograms {
+				finalMetrics = append(finalMetrics, gh.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates)...)
+			}
+			for _, gt := range wm.globalTimers {
+				finalMetrics = append(finalMetrics, gt.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates)...)
 			}
 		}
 	}

--- a/flusher.go
+++ b/flusher.go
@@ -295,103 +295,45 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 	defer span.ClientFinish(s.TraceClient)
 	jmLength := 0
 	for _, wm := range wms {
+		jmLength += len(wm.globalCounters)
+		jmLength += len(wm.globalGauges)
 		jmLength += len(wm.histograms)
+		jmLength += len(wm.globalHistograms)
 		jmLength += len(wm.sets)
 		jmLength += len(wm.timers)
+		jmLength += len(wm.globalTimers)
 	}
 
 	jsonMetrics := make([]samplers.JSONMetric, 0, jmLength)
 	exportStart := time.Now()
 	for _, wm := range wms {
 		for _, count := range wm.globalCounters {
-			jm, err := count.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "counter",
-					"name":          count.Name,
-				}).Error("Could not export metric")
-				continue
-			}
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(count, jsonMetrics, counterTypeName,
+				samplers.GlobalOnly)
 		}
 		for _, gauge := range wm.globalGauges {
-			jm, err := gauge.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "gauge",
-					"name":          gauge.Name,
-				}).Error("Could not export metric")
-				continue
-			}
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(gauge, jsonMetrics, gaugeTypeName,
+				samplers.GlobalOnly)
 		}
 		for _, histo := range wm.histograms {
-			jm, err := histo.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "histogram",
-					"name":          histo.Name,
-				}).Error("Could not export metric")
-				continue
-			}
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(histo, jsonMetrics, histogramTypeName,
+				samplers.MixedScope)
 		}
 		for _, histo := range wm.globalHistograms {
-			jm, err := histo.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "histogram",
-					"name":          histo.Name,
-					"global":        true,
-				}).Error("Could not export metric")
-				continue
-			}
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(histo, jsonMetrics, histogramTypeName,
+				samplers.GlobalOnly)
 		}
 		for _, set := range wm.sets {
-			jm, err := set.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "set",
-					"name":          set.Name,
-				}).Error("Could not export metric")
-				continue
-			}
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(set, jsonMetrics, setTypeName,
+				samplers.MixedScope)
 		}
 		for _, timer := range wm.timers {
-			jm, err := timer.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "timer",
-					"name":          timer.Name,
-				}).Error("Could not export metric")
-				continue
-			}
-			// the exporter doesn't know that these two are "different"
-			jm.Type = "timer"
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(timer, jsonMetrics, timerTypeName,
+				samplers.MixedScope)
 		}
 		for _, timer := range wm.globalTimers {
-			jm, err := timer.Export()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"type":          "timer",
-					"name":          timer.Name,
-					"global":        true,
-				}).Error("Could not export metric")
-				continue
-			}
-			// the exporter doesn't know that these two are "different"
-			jm.Type = "timer"
-			jsonMetrics = append(jsonMetrics, jm)
+			jsonMetrics = s.appendJSONMetric(timer, jsonMetrics, timerTypeName,
+				samplers.GlobalOnly)
 		}
 	}
 	span.Add(ssf.Timing("forward.duration_ns", time.Since(exportStart), time.Nanosecond, map[string]string{"part": "export"}),
@@ -415,4 +357,35 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 
 func (s *Server) flushTraces(ctx context.Context) {
 	s.SpanWorker.Flush()
+}
+
+// exporter is any metric that can be exported (and has a name)
+type exporter interface {
+	Export() (samplers.JSONMetric, error)
+	GetName() string
+}
+
+// appendJSONMetric appends a JSONMetric exported by the input metric m, or
+// does nothing and logs if the export fails.
+func (s *Server) appendJSONMetric(
+	m exporter,
+	metrics []samplers.JSONMetric,
+	mType string,
+	scope samplers.MetricScope,
+) []samplers.JSONMetric {
+	jm, err := m.Export()
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"type":          mType,
+			"name":          m.GetName(),
+			"scope":         scope,
+		}).Error("Could not export metric")
+		return metrics
+	}
+
+	jm.Type = mType
+	jm.Scope = scope
+
+	return append(metrics, jm)
 }

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -100,7 +100,8 @@ type JSONMetric struct {
 	Tags []string `json:"tags"`
 	// the Value is an internal representation of the metric's contents, eg a
 	// gob-encoded histogram or hyperloglog.
-	Value []byte `json:"value"`
+	Value []byte      `json:"value"`
+	Scope MetricScope `json:"scope"`
 }
 
 const sinkPrefix string = "veneursinkonly:"
@@ -183,6 +184,11 @@ func (c *Counter) Combine(other []byte) error {
 	return nil
 }
 
+// GetName returns the Name of the counter.
+func (c *Counter) GetName() string {
+	return c.Name
+}
+
 // NewCounter generates and returns a new Counter.
 func NewCounter(Name string, Tags []string) *Counter {
 	return &Counter{Name: Name, Tags: Tags}
@@ -247,6 +253,10 @@ func (g *Gauge) Combine(other []byte) error {
 	g.value = otherValue
 
 	return nil
+}
+
+func (g *Gauge) GetName() string {
+	return g.Name
 }
 
 // NewGauge genearaaaa who am I kidding just getting rid of the warning.
@@ -323,6 +333,10 @@ func (s *Set) Combine(other []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (s *Set) GetName() string {
+	return s.Name
 }
 
 // Histo is a collection of values that generates max, min, count, and
@@ -562,4 +576,8 @@ func (h *Histo) Combine(other []byte) error {
 	h.sum += val.Sum
 	h.reciprocalSum += val.ReciprocalSum
 	return nil
+}
+
+func (h *Histo) GetName() string {
+	return h.Name
 }

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -498,9 +498,9 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 	return metrics
 }
 
-// histoValue is a serializable version of a Histo that will be sent as the
+// HistoValue is a serializable version of a Histo that will be sent as the
 // Value of a JSONMetric, gob-encoded.
-type histoValue struct {
+type HistoValue struct {
 	TDigest       *tdigest.MergingDigest
 	Weight        float64
 	Min           float64
@@ -513,7 +513,7 @@ type histoValue struct {
 func (h *Histo) Export() (JSONMetric, error) {
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
-	hval := histoValue{
+	hval := HistoValue{
 		TDigest:       h.tDigest,
 		Weight:        h.weight,
 		Min:           h.min,
@@ -538,7 +538,7 @@ func (h *Histo) Export() (JSONMetric, error) {
 // Combine merges the values of a histogram with another histogram
 // (marshalled as a byte slice)
 func (h *Histo) Combine(other []byte) error {
-	var val histoValue
+	var val HistoValue
 	dec := gob.NewDecoder(bytes.NewReader(other))
 
 	if err := dec.Decode(&val); err != nil {

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -327,32 +327,32 @@ func (s *Set) Combine(other []byte) error {
 // Histo is a collection of values that generates max, min, count, and
 // percentiles over time.
 type Histo struct {
-	Name  string
-	Tags  []string
-	Value *tdigest.MergingDigest
+	Name    string
+	Tags    []string
+	tDigest *tdigest.MergingDigest
 	// these values are computed from only the samples that came through this
 	// veneur instance, ignoring any histograms merged from elsewhere
 	// we separate them because they're easy to aggregate on the backend without
 	// loss of granularity, and having host-local information on them might be
 	// useful
-	Weight        float64
-	Min           float64
-	Max           float64
-	Sum           float64
-	ReciprocalSum float64
+	weight        float64
+	min           float64
+	max           float64
+	sum           float64
+	reciprocalSum float64
 }
 
 // Sample adds the supplied value to the histogram.
 func (h *Histo) Sample(sample float64, sampleRate float32) {
 	weight := float64(1 / sampleRate)
-	h.Value.Add(sample, weight)
+	h.tDigest.Add(sample, weight)
 
-	h.Weight += weight
-	h.Min = math.Min(h.Min, sample)
-	h.Max = math.Max(h.Max, sample)
-	h.Sum += sample * weight
+	h.weight += weight
+	h.min = math.Min(h.min, sample)
+	h.max = math.Max(h.max, sample)
+	h.sum += sample * weight
 
-	h.ReciprocalSum += (1 / sample) * weight
+	h.reciprocalSum += (1 / sample) * weight
 }
 
 // NewHist generates a new Histo and returns it.
@@ -361,10 +361,10 @@ func NewHist(Name string, Tags []string) *Histo {
 		Name: Name,
 		Tags: Tags,
 		// we're going to allocate a lot of these, so we don't want them to be huge
-		Value: tdigest.NewMerging(100, false),
-		Min:   math.Inf(+1),
-		Max:   math.Inf(-1),
-		Sum:   0,
+		tDigest: tdigest.NewMerging(100, false),
+		min:     math.Inf(+1),
+		max:     math.Inf(-1),
+		sum:     0,
 	}
 }
 
@@ -375,7 +375,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 	metrics := make([]InterMetric, 0, aggregates.Count+len(percentiles))
 	sinks := routeInfo(h.Tags)
 
-	if (aggregates.Value&AggregateMax) == AggregateMax && !math.IsInf(h.Max, 0) {
+	if (aggregates.Value&AggregateMax) == AggregateMax && !math.IsInf(h.max, 0) {
 		// Defensively recopy tags to avoid aliasing bugs in case multiple InterMetrics share the same
 		// tag array in the future
 		tags := make([]string, len(h.Tags))
@@ -383,39 +383,39 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.max", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Max),
+			Value:     float64(h.max),
 			Tags:      tags,
 			Type:      GaugeMetric,
 			Sinks:     sinks,
 		})
 	}
-	if (aggregates.Value&AggregateMin) == AggregateMin && !math.IsInf(h.Min, 0) {
+	if (aggregates.Value&AggregateMin) == AggregateMin && !math.IsInf(h.min, 0) {
 		tags := make([]string, len(h.Tags))
 		copy(tags, h.Tags)
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.min", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Min),
+			Value:     float64(h.min),
 			Tags:      tags,
 			Type:      GaugeMetric,
 			Sinks:     sinks,
 		})
 	}
 
-	if (aggregates.Value&AggregateSum) == AggregateSum && h.Sum != 0 {
+	if (aggregates.Value&AggregateSum) == AggregateSum && h.sum != 0 {
 		tags := make([]string, len(h.Tags))
 		copy(tags, h.Tags)
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.sum", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Sum),
+			Value:     float64(h.sum),
 			Tags:      tags,
 			Type:      GaugeMetric,
 			Sinks:     sinks,
 		})
 	}
 
-	if (aggregates.Value&AggregateAverage) == AggregateAverage && h.Sum != 0 && h.Weight != 0 {
+	if (aggregates.Value&AggregateAverage) == AggregateAverage && h.sum != 0 && h.weight != 0 {
 		// we need both a rate and a non-zero sum before it will make sense
 		// to submit an average
 		tags := make([]string, len(h.Tags))
@@ -423,14 +423,14 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.avg", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Sum / h.Weight),
+			Value:     float64(h.sum / h.weight),
 			Tags:      tags,
 			Type:      GaugeMetric,
 			Sinks:     sinks,
 		})
 	}
 
-	if (aggregates.Value&AggregateCount) == AggregateCount && h.Weight != 0 {
+	if (aggregates.Value&AggregateCount) == AggregateCount && h.weight != 0 {
 		// if we haven't received any local samples, then leave this sparse,
 		// otherwise it can lead to some misleading zeroes in between the
 		// flushes of downstream instances
@@ -439,7 +439,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.count", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Weight),
+			Value:     float64(h.weight),
 			Tags:      tags,
 			Type:      CounterMetric,
 			Sinks:     sinks,
@@ -454,7 +454,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			InterMetric{
 				Name:      fmt.Sprintf("%s.median", h.Name),
 				Timestamp: now,
-				Value:     float64(h.Value.Quantile(0.5)),
+				Value:     float64(h.tDigest.Quantile(0.5)),
 				Tags:      tags,
 				Type:      GaugeMetric,
 				Sinks:     sinks,
@@ -462,7 +462,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 		)
 	}
 
-	if (aggregates.Value&AggregateHarmonicMean) == AggregateHarmonicMean && h.ReciprocalSum != 0 && h.Weight != 0 {
+	if (aggregates.Value&AggregateHarmonicMean) == AggregateHarmonicMean && h.reciprocalSum != 0 && h.weight != 0 {
 		// we need both a rate and a non-zero sum before it will make sense
 		// to submit an average
 		tags := make([]string, len(h.Tags))
@@ -470,7 +470,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 		metrics = append(metrics, InterMetric{
 			Name:      fmt.Sprintf("%s.hmean", h.Name),
 			Timestamp: now,
-			Value:     float64(h.Weight / h.ReciprocalSum),
+			Value:     float64(h.weight / h.reciprocalSum),
 			Tags:      tags,
 			Type:      GaugeMetric,
 			Sinks:     sinks,
@@ -486,7 +486,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 			InterMetric{
 				Name:      fmt.Sprintf("%s.%dpercentile", h.Name, int(p*100)),
 				Timestamp: now,
-				Value:     float64(h.Value.Quantile(p)),
+				Value:     float64(h.tDigest.Quantile(p)),
 				Tags:      tags,
 				Type:      GaugeMetric,
 				Sinks:     sinks,
@@ -499,7 +499,7 @@ func (h *Histo) Flush(interval time.Duration, percentiles []float64, aggregates 
 
 // Export converts a Histogram into a JSONMetric
 func (h *Histo) Export() (JSONMetric, error) {
-	val, err := h.Value.GobEncode()
+	val, err := h.tDigest.GobEncode()
 	if err != nil {
 		return JSONMetric{}, err
 	}
@@ -521,6 +521,6 @@ func (h *Histo) Combine(other []byte) error {
 	if err := otherHistogram.GobDecode(other); err != nil {
 		return err
 	}
-	h.Value.Merge(otherHistogram)
+	h.tDigest.Merge(otherHistogram)
 	return nil
 }

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -255,6 +255,7 @@ func (g *Gauge) Combine(other []byte) error {
 	return nil
 }
 
+// GetName returns the Name of the Gauge
 func (g *Gauge) GetName() string {
 	return g.Name
 }
@@ -335,6 +336,7 @@ func (s *Set) Combine(other []byte) error {
 	return nil
 }
 
+// GetName returns the Name of the Set
 func (s *Set) GetName() string {
 	return s.Name
 }
@@ -578,6 +580,7 @@ func (h *Histo) Combine(other []byte) error {
 	return nil
 }
 
+// GetName returns the Name of the Histo
 func (h *Histo) GetName() string {
 	return h.Name
 }

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/tdigest"
 )
 
 func TestRouting(t *testing.T) {
@@ -380,7 +381,7 @@ func TestHistoSampleRate(t *testing.T) {
 	assert.Equal(t, float64(10), count.Value, "count value")
 }
 
-func TestHistoMerge(t *testing.T) {
+func TestHistoMergeOneSideOnly(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
 	h := histoWithSamples("a.b.c", []string{"a:b"}, 100)
@@ -395,6 +396,86 @@ func TestHistoMerge(t *testing.T) {
 	assert.Equal(t, h.max, h2.max, "merged histogram should have the max of the other")
 	assert.Equal(t, h.sum, h2.sum, "merged histogram should have the sum of the other")
 	assert.Equal(t, h.reciprocalSum, h2.reciprocalSum, "merged histogram should have the reciprocal sum of the other")
+}
+
+func TestHistoMergeBoth(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	h := &Histo{
+		Name:          "a.b",
+		tDigest:       tdigest.NewMerging(100, false),
+		min:           1,
+		max:           10,
+		sum:           1,
+		weight:        1,
+		reciprocalSum: 1,
+	}
+
+	type histValues struct {
+		weight        float64
+		min           float64
+		max           float64
+		sum           float64
+		reciprocalSum float64
+	}
+
+	testCases := []struct {
+		description string
+		toCombine   *Histo
+		expected    histValues
+	}{
+		{
+			description: "values on both sides",
+			toCombine: &Histo{
+				tDigest:       tdigest.NewMerging(100, false),
+				min:           0,
+				max:           9,
+				sum:           2,
+				weight:        2,
+				reciprocalSum: 2,
+			},
+			expected: histValues{
+				weight:        3,
+				min:           0,
+				max:           10,
+				sum:           3,
+				reciprocalSum: 3,
+			},
+		},
+		{
+			description: "one side uninitialized",
+			toCombine:   NewHist("b.c", []string{}),
+			expected: histValues{
+				weight:        h.weight,
+				min:           h.min,
+				max:           h.max,
+				sum:           h.sum,
+				reciprocalSum: h.reciprocalSum,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			jm, err := h.Export()
+			assert.NoError(t, err, "the histo should have exported successfully")
+			assert.NoError(t, tc.toCombine.Combine(jm.Value), "combining the two should have succeeded")
+
+			assert.Equal(t, tc.expected.min, tc.toCombine.min,
+				"the merged min should be correct")
+			assert.Equal(t, tc.expected.weight, tc.toCombine.weight,
+				"merged histogram should have the weight of the other")
+			assert.Equal(t, tc.expected.min, tc.toCombine.min,
+				"merged histogram should have the min of the other")
+			assert.Equal(t, tc.expected.max, tc.toCombine.max,
+				"merged histogram should have the max of the other")
+			assert.Equal(t, tc.expected.sum, tc.toCombine.sum,
+				"merged histogram should have the sum of the other")
+			assert.Equal(t, tc.expected.reciprocalSum, tc.toCombine.reciprocalSum,
+				"merged histogram should have the reciprocal sum of the other")
+		})
+	}
 }
 
 func TestMetricKeyEquality(t *testing.T) {

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -2,7 +2,6 @@ package samplers
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -395,14 +394,14 @@ func TestHistoMerge(t *testing.T) {
 	h2 := NewHist("a.b.c", []string{"a:b"})
 	assert.NoError(t, h2.Combine(jm.Value), "should have combined successfully")
 	assert.InEpsilon(t, h.tDigest.Quantile(0.5), h2.tDigest.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
-	assert.InDelta(t, 0, h2.weight, 0.02, "merged histogram should have count of zero")
-	assert.True(t, math.IsInf(h2.min, +1), "merged histogram should have local minimum of +inf")
-	assert.True(t, math.IsInf(h2.max, -1), "merged histogram should have local minimum of -inf")
+	// assert.InDelta(t, 0, h2.weight, 0.02, "merged histogram should have count of zero")
+	// assert.True(t, math.IsInf(h2.min, +1), "merged histogram should have local minimum of +inf")
+	// assert.True(t, math.IsInf(h2.max, -1), "merged histogram should have local minimum of -inf")
 
 	h2.Sample(1.0, 1.0)
-	assert.InDelta(t, 1.0, h2.weight, 0.02, "merged histogram should have count of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.min, 0.02, "merged histogram should have min of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.max, 0.02, "merged histogram should have max of 1 after adding a value")
+	// assert.InDelta(t, 1.0, h2.weight, 0.02, "merged histogram should have count of 1 after adding a value")
+	// assert.InDelta(t, 1.0, h2.min, 0.02, "merged histogram should have min of 1 after adding a value")
+	// assert.InDelta(t, 1.0, h2.max, 0.02, "merged histogram should have max of 1 after adding a value")
 }
 
 func TestMetricKeyEquality(t *testing.T) {

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -394,15 +394,15 @@ func TestHistoMerge(t *testing.T) {
 
 	h2 := NewHist("a.b.c", []string{"a:b"})
 	assert.NoError(t, h2.Combine(jm.Value), "should have combined successfully")
-	assert.InEpsilon(t, h.Value.Quantile(0.5), h2.Value.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
-	assert.InDelta(t, 0, h2.Weight, 0.02, "merged histogram should have count of zero")
-	assert.True(t, math.IsInf(h2.Min, +1), "merged histogram should have local minimum of +inf")
-	assert.True(t, math.IsInf(h2.Max, -1), "merged histogram should have local minimum of -inf")
+	assert.InEpsilon(t, h.tDigest.Quantile(0.5), h2.tDigest.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
+	assert.InDelta(t, 0, h2.weight, 0.02, "merged histogram should have count of zero")
+	assert.True(t, math.IsInf(h2.min, +1), "merged histogram should have local minimum of +inf")
+	assert.True(t, math.IsInf(h2.max, -1), "merged histogram should have local minimum of -inf")
 
 	h2.Sample(1.0, 1.0)
-	assert.InDelta(t, 1.0, h2.Weight, 0.02, "merged histogram should have count of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.Min, 0.02, "merged histogram should have min of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.Max, 0.02, "merged histogram should have max of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.weight, 0.02, "merged histogram should have count of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.min, 0.02, "merged histogram should have min of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.max, 0.02, "merged histogram should have max of 1 after adding a value")
 }
 
 func TestMetricKeyEquality(t *testing.T) {

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -383,25 +383,18 @@ func TestHistoSampleRate(t *testing.T) {
 func TestHistoMerge(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	h := NewHist("a.b.c", []string{"a:b"})
-	for i := 0; i < 100; i++ {
-		h.Sample(rand.NormFloat64(), 1.0)
-	}
-
+	h := histoWithSamples("a.b.c", []string{"a:b"}, 100)
 	jm, err := h.Export()
 	assert.NoError(t, err, "should have exported successfully")
 
 	h2 := NewHist("a.b.c", []string{"a:b"})
 	assert.NoError(t, h2.Combine(jm.Value), "should have combined successfully")
 	assert.InEpsilon(t, h.tDigest.Quantile(0.5), h2.tDigest.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
-	// assert.InDelta(t, 0, h2.weight, 0.02, "merged histogram should have count of zero")
-	// assert.True(t, math.IsInf(h2.min, +1), "merged histogram should have local minimum of +inf")
-	// assert.True(t, math.IsInf(h2.max, -1), "merged histogram should have local minimum of -inf")
-
-	h2.Sample(1.0, 1.0)
-	// assert.InDelta(t, 1.0, h2.weight, 0.02, "merged histogram should have count of 1 after adding a value")
-	// assert.InDelta(t, 1.0, h2.min, 0.02, "merged histogram should have min of 1 after adding a value")
-	// assert.InDelta(t, 1.0, h2.max, 0.02, "merged histogram should have max of 1 after adding a value")
+	assert.Equal(t, h.weight, h2.weight, "merged histogram should have the weight of the other")
+	assert.Equal(t, h.min, h2.min, "merged histogram should have the min of the other")
+	assert.Equal(t, h.max, h2.max, "merged histogram should have the max of the other")
+	assert.Equal(t, h.sum, h2.sum, "merged histogram should have the sum of the other")
+	assert.Equal(t, h.reciprocalSum, h2.reciprocalSum, "merged histogram should have the reciprocal sum of the other")
 }
 
 func TestMetricKeyEquality(t *testing.T) {

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -543,7 +543,9 @@ func BenchmarkHistoExport(b *testing.B) {
 		h := histoWithSamples("a.b.c", []string{"a:b"}, samples)
 		b.Run(fmt.Sprintf("Samples=%d", samples), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				h.Export()
+				if _, err := h.Export(); err != nil {
+					b.Fatalf("Failed to export a histogram: %v", err)
+				}
 			}
 		})
 	}
@@ -561,7 +563,10 @@ func BenchmarkHistoCombine(b *testing.B) {
 
 		b.Run(fmt.Sprintf("Samples=%d", samples), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				h.Combine(marshalled.Value)
+				if err := h.Combine(marshalled.Value); err != nil {
+					b.Fatalf("Failed to combine with the other histogram: %v",
+						err)
+				}
 			}
 		})
 	}
@@ -581,7 +586,10 @@ func BenchmarkHistoCombineOldFormat(b *testing.B) {
 
 		b.Run(fmt.Sprintf("Samples=%d", samples), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				h.Combine(encoded)
+				if err := h.Combine(encoded); err != nil {
+					b.Fatalf("Failed to combine with a previous-format "+
+						"(gob-encoded) histogram: %v", err)
+				}
 			}
 		})
 	}

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -394,14 +394,14 @@ func TestHistoMerge(t *testing.T) {
 	h2 := NewHist("a.b.c", []string{"a:b"})
 	assert.NoError(t, h2.Combine(jm.Value), "should have combined successfully")
 	assert.InEpsilon(t, h.Value.Quantile(0.5), h2.Value.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
-	assert.InDelta(t, 0, h2.LocalWeight, 0.02, "merged histogram should have count of zero")
-	assert.True(t, math.IsInf(h2.LocalMin, +1), "merged histogram should have local minimum of +inf")
-	assert.True(t, math.IsInf(h2.LocalMax, -1), "merged histogram should have local minimum of -inf")
+	assert.InDelta(t, 0, h2.Weight, 0.02, "merged histogram should have count of zero")
+	assert.True(t, math.IsInf(h2.Min, +1), "merged histogram should have local minimum of +inf")
+	assert.True(t, math.IsInf(h2.Max, -1), "merged histogram should have local minimum of -inf")
 
 	h2.Sample(1.0, 1.0)
-	assert.InDelta(t, 1.0, h2.LocalWeight, 0.02, "merged histogram should have count of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.LocalMin, 0.02, "merged histogram should have min of 1 after adding a value")
-	assert.InDelta(t, 1.0, h2.LocalMax, 0.02, "merged histogram should have max of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.Weight, 0.02, "merged histogram should have count of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.Min, 0.02, "merged histogram should have min of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.Max, 0.02, "merged histogram should have max of 1 after adding a value")
 }
 
 func TestMetricKeyEquality(t *testing.T) {

--- a/tdigest/merging_digest.go
+++ b/tdigest/merging_digest.go
@@ -10,6 +10,8 @@ package tdigest
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -424,4 +426,23 @@ func (td *MergingDigest) Centroids() []Centroid {
 	}
 	td.mergeAllTemps()
 	return td.mainCentroids
+}
+
+func (td *MergingDigest) MarshalJSON() ([]byte, error) {
+	b, err := td.GobEncode()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the digest: %v")
+	}
+
+	return json.Marshal(b)
+}
+
+func (td *MergingDigest) UnmarshalJSON(b []byte) error {
+	var enc []byte
+	err := json.Unmarshal(b, &enc)
+	if err != nil {
+		return err
+	}
+
+	return td.GobDecode(enc)
 }

--- a/tdigest/merging_digest.go
+++ b/tdigest/merging_digest.go
@@ -10,8 +10,6 @@ package tdigest
 import (
 	"bytes"
 	"encoding/gob"
-	"encoding/json"
-	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -357,9 +355,6 @@ func (td *MergingDigest) Merge(other *MergingDigest) {
 	}
 }
 
-var _ gob.GobEncoder = &MergingDigest{}
-var _ gob.GobDecoder = &MergingDigest{}
-
 func (td *MergingDigest) GobEncode() ([]byte, error) {
 	td.mergeAllTemps()
 
@@ -426,23 +421,4 @@ func (td *MergingDigest) Centroids() []Centroid {
 	}
 	td.mergeAllTemps()
 	return td.mainCentroids
-}
-
-func (td *MergingDigest) MarshalJSON() ([]byte, error) {
-	b, err := td.GobEncode()
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode the digest: %v")
-	}
-
-	return json.Marshal(b)
-}
-
-func (td *MergingDigest) UnmarshalJSON(b []byte) error {
-	var enc []byte
-	err := json.Unmarshal(b, &enc)
-	if err != nil {
-		return err
-	}
-
-	return td.GobDecode(enc)
 }

--- a/worker.go
+++ b/worker.go
@@ -254,6 +254,9 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 		log.Error("Local metrics cannot be imported")
 		return
 	} else if other.Type == counterTypeName || other.Type == gaugeTypeName {
+		// This branch is only necessary to maintain compatibility with local
+		// Veneur's that don't send the `(JSONMetric).Scope` field.  It can be
+		// safely removed once all local instances are upgraded.
 		other.Scope = samplers.GlobalOnly
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -220,11 +220,15 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 			w.wm.gauges[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		}
 	case histogramTypeName:
-		if m.Scope == samplers.LocalOnly {
-			w.wm.localHistograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
-		} else {
-			w.wm.histograms[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		hs := w.wm.histograms
+		switch m.Scope {
+		case samplers.LocalOnly:
+			hs = w.wm.localHistograms
+		case samplers.GlobalOnly:
+			hs = w.wm.globalHistograms
 		}
+
+		hs[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 	case setTypeName:
 		if m.Scope == samplers.LocalOnly {
 			w.wm.localSets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)

--- a/worker.go
+++ b/worker.go
@@ -64,21 +64,26 @@ type WorkerMetrics struct {
 	localTimers     map[samplers.MetricKey]*samplers.Histo
 }
 
+type counterMap = map[samplers.MetricKey]*samplers.Counter
+type gaugeMap = map[samplers.MetricKey]*samplers.Gauge
+type setMap = map[samplers.MetricKey]*samplers.Set
+type histoMap = map[samplers.MetricKey]*samplers.Histo
+
 // NewWorkerMetrics initializes a WorkerMetrics struct
 func NewWorkerMetrics() WorkerMetrics {
 	return WorkerMetrics{
-		counters:         make(map[samplers.MetricKey]*samplers.Counter),
-		globalCounters:   make(map[samplers.MetricKey]*samplers.Counter),
-		globalGauges:     make(map[samplers.MetricKey]*samplers.Gauge),
-		gauges:           make(map[samplers.MetricKey]*samplers.Gauge),
-		histograms:       make(map[samplers.MetricKey]*samplers.Histo),
-		sets:             make(map[samplers.MetricKey]*samplers.Set),
-		timers:           make(map[samplers.MetricKey]*samplers.Histo),
-		localHistograms:  make(map[samplers.MetricKey]*samplers.Histo),
-		localSets:        make(map[samplers.MetricKey]*samplers.Set),
-		localTimers:      make(map[samplers.MetricKey]*samplers.Histo),
-		globalHistograms: make(map[samplers.MetricKey]*samplers.Histo),
-		globalTimers:     make(map[samplers.MetricKey]*samplers.Histo),
+		counters:         make(counterMap),
+		globalCounters:   make(counterMap),
+		globalGauges:     make(gaugeMap),
+		gauges:           make(gaugeMap),
+		histograms:       make(histoMap),
+		sets:             make(setMap),
+		timers:           make(histoMap),
+		localHistograms:  make(histoMap),
+		localSets:        make(setMap),
+		localTimers:      make(histoMap),
+		globalHistograms: make(histoMap),
+		globalTimers:     make(histoMap),
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -64,26 +64,21 @@ type WorkerMetrics struct {
 	localTimers     map[samplers.MetricKey]*samplers.Histo
 }
 
-type counterMap = map[samplers.MetricKey]*samplers.Counter
-type gaugeMap = map[samplers.MetricKey]*samplers.Gauge
-type setMap = map[samplers.MetricKey]*samplers.Set
-type histoMap = map[samplers.MetricKey]*samplers.Histo
-
 // NewWorkerMetrics initializes a WorkerMetrics struct
 func NewWorkerMetrics() WorkerMetrics {
 	return WorkerMetrics{
-		counters:         make(counterMap),
-		globalCounters:   make(counterMap),
-		globalGauges:     make(gaugeMap),
-		gauges:           make(gaugeMap),
-		histograms:       make(histoMap),
-		sets:             make(setMap),
-		timers:           make(histoMap),
-		localHistograms:  make(histoMap),
-		localSets:        make(setMap),
-		localTimers:      make(histoMap),
-		globalHistograms: make(histoMap),
-		globalTimers:     make(histoMap),
+		counters:         make(map[samplers.MetricKey]*samplers.Counter),
+		globalCounters:   make(map[samplers.MetricKey]*samplers.Counter),
+		globalGauges:     make(map[samplers.MetricKey]*samplers.Gauge),
+		gauges:           make(map[samplers.MetricKey]*samplers.Gauge),
+		histograms:       make(map[samplers.MetricKey]*samplers.Histo),
+		globalHistograms: make(map[samplers.MetricKey]*samplers.Histo),
+		sets:             make(map[samplers.MetricKey]*samplers.Set),
+		timers:           make(map[samplers.MetricKey]*samplers.Histo),
+		globalTimers:     make(map[samplers.MetricKey]*samplers.Histo),
+		localHistograms:  make(map[samplers.MetricKey]*samplers.Histo),
+		localSets:        make(map[samplers.MetricKey]*samplers.Set),
+		localTimers:      make(map[samplers.MetricKey]*samplers.Histo),
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -254,6 +254,8 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 	if other.Scope == samplers.LocalOnly {
 		log.Error("Local metrics cannot be imported")
 		return
+	} else if other.Type == counterTypeName || other.Type == gaugeTypeName {
+		other.Scope = samplers.GlobalOnly
 	}
 
 	w.imported++

--- a/worker.go
+++ b/worker.go
@@ -236,11 +236,15 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 			w.wm.sets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
 		}
 	case timerTypeName:
-		if m.Scope == samplers.LocalOnly {
-			w.wm.localTimers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
-		} else {
-			w.wm.timers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+		ts := w.wm.timers
+		switch m.Scope {
+		case samplers.LocalOnly:
+			ts = w.wm.localTimers
+		case samplers.GlobalOnly:
+			ts = w.wm.globalTimers
 		}
+
+		ts[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 	default:
 		log.WithField("type", m.Type).Error("Unknown metric type for processing")
 	}
@@ -284,7 +288,12 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 			log.WithError(err).Error("Could not merge histograms")
 		}
 	case timerTypeName:
-		if err := w.wm.timers[other.MetricKey].Combine(other.Value); err != nil {
+		ms := w.wm.timers
+		if other.Scope == samplers.GlobalOnly {
+			ms = w.wm.globalTimers
+		}
+
+		if err := ms[other.MetricKey].Combine(other.Value); err != nil {
 			log.WithError(err).Error("Could not merge timers")
 		}
 	default:


### PR DESCRIPTION
#### Summary

This implements #155, making histogram aggregates submit from a global Veneur rather than flushing locally to Datadog when `veneurglobalonly` is set.  There are a couple different important changes that I made here to get this to work.  I tried to steer clear of introducing performance regressions, and in some cases tried to reduce some code duplication where possible as well.

##### `globalHistograms` and `globalTimers` in `Worker`

The `Worker` now includes `globalHistograms` and `globalTimers` maps.  The main purpose of these is to denote to the Global and Local Veneur's if or if not they should be flushing aggregates.  For both of these maps, the (indended :smile:) behavior is as follows:
* **Local**: Forward and don't flush.
* **Global**: Flush all percentiles and aggregates.

Additionally, these code changes modify the behavior of the existing `histograms` and `timers` maps as well to explicitly disable them flushing aggregates.  Currently, Global Veneur's never flush aggregates because `Histogram` fields such as `min` and `max` are always set to their default values.  Now they will be explicitly disabled, with the following behavior.
* **Local**: Flush aggregates but not percentiles, and forward.
* **Global**: Flush percentiles and explicitly disable flushing aggregates.

One potential bug now present is that intermediate Veneur's (where a histogram is forwarded to, but also forwards again) will now output aggregates (rolled up from multiple imports).  I'm not sure if this is actually bad behavior, and I'm interested in your thoughts there.

##### Adding a `Scope` field to `JSONMetric`

I added the `Scope` field to make it possible for a Global Veneur to know if a histogram was originally inteded to be `MixedScope` or `GlobalOnly`.  This previously wasn't necessary for Counters and Gauges, as the fact that they were being forwarded indicated that they should be global.  I added new logic to initialize this field to the proper value as necessary.

##### New serialization format for Histogram values

Currently, the `Value` field of a `JSONMetric` for histograms is just a gob-encoded `MergingDigest`.  In order to perform the aggregations, I created a new `HistogramValue` struct that will be gob-encoded as well, and contains a `MergingDigest`. I liked this option the best (compared to a couple others, including directly serializing the `Histo`) as it clearly defines the content of the `(JSONMetric).Value`.  I'm definitely open to suggestions on other options for this.

##### Profiling Histogram serilization

I was a little worried about the performance of doing even more Gob-decoding, as profiling our global Veneur's shows that gob-decoding is more or less the hottest area of the code (we don't use SSF).  I added some benchmarks for the `(Histo).Combine` and `(Histo).Export` functions, and ran them both with the new and old serialization formats.  See the results [in this Gist](https://gist.github.com/noahgoldman/7aaa01d491d2085c853959cf6a98819f), but it's pretty clear that the new format is slower.

I've also been playing around with converting the value to be protobuf-encoded, and the results look pretty good performance-wise.  Serialization is more or less an order of magnitude faster, and deserialization is much faster for Histograms with less than 100 samples (and slightly faster for larger histograms as well).  I decided to leave these changes out of this PR to make this one a little easier to review, but I figured that since the Histogram value is undergoing a backwards-incompatible change already it might make sense to at least prevent performance regressions!  These changes are in my [histo-value-protobuf](https://github.com/noahgoldman/veneur/tree/histo-value-protobuf) branch, which I'm happy to pull in as well if there's interest!

##### Reducing duplication

I made some pretty big changes to the `(Worker).flushForward` function, to get rid of a ton of repetitive code handling all of the different maps of metrics.  The diff looks pretty ugly, but I think the result is a whole lot more readable.

#### Motivation

This change will allow clients that know they don't need host-local histogram aggregations to reduce the number of custom metrics in Datadog (the metric cardinality) by setting the histograms as global.  I also personally believe that this behavior is more intuitive considering the behavior of the "veneurglobalonly" flag with other metric types.

#### Test plan

* I wrote a pair of large *integration*-style test cases that check the forwarding and flushing behavior of histograms with different scope, for both local and global Veneurs.  Existing tests seem to already cover a lot of the code paths I touched.
* I ran some small-scale tests on a running set of global, proxy, and local Veneurs, and plan to do more early next week.


#### Rollout/monitoring/revert plan

An ordered rollout will be required for these changes.  It should be as follows:
1. Proxy and Global Veneurs
    * They need to be able to accept the `(JSONMetric).Scope` parameter and decode the new encoding for the `Value` field for histograms.  I tried to be careful about retaining backwards compatibility with older local Veneurs once the new version is deployed.
2. Local Veneurs

I'm not sure if there's a good rollback plan unfortunately, local Veneur's with these changes will be incompatible with older Global instances.