### PR TITLE
AWS X-Ray Tracing Sink

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,5 +76,6 @@ type Config struct {
 	TraceLightstepNumClients      int      `yaml:"trace_lightstep_num_clients"`
 	TraceLightstepReconnectPeriod string   `yaml:"trace_lightstep_reconnect_period"`
 	TraceMaxLengthBytes           int      `yaml:"trace_max_length_bytes"`
-	TraceXrayAddress              string   `yaml:"trace_xray_address"`
+	XrayAddress                   string   `yaml:"xray_address"`
+	XraySamplePercentage          int      `yaml:"xray_sample_percentage"`
 }

--- a/config.go
+++ b/config.go
@@ -76,4 +76,5 @@ type Config struct {
 	TraceLightstepNumClients      int      `yaml:"trace_lightstep_num_clients"`
 	TraceLightstepReconnectPeriod string   `yaml:"trace_lightstep_reconnect_period"`
 	TraceMaxLengthBytes           int      `yaml:"trace_max_length_bytes"`
+	TraceXrayAddress              string   `yaml:"trace_xray_address"`
 }

--- a/example.yaml
+++ b/example.yaml
@@ -231,8 +231,14 @@ signalfx_per_tag_api_keys:
 # X-Ray can be a sink for trace spans.
 
 # If present, X-Ray will be enabled as a tracing sink
-trace_xray_address: "localhost:2000"
+xray_address: "localhost:2000"
 
+# Sample rate in percent (as an integer)
+# This should ideally be a floating point number, but at the time this was
+# written, gojson interpreted whole-number floats in yaml as integers.
+# The sink will hash the trace id of the span such that all Veneur instances
+# will sample the same segments by using the trace id as input for a checksum.
+xray_sample_percentage: 100
 
 # == LightStep ==
 # LightStep can be a sink for trace spans.

--- a/example.yaml
+++ b/example.yaml
@@ -196,7 +196,6 @@ datadog_trace_api_address: ""
 # The size of the ring buffer used for retaining spans during a flush interval.
 datadog_span_buffer_size: 16384
 
-
 # == SignalFx ==
 # SignalFx can be a sink for metrics and events.
 
@@ -227,6 +226,13 @@ signalfx_per_tag_api_keys:
   # key "definitely_no_farts"
   - name: "asf"
     api_key: "definitely_no_farts"
+
+# == X-Ray ==
+# X-Ray can be a sink for trace spans.
+
+# If present, X-Ray will be enabled as a tracing sink
+trace_xray_address: "localhost:2000"
+
 
 # == LightStep ==
 # LightStep can be a sink for trace spans.

--- a/fixtures/xray_segment.json
+++ b/fixtures/xray_segment.json
@@ -1,0 +1,2 @@
+{"format": "json", "version": 1}
+{"name":"farts-srv","id":"0000000000000002","trace_id":"1-5a7f1b99-000000000000000000000001","parent_id":"0000000000000001","start_time":1518279577,"end_time":1518279579,"type":"subsegment","annotations":{"foo":"bar"}}

--- a/fixtures/xray_segment.json
+++ b/fixtures/xray_segment.json
@@ -1,2 +1,2 @@
 {"format": "json", "version": 1}
-{"name":"farts-srv","id":"0000000000000002","trace_id":"1-5a7f1b99-000000000000000000000001","parent_id":"0000000000000001","start_time":1518279577,"end_time":1518279579,"type":"subsegment","annotations":{"foo":"bar"}}
+{"name":"farts-srv","id":"0000000000000002","trace_id":"1-5a7f1b99-000000003fdd0f60394d200c","parent_id":"0000000000000001","start_time":1518279577,"end_time":1518279579,"type":"subsegment","annotations":{"foo":"bar"}}

--- a/fixtures/xray_segment.json
+++ b/fixtures/xray_segment.json
@@ -1,2 +1,2 @@
 {"format": "json", "version": 1}
