### PR TITLE
Add a timer test for parsing floats

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -422,6 +422,14 @@ func TestParserTimer(t *testing.T) {
 	assert.Equal(t, "timer", m.Type, "Type")
 }
 
+func TestParserTimerFloat(t *testing.T) {
+	m, _ := samplers.ParseMetric([]byte("a.b.c:1.234|ms"))
+	assert.NotNil(t, m, "Got nil metric!")
+	assert.Equal(t, "a.b.c", m.Name, "Name")
+	assert.Equal(t, float64(1.234), m.Value, "Value")
+	assert.Equal(t, "timer", m.Type, "Type")
+}
+
 func TestParserSet(t *testing.T) {
 	m, _ := samplers.ParseMetric([]byte("a.b.c:foo|s"))
 	assert.NotNil(t, m, "Got nil metric!")


### PR DESCRIPTION
#### Summary
Add a test for non integer timers.

#### Motivation
I'm hunting for a bug in our metric pipeline and noticed we didn't have an explicit test for float timers.

#### Test plan
This IS a test, silly!

r? @sjung-stripe 