### PR TITLE
Bump Veneur to Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.8
   - 1.9
+  - "1.10"
   - tip
 
 install:
@@ -12,10 +13,10 @@ install:
   - rm protoc-3.1.0-linux-x86_64.zip
   # After 1.9 hits stable, replace this link
   # It is only used for gofmt
-  - wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
-  - tar -C /tmp -xvf go1.9.linux-amd64.tar.gz go/bin/gofmt
+  - wget https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
+  - tar -C /tmp -xvf go1.10.linux-amd64.tar.gz go/bin/gofmt
   - sudo mv /tmp/go/bin/gofmt /usr/bin/gofmt
-  - rm go1.9.linux-amd64.tar.gz
+  - rm go1.10.linux-amd64.tar.gz
 
 before_script:
   - go get -u github.com/ChimeraCoder/gojson/gojson

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4
+FROM golang:1.10.0
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build

--- a/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc/grpc.go
+++ b/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc/grpc.go
@@ -138,7 +138,7 @@ func (g *grpc) GenerateImports(file *generator.FileDescriptor) {
 
 // reservedClientName records whether a client name is reserved on the client side.
 var reservedClientName = map[string]bool{
-// TODO: do we need any in gRPC?
+	// TODO: do we need any in gRPC?
 }
 
 func unexport(s string) string { return strings.ToLower(s[:1]) + s[1:] }

--- a/vendor/github.com/golang/protobuf/protoc-gen-go/grpc/grpc.go
+++ b/vendor/github.com/golang/protobuf/protoc-gen-go/grpc/grpc.go
@@ -138,7 +138,7 @@ func (g *grpc) GenerateImports(file *generator.FileDescriptor) {
 
 // reservedClientName records whether a client name is reserved on the client side.
 var reservedClientName = map[string]bool{
-// TODO: do we need any in gRPC?
+	// TODO: do we need any in gRPC?
 }
 
 func unexport(s string) string { return strings.ToLower(s[:1]) + s[1:] }

--- a/vendor/github.com/json-iterator/go/jsoniter_object_test.go
+++ b/vendor/github.com/json-iterator/go/jsoniter_object_test.go
@@ -169,7 +169,7 @@ func Test_nested_field_omit_empty(t *testing.T) {
 		F2 string `json:",omitempty"`
 	}
 	s1 := &S1{
-	//F1: "abc",
+		//F1: "abc",
 	}
 	s2 := &S2{
 		S1: s1,

--- a/vendor/github.com/zenazn/goji/web/middleware.go
+++ b/vendor/github.com/zenazn/goji/web/middleware.go
@@ -147,7 +147,7 @@ func (m *mStack) Abandon(middleware interface{}) error {
 	}
 
 	copy(m.stack[i:], m.stack[i+1:])
-	m.stack = m.stack[:len(m.stack)-1 : len(m.stack)]
+	m.stack = m.stack[: len(m.stack)-1 : len(m.stack)]
 
 	m.invalidate()
 	return nil

--- a/vendor/golang.org/x/text/unicode/norm/normalize_test.go
+++ b/vendor/golang.org/x/text/unicode/norm/normalize_test.go
@@ -720,7 +720,7 @@ var appendTestsNFC = []AppendTest{
 }
 
 var appendTestsNFD = []AppendTest{
-// TODO: Move some of the tests here.
+	// TODO: Move some of the tests here.
 }
 
 var appendTestsNFKC = []AppendTest{


### PR DESCRIPTION
#### Summary

Bump Veneur to Go 1.10, both for local development and for the version used in building artifacts on Jenkins.

This PR supersedes https://github.com/stripe/veneur/pull/365.


#### Motivation



#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

Will send a [shipped] email to the team announcing the upgrade and documenting the steps for upgrading the local development environment.

r? @stripe/observability 