### PR TITLE
Parallelize SSF reading from UDP sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 4.0.0, in development
 
+## Improvements
+* Receiving SSF in UDP packets now happens on `num_readers` goroutines. Thanks, [antifuchs](https://github.com/antifuchs)
+
 ## Added
 
 * The new `tags_exclude` parameter can be used to strip tags from all metrics Veneur processes, either for all supported sinks or a subset of sinks. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/example.yaml
+++ b/example.yaml
@@ -132,8 +132,9 @@ trace_lightstep_num_clients: 0
 # of metrics.
 num_workers: 96
 
-# Numbers larger than 1 will enable the use of SO_REUSEPORT, make sure
-# this is supported on your platform!
+# Adjusts the number of listening goroutines on any UDP listener
+# (statsd and SSF). Numbers larger than 1 will enable the use of
+# SO_REUSEPORT, so make sure this is supported on your platform!
 num_readers: 1
 
 # Adjusts the number of span workers across which Veneur will


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR enables reading SSF packets from UDP sockets in parallel. This should ensure our receive queues don't run over and let us process more SSF packets!

#### Motivation
We've noticed 5-6% udp packet drop rates on various hosts, which indicates we're not keeping up with the spew!


#### Test plan
- [x] roll this to our staging system:
   - ensure we have >1 readers set up
   - spew a lot of SSF
   - see how it behaves!


#### Rollout/monitoring/revert plan
Merge & roll!