### PR TITLE
Report counter from SFX flush errors

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -358,7 +358,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 	// the error has already been logged (if there was one), so we only care
 	// about the success case
 	endpoint := fmt.Sprintf("%s/import", s.ForwardAddr)
-	if vhttp.PostHelper(span.Attach(ctx), s.HTTPClient, s.TraceClient, http.MethodPost, endpoint, jsonMetrics, "forward", true, log) == nil {
+	if vhttp.PostHelper(span.Attach(ctx), s.HTTPClient, s.TraceClient, http.MethodPost, endpoint, jsonMetrics, "forward", true, nil, log) == nil {
 		log.WithFields(logrus.Fields{
 			"metrics":     len(jsonMetrics),
 			"endpoint":    endpoint,

--- a/http/http.go
+++ b/http/http.go
@@ -105,15 +105,27 @@ func (hct *httpClientTracer) finishSpan() {
 	hct.currentSpan.ClientFinish(hct.traceClient)
 }
 
+func mergeTags(tags map[string]string, k, v string) map[string]string {
+	ret := make(map[string]string, len(tags)+1)
+	for k, v := range tags {
+		ret[k] = v
+	}
+	ret[k] = v
+	return ret
+}
+
 // PostHelper is shared code for POSTing to an endpoint, that consumes JSON, is zlib-
 // compressed, that returns 202 on success, that has a small response
 // action as a string used for statsd metric names and log messages emitted from
 // this function - probably a static string for each callsite
 // you can disable compression with compress=false for endpoints that don't
 // support it
-func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, method string, endpoint string, bodyObject interface{}, action string, compress bool, log *logrus.Logger) error {
+func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, method string, endpoint string, bodyObject interface{}, action string, compress bool, extraTags map[string]string, log *logrus.Logger) error {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	span.SetTag("action", action)
+	for k, v := range extraTags {
+		span.SetTag(k, v)
+	}
 	defer span.ClientFinish(tc)
 
 	// attach this field to all the logs we generate
@@ -133,7 +145,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 	}
 	if err := encoder.Encode(bodyObject); err != nil {
 		span.Error(err)
-		span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": "json"}))
+		span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", "json")))
 		innerLogger.WithError(err).Error("Could not render JSON")
 		return err
 	}
@@ -141,12 +153,12 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 		// don't forget to flush leftover compressed bytes to the buffer
 		if err := compressor.Close(); err != nil {
 			span.Error(err)
-			span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": "compress"}))
+			span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", "compress")))
 			innerLogger.WithError(err).Error("Could not finalize compression")
 			return err
 		}
 	}
-	span.Add(ssf.Timing(action+".duration_ns", time.Since(marshalStart), time.Nanosecond, map[string]string{"part": "json"}))
+	span.Add(ssf.Timing(action+".duration_ns", time.Since(marshalStart), time.Nanosecond, mergeTags(extraTags, "part", "json")))
 
 	// Len reports the unread length, so we have to record this before the
 	// http client consumes it
@@ -157,7 +169,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 	req = req.WithContext(ctx)
 
 	if err != nil {
-		span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": "construct"}))
+		span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", "construct")))
 		innerLogger.WithError(err).Error("Could not construct request")
 		return err
 	}
@@ -184,7 +196,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 			// and ditch the url (which might contain secrets)
 			err = urlErr.Err
 		}
-		span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": "io"}))
+		span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", "io")))
 		// Log at Warn level instead of Error, because we don't want to create
 		// Sentry events for these (they're only important in large numbers, and
 		// we already have Datadog metrics for them)
@@ -200,7 +212,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 	if err != nil {
 		// this error is not fatal, since we only need the body for reporting
 		// purposes
-		span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": "readresponse"}))
+		span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", "readresponse")))
 		innerLogger.WithError(err).Error("Could not read response body")
 	}
 	resultLogger := innerLogger.WithFields(logrus.Fields{
@@ -213,7 +225,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 	})
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		span.Add(ssf.Count(action+".error_total", 1, map[string]string{"cause": strconv.Itoa(resp.StatusCode)}))
+		span.Add(ssf.Count(action+".error_total", 1, mergeTags(extraTags, "cause", strconv.Itoa(resp.StatusCode))))
 		resultLogger.WithError(err).Warn("Could not POST")
 		return err
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -414,7 +414,7 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// this endpoint is not documented to take an array... but it does
 			// another curious constraint of this endpoint is that it does not
 			// support "Content-Encoding: deflate"
-			err := vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.TraceClient, http.MethodPost, fmt.Sprintf("%s/spans", dest), batch, "flush_traces", false, log)
+			err := vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.TraceClient, http.MethodPost, fmt.Sprintf("%s/spans", dest), batch, "flush_traces", false, nil, log)
 			if err == nil {
 				log.WithFields(logrus.Fields{
 					"traces":      len(batch),
@@ -489,7 +489,7 @@ func (p *Proxy) doPost(ctx context.Context, wg *sync.WaitGroup, destination stri
 	}
 
 	endpoint := fmt.Sprintf("%s/import", destination)
-	err := vhttp.PostHelper(ctx, p.HTTPClient, p.TraceClient, http.MethodPost, endpoint, batch, "forward", true, log)
+	err := vhttp.PostHelper(ctx, p.HTTPClient, p.TraceClient, http.MethodPost, endpoint, batch, "forward", true, nil, log)
 	if err == nil {
 		log.WithField("metrics", batchSize).Debug("Completed forward to Veneur")
 	} else {

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -249,7 +249,7 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 			"events": {
 				"api": events,
 			},
-		}, "flush_events", true, nil, dd.log)
+		}, "flush_events", true, map[string]string{"sink": "datadog"}, dd.log)
 
 		if err == nil {
 			dd.log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
@@ -264,7 +264,7 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 		// this endpoint is not documented to take an array... but it does
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey), checks, "flush_checks", false, nil, dd.log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey), checks, "flush_checks", false, map[string]string{"sink": "datadog"}, dd.log)
 		if err == nil {
 			dd.log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
@@ -340,7 +340,7 @@ func (dd *DatadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 	defer wg.Done()
 	vhttp.PostHelper(ctx, dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.DDHostname, dd.APIKey), map[string][]DDMetric{
 		"series": metricSlice,
-	}, "flush", true, nil, dd.log)
+	}, "flush", true, map[string]string{"sink": "datadog"}, dd.log)
 }
 
 // DatadogTraceSpan represents a trace span as JSON for the
