### PR TITLE
Remove Fail from test names and logs

### DIFF
--- a/plugins/localfile/localfile_test.go
+++ b/plugins/localfile/localfile_test.go
@@ -73,7 +73,7 @@ func TestWritesToDevNull(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestFailsWritingToInvalidPath(t *testing.T) {
+func TestWritingToInvalidPath(t *testing.T) {
 	plugin := Plugin{FilePath: "", Logger: logrus.New(), hostname: "globblestoots"}
 	err := plugin.Flush(context.TODO(), []samplers.InterMetric{
 		samplers.InterMetric{

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -191,6 +191,9 @@ func TestConsistentForward(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
+	defer log.SetLevel(log.Level)
+	log.SetLevel(logrus.ErrorLevel)
+
 	cfg := generateProxyConfig()
 	cfg.ConsulTraceServiceName = ""
 	cfg.ConsulForwardServiceName = ""

--- a/server_test.go
+++ b/server_test.go
@@ -483,6 +483,7 @@ func readTestKeysCerts() (map[string]string, error) {
 func TestTCPConfig(t *testing.T) {
 	config := localConfig()
 	logger := logrus.New()
+	logger.Out = ioutil.Discard
 
 	config.StatsdListenAddresses = []string{"tcp://invalid:invalid"}
 	_, err := NewFromConfig(logger, config)

--- a/sinks/grpsink/grpc_stream_test.go
+++ b/sinks/grpsink/grpc_stream_test.go
@@ -63,6 +63,9 @@ func (m *MockSpanSinkServer) spanCount() int {
 }
 
 func TestEndToEnd(t *testing.T) {
+	defer log.SetLevel(log.Level)
+	log.SetLevel(logrus.ErrorLevel)
+
 	testaddr := "127.0.0.1:15111"
 	lis, err := net.Listen("tcp", testaddr)
 	if err != nil {

--- a/sinks/grpsink/grpc_stream_test.go
+++ b/sinks/grpsink/grpc_stream_test.go
@@ -63,7 +63,7 @@ func (m *MockSpanSinkServer) spanCount() int {
 }
 
 func TestEndToEnd(t *testing.T) {
-	defer log.SetLevel(log.Level)
+	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 
 	testaddr := "127.0.0.1:15111"
@@ -82,7 +82,7 @@ func TestEndToEnd(t *testing.T) {
 	}()
 	block <- struct{}{}
 
-	sink, err := NewGRPCStreamingSpanSink(context.Background(), testaddr, "test1", tags, logrus.New(), grpc.WithInsecure())
+	sink, err := NewGRPCStreamingSpanSink(context.Background(), testaddr, "test1", tags, log, grpc.WithInsecure())
 	require.NoError(t, err)
 	assert.Equal(t, sink.commonTags, tags)
 	assert.NotNil(t, sink.grpcConn)

--- a/sinks/kafka/kafka_test.go
+++ b/sinks/kafka/kafka_test.go
@@ -166,7 +166,7 @@ func TestMetricConstructor(t *testing.T) {
 	assert.Equal(t, time.Second*10, sink.config.Producer.Flush.Frequency, "flush frequency did not set correctly")
 }
 
-func TestMetricInstantiateFailure(t *testing.T) {
+func TestMetricInstantiateError(t *testing.T) {
 	logger := logrus.StandardLogger()
 
 	// Busted duration
@@ -178,7 +178,7 @@ func TestMetricInstantiateFailure(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestSpanInstantiateFailure(t *testing.T) {
+func TestSpanInstantiateError(t *testing.T) {
 	logger := logrus.StandardLogger()
 
 	// Busted duration

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -189,7 +189,7 @@ func serveUNIX(t testing.TB, laddr *net.UnixAddr, onconnect func(conn net.Conn))
 	return
 }
 
-func TestFailingUDP(t *testing.T) {
+func TestUDPError(t *testing.T) {
 	// arbitrary
 	const BufferSize = 1087152
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Remove the word "Fail" from test names and (most) logs emitted during tests.

#### Motivation
<!-- Why are you making this change? -->

This makes the log output slightly more friendly to work with. CTRL+F "Fail" will result in fewer false positives. I had hoped to eliminate them all, but that'd require forking the Lightstep library to patch out the logs they write directly to stderr, and that's a yak I don't want to shave today.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 