### PR TITLE
Bump SFx dep to pick up compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 * Receiving SSF in UDP packets now happens on `num_readers` goroutines. Thanks, [antifuchs](https://github.com/antifuchs)
+* Updated [SignalFx library](https://github.com/signalfx/golib) dependency so that compression is enabled by default, saving significant time on large metric bodies. Thanks, [gphat](https://github.com/gphat)
 
 ## Added
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -348,7 +348,7 @@
     "sfxclient",
     "timekeeper"
   ]
-  revision = "9903a08c245ee6c06a365af98dac468dc1ef519a"
+  revision = "8321403a729d6c8fa60a3dcf2c60bf20f71f6062"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -636,6 +636,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5b1b65dcd3fc400a7a6b245cea1931d676ac05c9d5657e797d248f5ae73e926f"
+  inputs-digest = "387d1ea42404e79734ed7074ae2da0421823412ec6a61dca1ff0a2a0db0ebe3e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -98,7 +98,7 @@
 
 [[constraint]]
   name = "github.com/signalfx/golib"
-  revision = "9903a08c245ee6c06a365af98dac468dc1ef519a"
+  revision = "8321403a729d6c8fa60a3dcf2c60bf20f71f6062"
 
 [[constraint]]
   name = "github.com/axiomhq/hyperloglog"

--- a/vendor/github.com/signalfx/golib/README.md
+++ b/vendor/github.com/signalfx/golib/README.md
@@ -1,6 +1,6 @@
 # golib [![Build Status](https://travis-ci.org/signalfx/golib.svg?branch=master)](https://travis-ci.org/signalfx/golib)
 
-Various golang libraries we've found useful.
+Various golang libraries we've found useful. The SignalFx client library (SDK) for Go is available [here](https://github.com/signalfx/golib/tree/master/sfxclient) along with instructions for installing the library and using the included functions.
 
 ## Dependencies
 

--- a/vendor/github.com/signalfx/golib/sfxclient/httpsink_test.go
+++ b/vendor/github.com/signalfx/golib/sfxclient/httpsink_test.go
@@ -120,6 +120,7 @@ func ExampleHTTPSink() {
 func TestHTTPDatapointSink(t *testing.T) {
 	Convey("A default sink", t, func() {
 		s := NewHTTPSink()
+		s.DisableCompression = true
 		ctx := context.Background()
 		dps := GoMetricsSource.Datapoints()
 		Convey("should timeout", func() {
@@ -341,6 +342,7 @@ func BenchmarkHTTPSinkAddSeveralEvents(b *testing.B) {
 func TestHTTPEventSink(t *testing.T) {
 	Convey("A default event sink", t, func() {
 		s := NewHTTPSink()
+		s.DisableCompression = true
 		ctx := context.Background()
 		dps := GoEventSource.Events()
 		Convey("should timeout", func() {


### PR DESCRIPTION
#### Summary
Bumps SignalFx client library.

#### Motivation
SignalFx has enabled compression on their collection endpoint and bumped their client lib to support it. It's even enabled by default!

<img width="475" alt="screen shot 2018-03-12 at 1 34 32 pm" src="https://user-images.githubusercontent.com/23101296/37308081-25596882-25fa-11e8-82e1-1d4a04049460.png">

#### Test plan
I verified this in QA and saw a 2x reduction in bytes emitted and > 2x reduction of duration.

#### Rollout/monitoring/revert plan
Verified in QA so just gonna roll it to production.

r? @asf-stripe 