### PR TITLE
Add more instrumentation to sink flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
   * Method `trace.(*Trace).Add`, which allows adding metrics to a trace span.
 * `veneur-proxy` has a new configuration option `forward_timeout` which allows specifying how long forwarding a batch to global veneur servers may take in total. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Add native support for running Veneur within Kubernetes. Thanks, [aditya](https://github.com/chimeracoder)!
+* Improvements in instrumentation on flushing sinks – thanks, [rhwlo](https://github.com/rhwlo)!
+** New metrics `flush.sinks.total_duration_ns`, `flush.sinks.error_total`, and `flush.sinks.post_metrics_total` (each tagged with `sink:` and the sink name), to mirror the metrics being reported for plugin flushing.
+** New field on the warning line for `Error flushing sink` to indicate how many metrics were in the flush that encountered an error.
 
 ## Improvements
 * Updated Datadog span sink to latest version in Datadog tracing agent. Thanks, [gphat](https://github.com/gphat)!


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
- Adds metrics similar to the ones reported in plugin flushing to the sink flushing
- Adds an additional field to the sink flushing `Warn` line when it encounters an error so that we can see how many metrics may have been affected


#### Motivation
- Getting better insight into how well the sinks are working would be handy!
<!-- Why are you making this change? -->


#### Test plan
Added no tests.
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
No specific guidelines.
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @cory-stripe