### PR TITLE
Drop that annoying log statement entirely

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -34,8 +34,6 @@ func (c *collection) addPoint(key string, point *datapoint.Datapoint) {
 			return
 		}
 	}
-	logrus.WithField("key", key).WithField("pbk", c.pointsByKey).Debug("I have a fallback")
-
 	c.points = append(c.points, point)
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR drops the chunderous and kind useless log statement in the sfx sink.
<!-- Simple summary of what the code does or what you have changed. -->


#### Motivation
This should just not be there - it messes up custom log configs, and is kind of a meaningless statement anyway.

<!-- Why are you making this change? -->


#### Test plan
...none. Regression tests?


#### Rollout/monitoring/revert plan
Merge.