### PR TITLE
Decrease logging volume from proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 * Receiving SSF in UDP packets now happens on `num_readers` goroutines. Thanks, [antifuchs](https://github.com/antifuchs)
 * Updated [SignalFx library](https://github.com/signalfx/golib) dependency so that compression is enabled by default, saving significant time on large metric bodies. Thanks, [gphat](https://github.com/gphat)
+* Decreased logging output of veneur-proxy. Thanks, [gphat](https://github.com/gphat)!
 
 ## Added
 


### PR DESCRIPTION
#### Summary
Decrease logging volume from proxy/

#### Motivation
The proxy emits a log line for each destination it forwards to. On a high volume instance with many globals to forward to, this can be kinda loud.

```
[2018-03-19 15:33:02.883392] time="2018-03-19T15:33:02Z" level=info msg="Completed forward to upstream Veneur" metrics=10
[2018-03-19 15:33:02.883689] time="2018-03-19T15:33:02Z" level=info msg="Completed forward to upstream Veneur" metrics=3
[2018-03-19 15:33:02.883992] time="2018-03-19T15:33:02Z" level=info msg="Completed forward to upstream Veneur" metrics=2
[2018-03-19 15:33:02.884274] time="2018-03-19T15:33:02Z" level=info msg="Completed forward to upstream Veneur" metrics=3
```

This changes things to only log once for reach incoming import request, rather than `n` entries where `n` is the number of globals we merge to.

#### Test plan
Existing tests.

r? @stripe/observability 