### PR TITLE
Document the `ssf_destination_address` option

### DIFF
--- a/cmd/veneur-proxy/README.md
+++ b/cmd/veneur-proxy/README.md
@@ -25,7 +25,8 @@ Use the `consul_refresh_interval` to specify how often Veneur should refresh it'
 * `enable_profiling`: Enable or disable go profiling. Danger, might fill up your disk if not cared for.
 * `http_address`: The `host:port` pair in which this program will listen for HTTP commands.
 * `consul_refresh_interval`: How often to refresh from Consul's healthy nodes. Value must be parseable by time.ParseDuration (https://golang.org/pkg/time/#ParseDuration)
-* `stats_address`: The `host:port` destination to send `veneur-proxy`'s metrics.
+* `ssf_destination_address`: The `host:port` address of a Veneur to send `veneur_proxy`'s metrics to over SSF.
+* `stats_address`: The `host:port` destination to send metrics to over StatsD when `veneur-proxy` experiences backpressure on submitting to `ssf_destination_address`.
 * `forward_address`: Use a static host for forwarding…
 * `consul_forward_service_name`: The name of a consul service for consistent forwarding.
 * `sentry_dsn`: A [Sentry](https://sentry.io) DSN to which errors will be sent.


### PR DESCRIPTION
#### Summary

The changes to `veneur-proxy` in #338 make the `ssf_destination_address` a required configuration parameter for the proxy.  This is documented in "example_proxy.yaml", but there was no information about it in the `veneur-proxy` README.

This just adds a short description about the configuration option, and updates the description for `stats_address` to be what I understand it to now be used for (after #338).

#### Motivation

I had to dig around for a little bit to figure out why `veneur-proxy` metrics weren't working with my old configuration on the latest master, and what `ssf_listen_address` (and now `statsd_address`) mean. 

#### Test plan

None, this just updates docs.
