### PR TITLE
Attempt to debug & fix TestReconnectBufferedUNIX for real

### DIFF
--- a/trace/backend.go
+++ b/trace/backend.go
@@ -188,7 +188,7 @@ func (ds *streamBackend) connection(conn net.Conn) {
 	}
 }
 
-// SendSync on a DirectStream attempts to write the packet on the
+// SendSync on a streamBackend attempts to write the packet on the
 // connection to the upstream veneur directly. If it encounters a
 // protocol error, SendSync will return the original protocol error once
 // the connection is re-established.


### PR DESCRIPTION
#### Summary

This PR hopefully :100:% fixes the TestReconnectBufferedUNIX for good. Double non-determinism in `select` default branches means we have to loop for the outer _as well as_ the inner result. 

What happened was: Flushing a TraceBackend happens in two steps:
* One, `FlushAsync` kicks off the flush in the background. If the goroutine is busy/not reading from the chan, this can return `ErrWouldBlock`. We handled this case!
* Two, the background goroutine will loop over flushable backends and try to kick off the flush on each. This also errs towards not flushing & setting `ErrWouldBlock` if the backend is busy. We didn't handle this case!

The part of the test that this was in was expecting a "real" error (not ErrWouldBlock) from the flush, and so in the relatively rare cases that ErrWouldBlock was returned, it would not have kicked off the flush and the later parts of the test would fail. Now, we handle both cases, so the test should correctly be in the right state always.

#### Motivation

This broke travis ci builds a bunch.

#### Test plan
Ran Travis CI tests a bunch


#### Rollout/monitoring/revert plan
Just merge, no changelog necessary.
