### PR TITLE
Normalize flush of events and service checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated [SignalFx library](https://github.com/signalfx/golib) dependency so that compression is enabled by default, saving significant time on large metric bodies. Thanks, [gphat](https://github.com/gphat)
 * Decreased logging output of veneur-proxy. Thanks, [gphat](https://github.com/gphat)!
 * Better warnings when invalid flag combinations are passed to `veneur-emit`. Thanks, [sdboyer](https://github.com/sdboyer)!
+* Revamped how sinks handle DogStatsD's events and service checks. Thanks, [gphat](https://github.com/gphat)
 
 ## Added
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -642,6 +642,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9d41201a0c1a519f0fe2b049fd072210d4e24a8783ee408ee0c7861458cbd5d7"
+  inputs-digest = "42a5bb925a3dedbc5e5b03a67c08e99414354fcd0dfa1b2ef30bafe55e9b37fe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,7 +66,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.0"
+  version = "1.2.1"
 
 [[constraint]]
   name = "github.com/zenazn/goji"

--- a/flusher.go
+++ b/flusher.go
@@ -32,14 +32,11 @@ func (s *Server) Flush(ctx context.Context) {
 		ssf.Gauge("worker.span_chan.total_capacity", float32(cap(s.SpanChan)), nil),
 	)
 
-	// TODO Why is this not in the worker the way the trace worker is set up?
-	events, checks := s.EventWorker.Flush()
-	span.Add(ssf.Count("worker.events_flushed_total", float32(len(events)), nil),
-		ssf.Count("worker.checks_flushed_total", float32(len(checks)), nil))
+	samples := s.EventWorker.Flush()
 
 	// TODO Concurrency
 	for _, sink := range s.metricSinks {
-		sink.FlushEventsChecks(span.Attach(ctx), events, checks)
+		sink.FlushOtherSamples(span.Attach(ctx), samples)
 	}
 
 	go s.flushTraces(span.Attach(ctx))

--- a/parser_test.go
+++ b/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/protocol"
+	"github.com/stripe/veneur/protocol/dogstatsd"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/ssf"
 )
@@ -517,16 +518,20 @@ func TestGlobalOnlyEscape(t *testing.T) {
 func TestEvents(t *testing.T) {
 	evt, err := samplers.ParseEvent([]byte("_e{3,3}:foo|bar|k:foos|s:test|t:success|p:low|#foo:bar,baz:qux|d:1136239445|h:example.com"))
 	assert.NoError(t, err, "should have parsed correctly")
-	assert.EqualValues(t, &samplers.UDPEvent{
-		Title:       "foo",
-		Text:        "bar",
-		Timestamp:   1136239445,
-		Aggregation: "foos",
-		Source:      "test",
-		AlertLevel:  "success",
-		Priority:    "low",
-		Tags:        []string{"foo:bar", "baz:qux"},
-		Hostname:    "example.com",
+	assert.EqualValues(t, &ssf.SSFSample{
+		Name:      "foo",
+		Message:   "bar",
+		Timestamp: 1136239445,
+		Tags: map[string]string{
+			dogstatsd.EventIdentifierKey:        "",
+			dogstatsd.EventAggregationKeyTagKey: "foos",
+			dogstatsd.EventSourceTypeTagKey:     "test",
+			dogstatsd.EventAlertTypeTagKey:      "success",
+			dogstatsd.EventPriorityTagKey:       "low",
+			dogstatsd.EventHostnameTagKey:       "example.com",
+			"foo": "bar",
+			"baz": "qux",
+		},
 	}, evt, "should have parsed event")
 
 	table := map[string]string{
@@ -549,13 +554,17 @@ func TestEvents(t *testing.T) {
 }
 
 func TestServiceChecks(t *testing.T) {
-	evt, err := samplers.ParseServiceCheck([]byte("_sc|foo.bar|0|d:1136239445|h:example.com"))
+	evt, err := samplers.ParseServiceCheck([]byte("_sc|foo.bar|0|#foo:bar|d:1136239445|h:example.com"))
 	assert.NoError(t, err, "should have parsed correctly")
-	assert.EqualValues(t, &samplers.UDPServiceCheck{
+	assert.EqualValues(t, &ssf.SSFSample{
 		Name:      "foo.bar",
-		Status:    0,
+		Status:    ssf.SSFSample_OK,
 		Timestamp: 1136239445,
-		Hostname:  "example.com",
+		Tags: map[string]string{
+			dogstatsd.CheckIdentifierKey:  "",
+			dogstatsd.CheckHostnameTagKey: "example.com",
+			"foo": "bar",
+		},
 	}, evt, "should have parsed event")
 
 	table := map[string]string{
@@ -576,7 +585,7 @@ func TestEventMessageUnescape(t *testing.T) {
 	packet := []byte("_e{3,15}:foo|foo\\nbar\\nbaz\\n")
 	evt, err := samplers.ParseEvent(packet)
 	assert.NoError(t, err, "Should have parsed correctly")
-	assert.Equal(t, "foo\nbar\nbaz\n", evt.Text, "Should contain newline")
+	assert.Equal(t, "foo\nbar\nbaz\n", evt.Message, "Should contain newline")
 }
 
 func TestServiceCheckMessageUnescape(t *testing.T) {
@@ -622,6 +631,14 @@ func TestConsecutiveParseSSF(t *testing.T) {
 
 	assert.Equal(t, int64(12345679), span2.Id)
 	assert.Equal(t, "", span2.Tags["foo"], "Tagless span has tags!")
+}
+
+func TestTagSliceToMap(t *testing.T) {
+	tags := []string{"foo:bar", "baz:gorch", "blerg"}
+	mappedTags := samplers.ParseTagSliceToMap(tags)
+	assert.Equal(t, "bar", mappedTags["foo"])
+	assert.Equal(t, "gorch", mappedTags["baz"])
+	assert.Equal(t, "", mappedTags["blerg"])
 }
 
 func BenchmarkParseSSF(b *testing.B) {

--- a/protocol/dogstatsd/protocol.go
+++ b/protocol/dogstatsd/protocol.go
@@ -1,0 +1,25 @@
+package dogstatsd
+
+// CheckIdentifierKey flags a sample as a DogStatsD service check
+const CheckIdentifierKey = "vdogstatsd_sc"
+
+// CheckHostnameTagKey is a tag key used to conduct the hostname of a service check to a sink
+const CheckHostnameTagKey = "vdogstatsd_hostname"
+
+// EventAggregationKeyTagKey is a tag key used to conduct the aggregation key of an event to a sink
+const EventAggregationKeyTagKey = "vdogstatsd_ak"
+
+// EventAlertTypeTagKey is a tag key used to conduct the alert type of an event to a sink
+const EventAlertTypeTagKey = "vdogstatsd_at"
+
+// EventHostnameTagKey is a tag key used to conduct the hostname of an event to a sink
+const EventHostnameTagKey = "vdogstatsd_hostname"
+
+// EventIdentifierKey is a tag key used to conduct the event identifier of an event to a sink
+const EventIdentifierKey = "vdogstatsd_ev"
+
+// EventPriorityTagKey is a tag key used to conduct the priority of an event to a sink
+const EventPriorityTagKey = "vdogstatsd_pri"
+
+// EventSourceTypeTagKey is a tag key used to conduct the source type of an event to a sink
+const EventSourceTypeTagKey = "vdogstatsd_st"

--- a/server.go
+++ b/server.go
@@ -130,15 +130,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	ret.Hostname = conf.Hostname
 	ret.Tags = conf.Tags
 
-	mappedTags := make(map[string]string)
-	for _, tag := range ret.Tags {
-		splt := strings.SplitN(tag, ":", 2)
-		if len(splt) < 2 {
-			mappedTags[splt[0]] = ""
-		} else {
-			mappedTags[splt[0]] = splt[1]
-		}
-	}
+	mappedTags := samplers.ParseTagSliceToMap(ret.Tags)
 
 	ret.synchronizeInterval = conf.SynchronizeWithInterval
 
@@ -606,7 +598,7 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 			samples.Add(ssf.Count("packet.error_total", 1, map[string]string{"packet_type": "event", "reason": "parse"}))
 			return err
 		}
-		s.EventWorker.EventChan <- *event
+		s.EventWorker.sampleChan <- *event
 	} else if bytes.HasPrefix(packet, []byte{'_', 's', 'c'}) {
 		svcheck, err := samplers.ParseServiceCheck(packet)
 		if err != nil {
@@ -617,7 +609,7 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 			samples.Add(ssf.Count("packet.error_total", 1, map[string]string{"packet_type": "service_check", "reason": "parse"}))
 			return err
 		}
-		s.EventWorker.ServiceCheckChan <- *svcheck
+		s.EventWorker.sampleChan <- *svcheck
 	} else {
 		metric, err := samplers.ParseMetric(packet)
 		if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -192,7 +192,7 @@ func (c *channelMetricSink) Flush(ctx context.Context, metrics []samplers.InterM
 	return nil
 }
 
-func (c *channelMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+func (c *channelMetricSink) FlushOtherSamples(ctx context.Context, events []ssf.SSFSample) {
 	return
 }
 

--- a/sinks/blackhole/blackhole.go
+++ b/sinks/blackhole/blackhole.go
@@ -33,7 +33,7 @@ func (b *blackholeMetricSink) Flush(context.Context, []samplers.InterMetric) err
 	return nil
 }
 
-func (b *blackholeMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+func (b *blackholeMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
 	return
 }
 

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	vhttp "github.com/stripe/veneur/http"
 	"github.com/stripe/veneur/protocol"
+	"github.com/stripe/veneur/protocol/dogstatsd"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
@@ -42,6 +43,19 @@ type DatadogMetricSink struct {
 	log             *logrus.Logger
 }
 
+// DDEvent represents the structure of datadog's undocumented /intake endpoint
+type DDEvent struct {
+	Title       string   `json:"msg_title"`
+	Text        string   `json:"msg_text"`
+	Timestamp   int64    `json:"timestamp,omitempty"` // represented as a unix epoch
+	Hostname    string   `json:"host,omitempty"`
+	Aggregation string   `json:"aggregation_key,omitempty"`
+	Priority    string   `json:"priority,omitempty"`
+	Source      string   `json:"source_type_name,omitempty"`
+	AlertType   string   `json:"alert_type,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
 // DDMetric is a data structure that represents the JSON that Datadog
 // wants when posting to the API
 type DDMetric struct {
@@ -52,6 +66,16 @@ type DDMetric struct {
 	Hostname   string        `json:"host,omitempty"`
 	DeviceName string        `json:"device_name,omitempty"`
 	Interval   int32         `json:"interval,omitempty"`
+}
+
+// DDServiceCheck is a representation of the service check.
+type DDServiceCheck struct {
+	Name      string   `json:"check"`
+	Status    int      `json:"status"`
+	Hostname  string   `json:"host_name"`
+	Timestamp int64    `json:"timestamp,omitempty"` // represented as a unix epoch
+	Tags      []string `json:"tags,omitempty"`
+	Message   string   `json:"message,omitempty"`
 }
 
 // NewDatadogMetricSink creates a new Datadog sink for trace spans.
@@ -114,22 +138,106 @@ func (dd *DatadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.
 	return nil
 }
 
-func (dd *DatadogMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
+
+	events := []DDEvent{}
+	checks := []DDServiceCheck{}
+
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	defer span.ClientFinish(dd.traceClient)
 
 	// fill in the default hostname for packets that didn't set it
-	for i := range events {
-		if events[i].Hostname == "" {
-			events[i].Hostname = dd.hostname
+	for _, sample := range samples {
+
+		if _, ok := sample.Tags[dogstatsd.CheckIdentifierKey]; ok {
+			// This is a service check!
+			ret := DDServiceCheck{
+				Name:      sample.Name,
+				Message:   sample.Message,
+				Timestamp: sample.Timestamp,
+				Status:    0, // How to intify? TODO TKTK
+			}
+
+			// Defensively copy the tags that came in
+			tags := map[string]string{}
+			for k, v := range sample.Tags {
+				tags[k] = v
+			}
+			// Remove the tag that flagged this as a service check
+			delete(tags, dogstatsd.CheckIdentifierKey)
+
+			if v, ok := tags[dogstatsd.CheckHostnameTagKey]; ok {
+				ret.Hostname = v
+				delete(tags, dogstatsd.CheckHostnameTagKey)
+			} else {
+				// Default hostname since there isn't one
+				ret.Hostname = dd.hostname
+			}
+
+			// Do our last bit of tag housekeeping
+			finalTags := []string{}
+			for k, v := range tags {
+				finalTags = append(finalTags, fmt.Sprintf("%s:%s", k, v))
+			}
+			ret.Tags = append(finalTags, dd.tags...)
+
+			checks = append(checks, ret)
+
+		} else if _, ok := sample.Tags[dogstatsd.EventIdentifierKey]; ok {
+			// This is an event!
+			ret := DDEvent{
+				Title:     sample.Name,
+				Text:      sample.Message,
+				Timestamp: sample.Timestamp,
+				Priority:  "normal",
+				AlertType: "info",
+			}
+
+			// Defensively copy the tags that came in
+			tags := map[string]string{}
+			for k, v := range sample.Tags {
+				tags[k] = v
+			}
+			// Remove the tag that flagged this as an event
+			delete(tags, dogstatsd.EventIdentifierKey)
+
+			// The parser uses special tags to encode the fields for us from DogStatsD
+			// that don't fit into a normal SSF Sample. We'll hunt for each one and
+			// delete the tag if we find it.
+			if v, ok := tags[dogstatsd.EventAggregationKeyTagKey]; ok {
+				ret.Aggregation = v
+				delete(tags, dogstatsd.EventAggregationKeyTagKey)
+			}
+			if v, ok := tags[dogstatsd.EventPriorityTagKey]; ok {
+				ret.Priority = v
+				delete(tags, dogstatsd.EventPriorityTagKey)
+			}
+			if v, ok := tags[dogstatsd.EventSourceTypeTagKey]; ok {
+				ret.Source = v
+				delete(tags, dogstatsd.EventSourceTypeTagKey)
+			}
+			if v, ok := tags[dogstatsd.EventAlertTypeTagKey]; ok {
+				ret.AlertType = v
+				delete(tags, dogstatsd.EventAlertTypeTagKey)
+			}
+			if v, ok := tags[dogstatsd.EventHostnameTagKey]; ok {
+				ret.Hostname = v
+				delete(tags, dogstatsd.EventHostnameTagKey)
+			} else {
+				// Default hostname since there isn't one
+				ret.Hostname = dd.hostname
+			}
+			// Do our last bit of tag housekeeping
+			finalTags := []string{}
+			for k, v := range tags {
+				finalTags = append(finalTags, fmt.Sprintf("%s:%s", k, v))
+			}
+
+			ret.Tags = append(finalTags, dd.tags...)
+			events = append(events, ret)
+		} else {
+			dd.log.Warn("Received an SSF Sample that wasn't an event or service check, ack!")
 		}
-		events[i].Tags = append(events[i].Tags, dd.tags...)
-	}
-	for i := range checks {
-		if checks[i].Hostname == "" {
-			checks[i].Hostname = dd.hostname
-		}
-		checks[i].Tags = append(checks[i].Tags, dd.tags...)
 	}
 
 	if len(events) != 0 {
@@ -137,7 +245,7 @@ func (dd *DatadogMetricSink) FlushEventsChecks(ctx context.Context, events []sam
 		// the official dd-agent
 		// we don't actually pass all the body keys that dd-agent passes here... but
 		// it still works
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/intake?api_key=%s", dd.DDHostname, dd.APIKey), map[string]map[string][]samplers.UDPEvent{
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/intake?api_key=%s", dd.DDHostname, dd.APIKey), map[string]map[string][]DDEvent{
 			"events": {
 				"api": events,
 			},

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -3,6 +3,7 @@ package datadog
 import (
 	"compress/zlib"
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/protocol/dogstatsd"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/ssf"
 )
@@ -22,6 +24,12 @@ import (
 // Eventually we'll want to define this symmetrically.
 type DDMetricsRequest struct {
 	Series []DDMetric
+}
+
+type DDEventRequest struct {
+	Events struct {
+		Api []DDEvent
+	}
 }
 
 func TestDatadogRate(t *testing.T) {
@@ -122,16 +130,24 @@ type DatadogRoundTripper struct {
 	Contains      string
 	GotCalled     bool
 	ThingReceived bool
+	Contents      string
 }
 
 func (rt *DatadogRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rec := httptest.NewRecorder()
 	if strings.HasPrefix(req.URL.Path, rt.Endpoint) {
-		body, _ := ioutil.ReadAll(req.Body)
-		defer req.Body.Close()
-		if strings.Contains(string(body), rt.Contains) {
-			rt.ThingReceived = true
+		bstream := req.Body
+		if req.Header.Get("Content-Encoding") == "deflate" {
+			bstream, _ = zlib.NewReader(req.Body)
 		}
+		body, _ := ioutil.ReadAll(bstream)
+		defer bstream.Close()
+		if rt.Contains != "" {
+			if strings.Contains(string(body), rt.Contains) {
+				rt.ThingReceived = true
+			}
+		}
+		rt.Contents = string(body)
 
 		rec.Code = http.StatusOK
 		rt.GotCalled = true
@@ -270,4 +286,106 @@ func TestDatadogMetricRouting(t *testing.T) {
 		})
 	}
 
+}
+
+func TestDatadogFlushEvents(t *testing.T) {
+	transport := &DatadogRoundTripper{Endpoint: "/intake", Contains: ""}
+	ddSink, err := NewDatadogMetricSink(10, 2500, "example.com", []string{"gloobles:toots"}, "http://example.com", "secret", &http.Client{Transport: transport}, logrus.New())
+	assert.NoError(t, err)
+
+	testEvent := ssf.SSFSample{
+		Name:      "foo",
+		Message:   "bar",
+		Timestamp: 1136239445,
+		Tags: map[string]string{
+			dogstatsd.EventIdentifierKey:        "",
+			dogstatsd.EventAggregationKeyTagKey: "foos",
+			dogstatsd.EventSourceTypeTagKey:     "test",
+			dogstatsd.EventAlertTypeTagKey:      "success",
+			dogstatsd.EventPriorityTagKey:       "low",
+			dogstatsd.EventHostnameTagKey:       "example.com",
+			"foo": "bar",
+			"baz": "qux",
+		},
+	}
+	ddFixtureEvent := DDEvent{
+		Title:       testEvent.Name,
+		Text:        testEvent.Message,
+		Timestamp:   testEvent.Timestamp,
+		Hostname:    testEvent.Tags[dogstatsd.EventHostnameTagKey],
+		Aggregation: testEvent.Tags[dogstatsd.EventAggregationKeyTagKey],
+		Source:      testEvent.Tags[dogstatsd.EventSourceTypeTagKey],
+		Priority:    testEvent.Tags[dogstatsd.EventPriorityTagKey],
+		AlertType:   testEvent.Tags[dogstatsd.EventAlertTypeTagKey],
+		Tags: []string{
+			"foo:bar",
+			"baz:qux",
+			"gloobles:toots", // This one needs to be here because of the Sink's common tags!
+		},
+	}
+
+	ddSink.FlushOtherSamples(context.TODO(), []ssf.SSFSample{testEvent})
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, transport.GotCalled, "Did not call endpoint")
+	ddEvents := DDEventRequest{}
+	jsonErr := json.Unmarshal([]byte(transport.Contents), &ddEvents)
+	assert.NoError(t, jsonErr)
+	event := ddEvents.Events.Api[0]
+
+	assert.Subset(t, ddFixtureEvent.Tags, event.Tags, "Event tags do not match")
+	assert.Equal(t, ddFixtureEvent.Aggregation, event.Aggregation, "Event aggregation doesn't match")
+	assert.Equal(t, ddFixtureEvent.AlertType, event.AlertType, "Event alert type doesn't match")
+	assert.Equal(t, ddFixtureEvent.Hostname, event.Hostname, "Event hostname doesn't match")
+	assert.Equal(t, ddFixtureEvent.Priority, event.Priority, "Event priority doesn't match")
+	assert.Equal(t, ddFixtureEvent.Source, event.Source, "Event source doesn't match")
+	assert.Equal(t, ddFixtureEvent.Text, event.Text, "Event text doesn't match")
+	assert.Equal(t, ddFixtureEvent.Timestamp, event.Timestamp, "Event timestamp doesn't match")
+	assert.Equal(t, ddFixtureEvent.Title, event.Title, "Event title doesn't match")
+}
+
+func TestDatadogFlushServiceChecks(t *testing.T) {
+	transport := &DatadogRoundTripper{Endpoint: "/api/v1/check_run", Contains: ""}
+	ddSink, err := NewDatadogMetricSink(10, 2500, "example.com", []string{"gloobles:toots"}, "http://example.com", "secret", &http.Client{Transport: transport}, logrus.New())
+	assert.NoError(t, err)
+
+	testCheck := ssf.SSFSample{
+		Name:      "foo",
+		Message:   "bar",
+		Status:    ssf.SSFSample_OK,
+		Timestamp: 1136239445,
+		Tags: map[string]string{
+			dogstatsd.CheckIdentifierKey:  "",
+			dogstatsd.CheckHostnameTagKey: "example.com",
+			"foo": "bar",
+			"baz": "qux",
+		},
+	}
+	ddFixtureCheck := DDServiceCheck{
+		Name:      testCheck.Name,
+		Status:    int(ssf.SSFSample_Status_value[testCheck.Status.String()]),
+		Hostname:  testCheck.Tags[dogstatsd.CheckHostnameTagKey],
+		Timestamp: testCheck.Timestamp,
+		Message:   testCheck.Message,
+		Tags: []string{
+			"foo:bar",
+			"baz:qux",
+			"gloobles:toots", // This one needs to be here because of the Sink's common tags!
+		},
+	}
+
+	ddSink.FlushOtherSamples(context.TODO(), []ssf.SSFSample{testCheck})
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, transport.GotCalled, "Did not call endpoint")
+	ddChecks := []DDServiceCheck{}
+	jsonErr := json.Unmarshal([]byte(transport.Contents), &ddChecks)
+	assert.NoError(t, jsonErr)
+
+	assert.Equal(t, ddFixtureCheck.Name, ddChecks[0].Name, "Check name doesn't match")
+	assert.Equal(t, ddFixtureCheck.Hostname, ddChecks[0].Hostname, "Check hostname doesn't match")
+	assert.Equal(t, ddFixtureCheck.Message, ddChecks[0].Message, "Check message doesn't match")
+	assert.Equal(t, ddFixtureCheck.Status, ddChecks[0].Status, "Check status doesn't match")
+	assert.Equal(t, ddFixtureCheck.Timestamp, ddChecks[0].Timestamp, "Check timestamp doesn't match")
+	assert.Subset(t, ddFixtureCheck.Tags, ddChecks[0].Tags, "Check posted to DD does not have matching tags")
 }

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -204,8 +204,8 @@ func (k *KafkaMetricSink) Flush(ctx context.Context, interMetrics []samplers.Int
 	return nil
 }
 
-// FlushEventsChecks flushes Events and Checks
-func (k *KafkaMetricSink) FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck) {
+// FlushOtherSamples flushes non-metric, non-span samples
+func (k *KafkaMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
 	// TODO
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/signalfx/golib/sfxclient"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/protocol/dogstatsd"
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/ssf"
 )
 
 type FakeSink struct {
@@ -181,17 +183,23 @@ func TestSignalFxEventFlush(t *testing.T) {
 	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil)
 	assert.NoError(t, err)
 
-	ev := samplers.UDPEvent{
-		Title:     "Farts farts farts",
+	evMessage := "[an example link](http://catchpoint.com/session_id \"Title\")"
+	ev := ssf.SSFSample{
+		Name: "Farts farts farts",
+		// Include the markdown bits DD expects, we'll trim it out hopefully!
+		Message:   "%%% \n " + evMessage + " \n %%%",
 		Timestamp: time.Now().Unix(),
-		Tags:      []string{"foo:bar", "baz:gorch", "novalue"},
+		Tags:      map[string]string{"foo": "bar", "baz": "gorch", "novalue": "", dogstatsd.EventIdentifierKey: ""},
 	}
-	sink.FlushEventsChecks(context.TODO(), []samplers.UDPEvent{ev}, nil)
+	sink.FlushOtherSamples(context.TODO(), []ssf.SSFSample{ev})
 
 	assert.Equal(t, 1, len(fakeSink.events))
 	event := fakeSink.events[0]
-	assert.Equal(t, ev.Title, event.EventType)
+	assert.Equal(t, ev.Name, event.EventType)
+	// We're checking this to ensure the above markdown is also gone!
+	assert.Equal(t, event.Properties["description"], evMessage)
 	dims := event.Dimensions
+	// 5 because 5 passed in, 1 eliminated (identifier) and 1 added (host!)
 	assert.Equal(t, 5, len(dims), "Event has incorrect tag count")
 	assert.Equal(t, "bar", dims["foo"], "Event has a busted tag")
 	assert.Equal(t, "gorch", dims["baz"], "Event has a busted tag")
@@ -202,8 +210,9 @@ func TestSignalFxEventFlush(t *testing.T) {
 
 func TestSignalFxSetExcludeTags(t *testing.T) {
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil)
-	sink.SetExcludedTags([]string{"foo", "host"})
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie", "boo": "snakes"}, logrus.New(), fakeSink, "", nil)
+
+	sink.SetExcludedTags([]string{"foo", "boo", "host"})
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{samplers.InterMetric{
@@ -219,17 +228,18 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 	}}
 	sink.Flush(context.Background(), interMetrics)
 
-	ev := samplers.UDPEvent{
-		Title:     "Test Event",
+	ev := ssf.SSFSample{
+		Name:      "Test Event",
 		Timestamp: time.Now().Unix(),
-		Tags: []string{
-			"foo:bar",
-			"baz:gorch",
-			"novalue",
+		Tags: map[string]string{
+			dogstatsd.EventIdentifierKey: "",
+			"foo":     "bar",
+			"baz":     "gorch",
+			"novalue": "",
 		},
 	}
 
-	sink.FlushEventsChecks(context.Background(), []samplers.UDPEvent{ev}, nil)
+	sink.FlushOtherSamples(context.Background(), []ssf.SSFSample{ev})
 
 	assert.Equal(t, 1, len(fakeSink.points))
 	point := fakeSink.points[0]
@@ -241,18 +251,18 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "", dims["novalue"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing a common tag")
-	assert.Equal(t, "", dims["host"], "Metric has host tag despite exclude rule")
+	assert.Equal(t, "", dims["boo"], "Metric has host tag despite exclude rule")
 
 	assert.Equal(t, 1, len(fakeSink.events))
 	event := fakeSink.events[0]
-	assert.Equal(t, ev.Title, event.EventType)
+	assert.Equal(t, ev.Name, event.EventType)
 	dims = event.Dimensions
 	assert.Equal(t, 3, len(dims), "Event has incorrect tag count")
 	assert.Equal(t, "", dims["foo"], "Event has a foo tag despite exclude rule")
 	assert.Equal(t, "gorch", dims["baz"], "Event has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Event missing a common tag")
 	assert.Equal(t, "", dims["novalue"], "Event has a busted tag")
-	assert.Equal(t, "", dims["host"], "Event has host tag despite exclude rule")
+	assert.Equal(t, "", dims["boo"], "Event has host tag despite exclude rule")
 }
 
 func TestSignalFxFlushMultiKey(t *testing.T) {

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -33,8 +33,8 @@ type MetricSink interface {
 	// must also check each metric with IsAcceptableMetric to
 	// verify they are eligible to consume the metric.
 	Flush(context.Context, []samplers.InterMetric) error
-	// This one is temporary?
-	FlushEventsChecks(ctx context.Context, events []samplers.UDPEvent, checks []samplers.UDPServiceCheck)
+	// Handle non-metric, non-span samples.
+	FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample)
 }
 
 // IsAcceptableMetric returns true if a metric is meant to be ingested


### PR DESCRIPTION
#### Summary
Reapplies #394 which was reverted in #422 due to confusion around SignalFx failures.

#### Motivation
Turns out the problems we saw with SignalFx data that caused us to revert in #422 were the result of a bug in the current master where some tags were *not* being excluded from SignalFx. Turns out that bug is fixed by this branch and therefore correct!

#### Test plan
New and existing tests!

r? @asf-stripe 