-{"name":"farts-srv","id":"0000000000000002","trace_id":"1-5a7f1b99-000000003fdd0f60394d200c","parent_id":"0000000000000001","start_time":1518279577,"end_time":1518279579,"type":"subsegment","annotations":{"foo":"bar"}}
+{"name":"farts-srv:farting farty farts","id":"0000000000000002","trace_id":"1-5a7f1b99-000000003fdd0f60394d200c","parent_id":"0000000000000001","start_time":1518279577,"end_time":1518279579,"type":"subsegment","namespace":"remote","error":false,"annotations":{"foo":"bar"}}

--- a/server.go
+++ b/server.go
@@ -353,7 +353,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		}
 
 		if conf.TraceXrayAddress != "" {
-			xraySink, err := xray.NewXRaySpanSink(conf.TraceXrayAddress, ret.Statsd, ret.TagsAsMap, log)
+			xraySink, err := xray.NewXRaySpanSink(conf.TraceXrayAddress, ret.TagsAsMap, log)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -352,8 +352,11 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			logger.Info("Configured Datadog span sink")
 		}
 
-		if conf.TraceXrayAddress != "" {
-			xraySink, err := xray.NewXRaySpanSink(conf.TraceXrayAddress, ret.TagsAsMap, log)
+		if conf.XrayAddress != "" {
+			if conf.XraySamplePercentage == 0 {
+				log.Warn("XRay sample percentage is 0, no segments will be sent.")
+			}
+			xraySink, err := xray.NewXRaySpanSink(conf.XrayAddress, conf.XraySamplePercentage, ret.TagsAsMap, log)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stripe/veneur/sinks/lightstep"
 	"github.com/stripe/veneur/sinks/signalfx"
 	"github.com/stripe/veneur/sinks/ssfmetrics"
+	"github.com/stripe/veneur/sinks/xray"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
 	"github.com/stripe/veneur/trace/metrics"
@@ -348,7 +349,17 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			}
 
 			ret.spanSinks = append(ret.spanSinks, ddSink)
-			logger.Info("Configured Datadog trace sink")
+			logger.Info("Configured Datadog span sink")
+		}
+
+		if conf.TraceXrayAddress != "" {
+			xraySink, err := xray.NewXRaySpanSink(conf.TraceXrayAddress, ret.Statsd, ret.TagsAsMap, log)
+			if err != nil {
+				return ret, err
+			}
+			ret.spanSinks = append(ret.spanSinks, xraySink)
+
+			logger.Info("Configured X-Ray span sink")
 		}
 
 		// configure Lightstep as a Span Sink
@@ -365,7 +376,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			}
 			ret.spanSinks = append(ret.spanSinks, lsSink)
 
