### PR TITLE
Add periodic runtime metric reporting for veneur-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * `veneur.worker.span_chan.total_elements` over `veneur.worker.span_chan.total_capacity` gives the utilization of the sink ingestion channel.
 * Introduce a generic gRPC streaming backend for trace spans. Thanks, [sdboyer](https://github.com/sdboyer)!
 * New config keys `signalfx_vary_key_by` and `signalfx_per_tag_api_keys` which which allow sending signalfx data points with an API key specific to these data points' dimensions. Thanks, [antifuchs](https://github.com/antifuchs)!
+* veneur-proxy now reports runtime metrics (with the prefix `veneur-proxy.`) at a configurable interval controlled by `runtime_metrics_interval`. It defaults to 10s. Thanks [gphat](https://github.com/gphat)!
 
 # 3.0.0, 2018-02-27
 

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -9,6 +9,7 @@ type ProxyConfig struct {
 	ForwardAddress           string `yaml:"forward_address"`
 	ForwardTimeout           string `yaml:"forward_timeout"`
 	HTTPAddress              string `yaml:"http_address"`
+	RuntimeMetricsInterval   string `yaml:"runtime_metrics_interval"`
 	SentryDsn                string `yaml:"sentry_dsn"`
 	SsfDestinationAddress    string `yaml:"ssf_destination_address"`
 	StatsAddress             string `yaml:"stats_address"`

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -3,6 +3,9 @@ debug: true
 enable_profiling: false
 http_address: "localhost:8127"
 
+# How often to flush metrics about the Go runtime (heap, GC, etc)
+runtime_metrics_interval: "10s"
+
 # How often to refresh from Consul's healthy nodes
 consul_refresh_interval: "30s"
 


### PR DESCRIPTION
#### Summary
Periodically report runtime metrics from veneur-proxy.


#### Motivation
We recently saw an OOM on a veneur-proxy instance. Since we have no runtime information here, it was difficult to see what lead to the problem. Since we already report these metrics from veneur, it seems we should do it in veneur-proxy too!

#### Test plan
Didn't, since we'd have to test the metric emission which we ironically don't do anywhere. Will test out in QA?

r? @stripe/observability 