### PR TITLE
Use shared http.Client for signalfx sink

### DIFF
--- a/server.go
+++ b/server.go
@@ -303,10 +303,10 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	}
 
 	if conf.SignalfxAPIKey != "" {
-		fallback := signalfx.NewClient(conf.SignalfxEndpointBase, conf.SignalfxAPIKey)
+		fallback := signalfx.NewClient(conf.SignalfxEndpointBase, conf.SignalfxAPIKey, *ret.HTTPClient)
 		byTagClients := map[string]signalfx.DPClient{}
 		for _, perTag := range conf.SignalfxPerTagAPIKeys {
-			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey)
+			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, *ret.HTTPClient)
 		}
 		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients)
 		if err != nil {

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -3,6 +3,7 @@ package signalfx
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -95,11 +96,12 @@ type DPClient dpsink.Sink
 
 // NewClient constructs a new signalfx HTTP client for the given
 // endpoint and API token.
-func NewClient(endpoint, apiKey string) DPClient {
+func NewClient(endpoint, apiKey string, client http.Client) DPClient {
 	httpSink := sfxclient.NewHTTPSink()
 	httpSink.AuthToken = apiKey
 	httpSink.DatapointEndpoint = fmt.Sprintf("%s/v2/datapoint", endpoint)
 	httpSink.EventEndpoint = fmt.Sprintf("%s/v2/event", endpoint)
+	httpSink.Client = client
 	return httpSink
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"context"
+	"net/http"
 	"sort"
 	"testing"
 	"time"
@@ -39,7 +40,7 @@ func (fs *FakeSink) AddEvents(ctx context.Context, events []*event.Event) (err e
 
 func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
-	client := NewClient("http://www.example.com", "secret")
+	client := NewClient("http://www.example.com", "secret", *http.DefaultClient)
 	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), client, "", nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
basically see commits

r? @aditya-stripe 

#### Motivation
<!-- Why are you making this change? -->
the sfx sink should use the same http client object as the rest of veneur, so it can share keepalive connections

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
been baking in qa for a while

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
as normal