### PR TITLE
Lower log level of SFx fallback message

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -34,7 +34,7 @@ func (c *collection) addPoint(key string, point *datapoint.Datapoint) {
 			return
 		}
 	}
-	logrus.WithField("key", key).WithField("pbk", c.pointsByKey).Info("I have a fallback")
+	logrus.WithField("key", key).WithField("pbk", c.pointsByKey).Debug("I have a fallback")
 
 	c.points = append(c.points, point)
 }


### PR DESCRIPTION
This log level is too high. Lower it, it's chundering.

r? @krisreeves-stripe 