### PR TITLE
Add default for span channel capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * New config keys `signalfx_vary_key_by` and `signalfx_per_tag_api_keys` which which allow sending signalfx data points with an API key specific to these data points' dimensions. Thanks, [antifuchs](https://github.com/antifuchs)!
 * veneur-proxy now reports runtime metrics (with the prefix `veneur-proxy.`) at a configurable interval controlled by `runtime_metrics_interval`. It defaults to 10s. Thanks [gphat](https://github.com/gphat)!
 * Allow specifying trace start/end times on `veneur-emit`. Thanks, [sdboyer](https://github.com/sdboyer)!
+* Default `span_channel_capacity` to a non-zero value so we don't drop most spans in a minimal configuration. Thanks, [gphat](http://github.com/gphat)!
 
 # 3.0.0, 2018-02-27
 

--- a/config_parse.go
+++ b/config_parse.go
@@ -17,6 +17,7 @@ var defaultConfig = Config{
 	Interval:               "10s",
 	MetricMaxLength:        4096,
 	ReadBufferSizeBytes:    1048576 * 2, // 2 MiB
+	SpanChannelCapacity:    100,
 }
 
 // ReadProxyConfig unmarshals the proxy config file and slurps in its data.
@@ -176,6 +177,10 @@ func (c *Config) applyDefaults() {
 
 	if c.DatadogFlushMaxPerBody == 0 {
 		c.DatadogFlushMaxPerBody = defaultConfig.DatadogFlushMaxPerBody
+	}
+
+	if c.SpanChannelCapacity == 0 {
+		c.SpanChannelCapacity = defaultConfig.SpanChannelCapacity
 	}
 }
 


### PR DESCRIPTION
#### Summary
Set the `span_channel_capacity` to a reasonable default if 0.

#### Motivation
A minimal or upgrade configuration that does not specify this configuration option will currently default to 0 and drop most spans.

#### Test plan
Existing default config unit test.

r? @sdboyer-stripe 
cc @stripe/observability 