### PR TITLE
Improve subtest names to be compatible with test2json

### DIFF
--- a/socket_test.go
+++ b/socket_test.go
@@ -47,14 +47,15 @@ func TestSocket(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		addr     string
 		sendAddr string
 		isIPv6   bool
 	}{
-		{"127.0.0.1:0", "127.0.0.1", false},
-		{"[::1]:0", "[::1]", true},
-		{":0", "127.0.0.1", false},
-		{":0", "[::1]", true},
+		{"IPv4 only", "127.0.0.1:0", "127.0.0.1", false},
+		{"IPv6 only", "[::1]:0", "[::1]", true},
+		{"IPv4 to any", ":0", "127.0.0.1", false},
+		{"IPv6 to any", ":0", "[::1]", true},
 	}
 
 	for _, elt := range tests {
@@ -62,6 +63,6 @@ func TestSocket(t *testing.T) {
 		if test.isIPv6 && !systemSupportsV6 {
 			continue
 		}
-		t.Run(fmt.Sprintf("%s to %s", test.sendAddr, test.addr), writeReadUDP(test.addr, test.sendAddr))
+		t.Run(test.name, writeReadUDP(test.addr, test.sendAddr))
 	}
 }


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adjusts subtest names to be friendly to `test2json`

#### Motivation
It turns out that https://github.com/golang/go/issues/23920 hits us in veneur: Since these subtest names contain the : character, test2json never lists the test as having passed. Let's be friendly to good tools!


#### Test plan
I ran tests against my `go test -json` emacs mode, which now presents all the veneur test cases correctly (:


#### Rollout/monitoring/revert plan
Just merge, no changelog necessary
