### PR TITLE
Add CL for changed metric names and change one more for consistency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Decreased logging output of veneur-proxy. Thanks, [gphat](https://github.com/gphat)!
 * Better warnings when invalid flag combinations are passed to `veneur-emit`. Thanks, [sdboyer](https://github.com/sdboyer)!
 * Revamped how sinks handle DogStatsD's events and service checks. Thanks, [gphat](https://github.com/gphat)
+  * `veneur.worker.events_flushed_total` and `veneur.worker.checks_flushed_total` have been replaced by `veneur.worker.other_samples_flushed_total`
+  * `veneur.flush.event_worker_duration_ns` has been replaced by `veneur.flush.other_samples_duration_ns`
 
 ## Added
 

--- a/worker.go
+++ b/worker.go
@@ -345,7 +345,7 @@ func (ew *EventWorker) Flush() []ssf.SSFSample {
 
 	ew.mutex.Unlock()
 	metrics.ReportOne(ew.traceClient, ssf.Count("worker.other_samples_flushed_total", float32(len(retsamples)), nil))
-	metrics.ReportOne(ew.traceClient, ssf.Timing("flush.event_worker_duration_ns", time.Since(start), time.Nanosecond, nil))
+	metrics.ReportOne(ew.traceClient, ssf.Timing("flush.other_samples_duration_ns", time.Since(start), time.Nanosecond, nil))
 	return retsamples
 }
 


### PR DESCRIPTION
#### Summary
Document some metric changes I left out of #425 and change one more for consistency.

#### Motivation
I realized yesterday I hadn't documented these metric changes, oh no! In writing the PR I realized this other one needed to change also.

r? @aditya-stripe 