### PR TITLE
Hopefully fix TestReconnectBufferedUNIX

### DIFF
--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -353,10 +353,16 @@ func TestReconnectBufferedUNIX(t *testing.T) {
 		t.Logf("Flushing to the closed socket")
 		flushErr := make(chan error)
 		// Just keep trying until we get a flush kicked off
-		for FlushAsync(client, flushErr) != nil {
+		for {
+			err := FlushAsync(client, flushErr)
+			if err != ErrWouldBlock {
+				break
+			}
 			t.Log("Retrying flush on closed socket")
 			time.Sleep(1 * time.Millisecond)
 		}
+		require.NoError(t, err)
+
 		// ...and this flush should have resulted in an error
 		// (going to a closed socket and all), nothing will be
 		// received by the other side.


### PR DESCRIPTION
#### Summary
This change makes the kickoff for the "broken" flush retry, which has so far allowed the test to run hundreds of times without issue.



#### Motivation
There was one bit of unchecked non-determinism left: When flushing for the error case, the flush might not get kicked off correctly, which could cause the subsequent (post-reconnect) flush to send with the broken connection, timing out the test. We saw this happen occasionally on travis, so I'm pushing this in the hopes of appeasing the travis gods.



#### Test plan

I ran this with:

``` shellsession
$ go test -o testit -race ./trace
$ while ./testit -test.timeout 1s -test.v -test.run 'TestReconnectBufferedUNIX$' ; do : ; done
```

and let it run for a few hundred iterations locally. I think the real test will come when I push this to travis (:

#### Rollout/monitoring/revert plan
Just merge; it's a test-only change, so no changelog necessary.