@@ -538,7 +538,7 @@ func (dd *DatadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut, fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces, "flush_traces", false, nil, dd.log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut, fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces, "flush_traces", false, map[string]string{"sink": "datadog"}, dd.log)
 		if err == nil {
 			dd.log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")
 		} else {

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -249,7 +249,8 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 			"events": {
 				"api": events,
 			},
-		}, "flush_events", true, dd.log)
+		}, "flush_events", true, nil, dd.log)
+
 		if err == nil {
 			dd.log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
 		} else {
@@ -263,7 +264,7 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 		// this endpoint is not documented to take an array... but it does
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey), checks, "flush_checks", false, dd.log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey), checks, "flush_checks", false, nil, dd.log)
 		if err == nil {
 			dd.log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
@@ -339,7 +340,7 @@ func (dd *DatadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetr
 	defer wg.Done()
 	vhttp.PostHelper(ctx, dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.DDHostname, dd.APIKey), map[string][]DDMetric{
 		"series": metricSlice,
-	}, "flush", true, dd.log)
+	}, "flush", true, nil, dd.log)
 }
 
 // DatadogTraceSpan represents a trace span as JSON for the
@@ -537,7 +538,7 @@ func (dd *DatadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut, fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces, "flush_traces", false, dd.log)
+		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut, fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces, "flush_traces", false, nil, dd.log)
 		if err == nil {
 			dd.log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")
 		} else {

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -51,6 +51,7 @@ func (c *collection) submit(ctx context.Context, cl *trace.Client) error {
 		err := client.AddDatapoints(ctx, points)
 		if err != nil {
 			span.Error(err)
+			span.Add(ssf.Count("flush.error_total", 1, map[string]string{"cause": "io", "sink": "signalfx"}))
 			errorCh <- err
 		}
 		wg.Done()


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
See commit message. Bikeshed welcome on the metric name or tags. Right now it's reporting `veneur.flush.error_total` with `cause:io`, which is the same as what the datadog sink does, but as a result, you can't tell the two sinks apart.

r? @asf-stripe 

#### Motivation
<!-- Why are you making this change? -->
No metric is reported on this error path right now

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
haven't tested at all yet

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
as normal