### PR TITLE
Stronger sequence guarantees in gRPC idle test

### DIFF
--- a/sinks/grpsink/state_helper_test19.go
+++ b/sinks/grpsink/state_helper_test19.go
@@ -53,7 +53,7 @@ func reconnectWithin(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duratio
 		switch state {
 		case connectivity.Ready:
 			// Spin on the internal state marker that indicates the stream state is bad
-			for !atomic.CompareAndSwapUint32(&sink.bad, 0, 0) {
+			for atomic.LoadUint32(&sink.bad) != 0 {
 				// Make sure ctx hasn't expired
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
It was possible for the gRPC connection in the `TestIdleClientRecovery` test to re-enter the READY state, but have the test goroutine progress to the point of calling Ingest() before the state machine manager goroutine got rescheduled and created the stream for use, resulting in a nil pointer panic.

https://travis-ci.org/stripe/veneur/jobs/347948537

This goroutine ordering was very unlikely to occur in any sort of developer machine, but was much more likely in Travis' resource-constrained environment.

By adding a `reconnectWithin()` call and forcing the stream state marker to bad initially, it should now be impossible for the test goroutine to proceed before the stream object gets created.

#### Motivation
<!-- Why are you making this change? -->

Fix flaky test.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Fix is to a test, exclusively.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

No affect on runtime behavior of any kind.