### PR TITLE
Validate veneur-emit mode + flag combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Receiving SSF in UDP packets now happens on `num_readers` goroutines. Thanks, [antifuchs](https://github.com/antifuchs)
 * Updated [SignalFx library](https://github.com/signalfx/golib) dependency so that compression is enabled by default, saving significant time on large metric bodies. Thanks, [gphat](https://github.com/gphat)
 * Decreased logging output of veneur-proxy. Thanks, [gphat](https://github.com/gphat)!
+* Better warnings when invalid flag combinations are passed to `veneur-emit`. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Added
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -69,6 +69,73 @@ var (
 	indicator = flag.Bool("indicator", false, "Mark the reported span as an indicator span")
 )
 
+type EmitMode uint
+
+const (
+	MetricMode EmitMode = 1 << iota
+	EventMode
+	ServiceCheckMode
+	AllModes = MetricMode | EventMode | ServiceCheckMode
+)
+
+func (m EmitMode) String() string {
+	switch m {
+	case MetricMode:
+		return "metric"
+	case EventMode:
+		return "event"
+	case ServiceCheckMode:
+		return "sc"
+	case AllModes:
+		return "any"
+	}
+
+	return ""
+}
+
+var flagModeMappings = map[string]EmitMode{}
+
+func init() {
+	for mode, flags := range map[EmitMode][]string{
+		AllModes: []string{
+			"hostport",
+			"debug",
+			"command",
+		},
+		MetricMode: []string{
+			"name",
+			"gauge",
+			"timing",
+			"count",
+			"tag",
+			"ssf",
+		},
+		EventMode: []string{
+			"e_title",
+			"e_text",
+			"e_time",
+			"e_hostname",
+			"e_aggr_key",
+			"e_priority",
+			"e_source_type",
+			"e_alert_type",
+			"e_event_tags",
+		},
+		ServiceCheckMode: []string{
+			"sc_name",
+			"sc_status",
+			"sc_time",
+			"sc_hostname",
+			"sc_tags",
+			"sc_msg",
+		},
+	} {
+		for _, flag := range flags {
+			flagModeMappings[flag] = mode
+		}
+	}
+}
+
 const (
 	envTraceID = "VENEUR_EMIT_TRACE_ID"
 	envSpanID  = "VENEUR_EMIT_PARENT_SPAN_ID"
@@ -92,6 +159,8 @@ func main() {
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	validateFlagCombinations(passedFlags)
 
 	addr, netAddr, err := destination(hostport, *toSSF)
 	if err != nil {
@@ -435,6 +504,30 @@ func sendStatsd(addr string, span *ssf.SSFSpan) error {
 		}
 	}
 	return nil
+}
+
+func validateFlagCombinations(passedFlags map[string]flag.Value) {
+	// Figure out which mode we're in
+	var mode EmitMode
+	mv, has := passedFlags["mode"]
+	if !has {
+		mode = MetricMode
+	} else {
+		switch mv.String() {
+		case "metric":
+			mode = MetricMode
+		case "event":
+			mode = EventMode
+		case "sc":
+			mode = ServiceCheckMode
+		}
+	}
+
+	for flagname := range passedFlags {
+		if fmode, has := flagModeMappings[flagname]; has && (fmode&mode) != mode {
+			logrus.Fatalf("Flag %q is only valid with \"-mode %s\"", flagname, fmode)
+		}
+	}
 }
 
 func buildEventPacket(passedFlags map[string]flag.Value) (bytes.Buffer, error) {

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -519,6 +519,7 @@ func validateFlagCombinations(passedFlags map[string]flag.Value) {
 	// Figure out which mode we're in
 	var mode EmitMode
 	mv, has := passedFlags["mode"]
+	// "metric" is the default mode, so assume that if the flag wasn't passed.
 	if !has {
 		mode = MetricMode
 	} else {

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -414,8 +414,17 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 	tags := map[string]string{}
 	if tagStr != "" {
 		for _, elem := range strings.Split(tagStr, ",") {
+			if len(elem) == 0 {
+				// Gracefully ignore a trailing comma.
+				continue
+			}
+
 			tag := strings.Split(elem, ":")
-			tags[tag[0]] = tag[1]
+			if len(tag) == 2 {
+				tags[tag[0]] = tag[1]
+			} else {
+				logrus.Fatalf("Arguments to -tag should be of the form <key>:<value>, got %q", elem)
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Adds validation to ensure that the `-mode` of `veneur-emit` aligns with the flags that have been passed.

i didn't thoroughly validate that my assumptions about which flags belong in which groups were correct. i also omitted the trace-related flags. That definitely needs a check over.

Also checks that the arguments to `-tag` are well-formed, and provides a helpful err (instead of panicking)

#### Motivation
<!-- Why are you making this change? -->

Otherwise, `veneur-emit` fails silently when using flags from the wrong mode.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Ran basic checks on the CLI. Not really easy to do automated tests for this.

r? @cory-stripe 