-			logger.Info("Configured Lightstep trace sink")
+			logger.Info("Configured Lightstep span sink")
 		}
 		// Set up as many span workers as we need:
 		workerCount := 1

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -1,0 +1,129 @@
+package xray
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/protocol"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+const subsegmentType = "subsegment"
+
+var segmentHeader = []byte(`{"format": "json", "version": 1}` + "\n")
+
+// XRaySegment is a trace segment for X-Ray as defined by:
+// https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
+type XRaySegment struct {
+	Name        string            `json:"name"`
+	ID          string            `json:"id"`
+	TraceID     string            `json:"trace_id"`
+	ParentID    string            `json:"parent_id,omitempty"`
+	StartTime   float64           `json:"start_time"`
+	EndTime     float64           `json:"end_time"`
+	SegmentType string            `json:"type,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// XRaySpanSink is a sink for spans to be sent to AWS X-Ray.
+type XRaySpanSink struct {
+	daemonAddr   string
+	stats        *statsd.Client
+	traceClient  *trace.Client
+	conn         *net.UDPConn
+	commonTags   map[string]string
+	log          *logrus.Logger
+	spansHandled int64
+}
+
+var _ sinks.SpanSink = &XRaySpanSink{}
+
+// NewXRaySpanSink creates a new instance of a XRaySpanSink.
+func NewXRaySpanSink(daemonAddr string, stats *statsd.Client, commonTags map[string]string, log *logrus.Logger) (*XRaySpanSink, error) {
+
+	log.WithFields(logrus.Fields{
+		"Address": daemonAddr,
+	}).Info("Creating X-Ray client")
+
+	return &XRaySpanSink{
+		daemonAddr: daemonAddr,
+		stats:      stats,
+		commonTags: commonTags,
+		log:        log,
+	}, nil
+}
+
+// Start the sink
+func (x *XRaySpanSink) Start(cl *trace.Client) error {
+	x.traceClient = cl
+
+	xrayDaemon, err := net.ResolveUDPAddr("udp", x.daemonAddr)
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUDP("udp", nil, xrayDaemon)
+	if err != nil {
+		return err
+	}
+	x.conn = conn
+
+	return nil
+}
+
+// Name returns this sink's name.
+func (x *XRaySpanSink) Name() string {
+	return "xray"
+}
+
+// Ingest takes in a span and passed it along to the X-Ray client after
+// some sanity checks and improvements are made.
+func (x *XRaySpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+	if err := protocol.ValidateTrace(ssfSpan); err != nil {
+		return err
+	}
+
+	annos := map[string]string{}
+	for k, v := range x.commonTags {
+		annos[k] = v
+	}
+
+	segment := XRaySegment{
+		ID:          fmt.Sprintf("%016x", ssfSpan.Id),
+		TraceID:     fmt.Sprintf("1-%08x-%024x", ssfSpan.StartTimestamp/1e9, ssfSpan.TraceId),
+		Name:        ssfSpan.Service,
+		StartTime:   float64(ssfSpan.StartTimestamp / 1e9),
+		EndTime:     float64(ssfSpan.EndTimestamp / 1e9),
+		Annotations: annos,
+	}
+	if ssfSpan.ParentId != 0 {
+		segment.ParentID = fmt.Sprintf("%016x", ssfSpan.ParentId)
+		segment.SegmentType = subsegmentType
+	}
+	b, err := json.Marshal(segment)
+	if err != nil {
+		// TODO Uhm, squawk?
+	}
+	// Send the segment
+	_, err = x.conn.Write(append(segmentHeader, b...))
+	if err != nil {
+		// TODO Uh, squawk?
+	}
+
+	atomic.AddInt64(&x.spansHandled, 1)
+	return nil
+}
+
+// Flush doesn't need to do anything to us, so we emit metrics
+// instead.
+func (x *XRaySpanSink) Flush() {
+
+	x.stats.Count(sinks.MetricKeyTotalSpansFlushed, atomic.LoadInt64(&x.spansHandled), []string{fmt.Sprintf("sink:%s", x.Name())}, 1)
+	x.log.WithField("total_spans", atomic.LoadInt64(&x.spansHandled)).Debug("Checkpointing flushed spans for X-Ray")
+	atomic.SwapInt64(&x.spansHandled, 0)
+}

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -108,19 +108,21 @@ func (x *XRaySpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	}
 	b, err := json.Marshal(segment)
 	if err != nil {
-		// TODO Uhm, squawk?
+		x.log.WithError(err).Error("Error marshaling segment")
+		return err
 	}
 	// Send the segment
 	_, err = x.conn.Write(append(segmentHeader, b...))
 	if err != nil {
-		// TODO Uh, squawk?
+		x.log.WithError(err).Error("Error sending segment")
+		return err
 	}
 
 	atomic.AddInt64(&x.spansHandled, 1)
 	return nil
 }
 
-// Flush doesn't need to do anything to us, so we emit metrics
+// Flush doesn't need to do anything, so we emit metrics
 // instead.
 func (x *XRaySpanSink) Flush() {
 

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync/atomic"
+	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
@@ -97,8 +98,8 @@ func (x *XRaySpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		ID:          fmt.Sprintf("%016x", ssfSpan.Id),
 		TraceID:     fmt.Sprintf("1-%08x-%024x", ssfSpan.StartTimestamp/1e9, ssfSpan.TraceId),
 		Name:        ssfSpan.Service,
-		StartTime:   float64(ssfSpan.StartTimestamp / 1e9),
-		EndTime:     float64(ssfSpan.EndTimestamp / 1e9),
+		StartTime:   float64(float64(ssfSpan.StartTimestamp) / float64(time.Second)),
+		EndTime:     float64(float64(ssfSpan.EndTimestamp) / float64(time.Second)),
 		Annotations: annos,
 	}
 	if ssfSpan.ParentId != 0 {

--- a/sinks/xray/xray_test.go
+++ b/sinks/xray/xray_test.go
@@ -1,0 +1,20 @@
+package xray
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstructor(t *testing.T) {
+	logger := logrus.StandardLogger()
+	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
+
+	sink, err := NewXRaySpanSink("127.0.0.1:2000", stats, map[string]string{"foo": "bar"}, logger)
+	assert.NoError(t, err)
+	assert.Equal(t, "xray", sink.Name())
+	assert.Equal(t, "bar", sink.commonTags["foo"])
+	assert.Equal(t, "127.0.0.1:2000", sink.daemonAddr)
+}

--- a/sinks/xray/xray_test.go
+++ b/sinks/xray/xray_test.go
@@ -17,7 +17,7 @@ import (
 func TestConstructor(t *testing.T) {
 	logger := logrus.StandardLogger()
 
-	sink, err := NewXRaySpanSink("127.0.0.1:2000", map[string]string{"foo": "bar"}, logger)
+	sink, err := NewXRaySpanSink("127.0.0.1:2000", 100, map[string]string{"foo": "bar"}, logger)
 	assert.NoError(t, err)
 	assert.Equal(t, "xray", sink.Name())
 	assert.Equal(t, "bar", sink.commonTags["foo"])
@@ -54,7 +54,7 @@ func TestIngestSpans(t *testing.T) {
 		}
 	}()
 
-	sink, err := NewXRaySpanSink(fmt.Sprintf("127.0.0.1:%d", port), map[string]string{"foo": "bar"}, logrus.New())
+	sink, err := NewXRaySpanSink(fmt.Sprintf("127.0.0.1:%d", port), 100, map[string]string{"foo": "bar"}, logrus.New())
 	assert.NoError(t, err)
 	err = sink.Start(nil)
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestIngestSpans(t *testing.T) {
 	end := start.Add(2 * time.Second)
 
 	testSpan := &ssf.SSFSpan{
-		TraceId:        1,
+		TraceId:        4601851300195147788,
 		ParentId:       1,
 		Id:             2,
 		StartTimestamp: int64(start.UnixNano()),
@@ -80,6 +80,106 @@ func TestIngestSpans(t *testing.T) {
 	}
 	err = sink.Ingest(testSpan)
 	assert.NoError(t, err)
+
+	select {
+	case seg := <-segments:
+		assert.Equal(t, string(fixtureSegment), seg)
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Did not receive segment from xray ingest")
+	}
+
+	assert.Equal(t, int64(1), sink.spansHandled)
+	sink.Flush()
+	assert.Equal(t, int64(0), sink.spansHandled)
+}
+
+func TestSampleSpans(t *testing.T) {
+
+	// Load up a fixture to compare the output to what we get over UDP
+	reader, err := os.Open(filepath.Join("..", "..", "fixtures", "xray_segment.json"))
+	assert.NoError(t, err)
+	defer reader.Close()
+	fixtureSegment, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+
+	// Don't use a port so we get one auto-assigned
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	sock, _ := net.ListenUDP("udp", udpAddr)
+	defer sock.Close()
+	// Grab the port we got assigned so we can use it.
+	port := sock.LocalAddr().(*net.UDPAddr).Port
+
+	segments := make(chan string)
+
+	buf := make([]byte, 1024)
+	go func() {
+		for {
+			n, _, serr := sock.ReadFromUDP(buf)
+			segments <- string(buf[0:n])
+			if serr != nil {
+				assert.NoError(t, serr)
+			}
+		}
+	}()
+
+	sink, err := NewXRaySpanSink(fmt.Sprintf("127.0.0.1:%d", port), 50, map[string]string{"foo": "bar"}, logrus.New())
+	assert.NoError(t, err)
+	err = sink.Start(nil)
+	assert.NoError(t, err)
+
+	// Because xray uses the timestamp as part of the trace id, this must remain
+	// fixed for the fixture comparison to work!
+	start := time.Unix(1518279577, 0)
+	end := start.Add(2 * time.Second)
+
+	testSpan := &ssf.SSFSpan{
+		TraceId:        548547320537590250, // This one will NOT be sampled!
+		ParentId:       1,
+		Id:             2,
+		StartTimestamp: int64(start.UnixNano()),
+		EndTimestamp:   int64(end.UnixNano()),
+		Error:          false,
+		Service:        "farts-srv",
+		Tags: map[string]string{
+			"baz": "qux",
+		},
+		Indicator: false,
+		Name:      "farting farty farts",
+	}
+	assert.NoError(t, sink.Ingest(testSpan))
+
+	testSpan2 := &ssf.SSFSpan{
+		TraceId:        548547320537590250, // This one will NOT be sampled!
+		ParentId:       1,
+		Id:             2,
+		StartTimestamp: int64(start.UnixNano()),
+		EndTimestamp:   int64(end.UnixNano()),
+		Error:          false,
+		Service:        "farts-srv",
+		Tags: map[string]string{
+			"baz": "qux",
+		},
+		Indicator: false,
+		Name:      "farting farty farts",
+	}
+	assert.NoError(t, sink.Ingest(testSpan2))
+
+	testSpan3 := &ssf.SSFSpan{
+		TraceId:        4601851300195147788, // This one will be sampled!
+		ParentId:       1,
+		Id:             2,
+		StartTimestamp: int64(start.UnixNano()),
+		EndTimestamp:   int64(end.UnixNano()),
+		Error:          false,
+		Service:        "farts-srv",
+		Tags: map[string]string{
+			"baz": "qux",
+		},
+		Indicator: false,
+		Name:      "farting farty farts",
+	}
+	assert.NoError(t, sink.Ingest(testSpan3))
 
 	select {
 	case seg := <-segments:

--- a/sinks/xray/xray_test.go
+++ b/sinks/xray/xray_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/ssf"
@@ -17,9 +16,8 @@ import (
 
 func TestConstructor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
 
-	sink, err := NewXRaySpanSink("127.0.0.1:2000", stats, map[string]string{"foo": "bar"}, logger)
+	sink, err := NewXRaySpanSink("127.0.0.1:2000", map[string]string{"foo": "bar"}, logger)
 	assert.NoError(t, err)
 	assert.Equal(t, "xray", sink.Name())
 	assert.Equal(t, "bar", sink.commonTags["foo"])
@@ -56,9 +54,7 @@ func TestIngestSpans(t *testing.T) {
 		}
 	}()
 
-	stats, _ := statsd.NewBuffered("localhost:1235", 1024)
-
-	sink, err := NewXRaySpanSink(fmt.Sprintf("127.0.0.1:%d", port), stats, map[string]string{"foo": "bar"}, logrus.New())
+	sink, err := NewXRaySpanSink(fmt.Sprintf("127.0.0.1:%d", port), map[string]string{"foo": "bar"}, logrus.New())
 	assert.NoError(t, err)
 	err = sink.Start(nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Summary
Add support for AWS X-Ray tracing as a span sink.

This PR supersedes https://github.com/stripe/veneur/pull/359 (see https://github.com/stripe/veneur/pull/359#issuecomment-364670510 for details).


#### Motivation
X-Ray uses [a local system agent](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html) that receives spans [as JSON](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html) over UDP. It looks like this:

<img width="1019" alt="screenshot 2018-01-20 12 09 00" src="https://user-images.githubusercontent.com/45159/35186495-c1659018-fdda-11e7-8dc0-47ae20a1ddc6.png">

#### Testing
Includes a basic test as well as an agent simulation test where we read from UDP and compare to a test fixture.