### PR TITLE
Convert grpsink to unary RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Revamped how sinks handle DogStatsD's events and service checks. Thanks, [gphat](https://github.com/gphat)
   * `veneur.worker.events_flushed_total` and `veneur.worker.checks_flushed_total` have been replaced by `veneur.worker.other_samples_flushed_total`
   * `veneur.flush.event_worker_duration_ns` has been replaced by `veneur.flush.other_samples_duration_ns`
+* Converted the grpsink to use unary instead of stream RPCs. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Added
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -642,6 +642,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "42a5bb925a3dedbc5e5b03a67c08e99414354fcd0dfa1b2ef30bafe55e9b37fe"
+  inputs-digest = "d9dba5f18819a10a885632f4c9767664744f9778e5f8db3be17489c9330ced71"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/sinks/grpsink/convert_context_18.go
+++ b/sinks/grpsink/convert_context_18.go
@@ -1,0 +1,21 @@
+// +build !go1.9
+
+package grpsink
+
+import (
+	"context"
+
+	ocontext "golang.org/x/net/context"
+)
+
+func convertContext(ctx context.Context) ocontext.Context {
+	octx, cf := ocontext.WithCancel(ocontext.Background())
+
+	// This is ok to do because we only use it on sink startup, not on a hot
+	// path. Otherwise it'd leak goroutines like crazy.
+	go func() {
+		<-ctx.Done()
+		cf()
+	}()
+	return octx
+}

--- a/sinks/grpsink/convert_context_19.go
+++ b/sinks/grpsink/convert_context_19.go
@@ -1,0 +1,13 @@
+// +build go1.9
+
+package grpsink
+
+import (
+	"context"
+
+	ocontext "golang.org/x/net/context"
+)
+
+func convertContext(ctx context.Context) ocontext.Context {
+	return ctx
+}

--- a/sinks/grpsink/grpc_sink.pb.go
+++ b/sinks/grpsink/grpc_sink.pb.go
@@ -8,7 +8,7 @@
 		sinks/grpsink/grpc_sink.proto
 
 	It has these top-level messages:
-		SpanResponse
+		Empty
 */
 package grpsink
 
@@ -35,24 +35,16 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type SpanResponse struct {
-	Greeting string `protobuf:"bytes,1,opt,name=greeting,proto3" json:"greeting,omitempty"`
+type Empty struct {
 }
 
-func (m *SpanResponse) Reset()                    { *m = SpanResponse{} }
-func (m *SpanResponse) String() string            { return proto.CompactTextString(m) }
-func (*SpanResponse) ProtoMessage()               {}
-func (*SpanResponse) Descriptor() ([]byte, []int) { return fileDescriptorGrpcSink, []int{0} }
-
-func (m *SpanResponse) GetGreeting() string {
-	if m != nil {
-		return m.Greeting
-	}
-	return ""
-}
+func (m *Empty) Reset()                    { *m = Empty{} }
+func (m *Empty) String() string            { return proto.CompactTextString(m) }
+func (*Empty) ProtoMessage()               {}
+func (*Empty) Descriptor() ([]byte, []int) { return fileDescriptorGrpcSink, []int{0} }
 
 func init() {
-	proto.RegisterType((*SpanResponse)(nil), "grpsink.SpanResponse")
+	proto.RegisterType((*Empty)(nil), "grpsink.Empty")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -66,7 +58,7 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for SpanSink service
 
 type SpanSinkClient interface {
-	SendSpans(ctx context.Context, opts ...grpc.CallOption) (SpanSink_SendSpansClient, error)
+	SendSpan(ctx context.Context, in *ssf.SSFSpan, opts ...grpc.CallOption) (*Empty, error)
 }
 
 type spanSinkClient struct {
@@ -77,91 +69,57 @@ func NewSpanSinkClient(cc *grpc.ClientConn) SpanSinkClient {
 	return &spanSinkClient{cc}
 }
 
-func (c *spanSinkClient) SendSpans(ctx context.Context, opts ...grpc.CallOption) (SpanSink_SendSpansClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_SpanSink_serviceDesc.Streams[0], c.cc, "/grpsink.SpanSink/SendSpans", opts...)
+func (c *spanSinkClient) SendSpan(ctx context.Context, in *ssf.SSFSpan, opts ...grpc.CallOption) (*Empty, error) {
+	out := new(Empty)
+	err := grpc.Invoke(ctx, "/grpsink.SpanSink/SendSpan", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &spanSinkSendSpansClient{stream}
-	return x, nil
-}
-
-type SpanSink_SendSpansClient interface {
-	Send(*ssf.SSFSpan) error
-	CloseAndRecv() (*SpanResponse, error)
-	grpc.ClientStream
-}
-
-type spanSinkSendSpansClient struct {
-	grpc.ClientStream
-}
-
-func (x *spanSinkSendSpansClient) Send(m *ssf.SSFSpan) error {
-	return x.ClientStream.SendMsg(m)
-}
-
-func (x *spanSinkSendSpansClient) CloseAndRecv() (*SpanResponse, error) {
-	if err := x.ClientStream.CloseSend(); err != nil {
-		return nil, err
-	}
-	m := new(SpanResponse)
-	if err := x.ClientStream.RecvMsg(m); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return out, nil
 }
 
 // Server API for SpanSink service
 
 type SpanSinkServer interface {
-	SendSpans(SpanSink_SendSpansServer) error
+	SendSpan(context.Context, *ssf.SSFSpan) (*Empty, error)
 }
 
 func RegisterSpanSinkServer(s *grpc.Server, srv SpanSinkServer) {
 	s.RegisterService(&_SpanSink_serviceDesc, srv)
 }
 
-func _SpanSink_SendSpans_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(SpanSinkServer).SendSpans(&spanSinkSendSpansServer{stream})
-}
-
-type SpanSink_SendSpansServer interface {
-	SendAndClose(*SpanResponse) error
-	Recv() (*ssf.SSFSpan, error)
-	grpc.ServerStream
-}
-
-type spanSinkSendSpansServer struct {
-	grpc.ServerStream
-}
-
-func (x *spanSinkSendSpansServer) SendAndClose(m *SpanResponse) error {
-	return x.ServerStream.SendMsg(m)
-}
-
-func (x *spanSinkSendSpansServer) Recv() (*ssf.SSFSpan, error) {
-	m := new(ssf.SSFSpan)
-	if err := x.ServerStream.RecvMsg(m); err != nil {
+func _SpanSink_SendSpan_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ssf.SSFSpan)
+	if err := dec(in); err != nil {
 		return nil, err
 	}
-	return m, nil
+	if interceptor == nil {
+		return srv.(SpanSinkServer).SendSpan(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/grpsink.SpanSink/SendSpan",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SpanSinkServer).SendSpan(ctx, req.(*ssf.SSFSpan))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _SpanSink_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "grpsink.SpanSink",
 	HandlerType: (*SpanSinkServer)(nil),
-	Methods:     []grpc.MethodDesc{},
-	Streams: []grpc.StreamDesc{
+	Methods: []grpc.MethodDesc{
 		{
-			StreamName:    "SendSpans",
-			Handler:       _SpanSink_SendSpans_Handler,
-			ClientStreams: true,
+			MethodName: "SendSpan",
+			Handler:    _SpanSink_SendSpan_Handler,
 		},
 	},
+	Streams:  []grpc.StreamDesc{},
 	Metadata: "sinks/grpsink/grpc_sink.proto",
 }
 
-func (m *SpanResponse) Marshal() (dAtA []byte, err error) {
+func (m *Empty) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -171,17 +129,11 @@ func (m *SpanResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SpanResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *Empty) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
 	_ = l
-	if len(m.Greeting) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintGrpcSink(dAtA, i, uint64(len(m.Greeting)))
-		i += copy(dAtA[i:], m.Greeting)
-	}
 	return i, nil
 }
 
@@ -194,13 +146,9 @@ func encodeVarintGrpcSink(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
-func (m *SpanResponse) Size() (n int) {
+func (m *Empty) Size() (n int) {
 	var l int
 	_ = l
-	l = len(m.Greeting)
-	if l > 0 {
-		n += 1 + l + sovGrpcSink(uint64(l))
-	}
 	return n
 }
 
@@ -217,7 +165,7 @@ func sovGrpcSink(x uint64) (n int) {
 func sozGrpcSink(x uint64) (n int) {
 	return sovGrpcSink(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *SpanResponse) Unmarshal(dAtA []byte) error {
+func (m *Empty) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -240,41 +188,12 @@ func (m *SpanResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SpanResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: Empty: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SpanResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: Empty: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Greeting", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGrpcSink
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGrpcSink
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Greeting = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGrpcSink(dAtA[iNdEx:])
@@ -404,16 +323,14 @@ var (
 func init() { proto.RegisterFile("sinks/grpsink/grpc_sink.proto", fileDescriptorGrpcSink) }
 
 var fileDescriptorGrpcSink = []byte{
-	// 172 bytes of a gzipped FileDescriptorProto
+	// 141 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2d, 0xce, 0xcc, 0xcb,
 	0x2e, 0xd6, 0x4f, 0x2f, 0x2a, 0x00, 0x31, 0x40, 0x74, 0x72, 0x3c, 0x88, 0xa5, 0x57, 0x50, 0x94,
 	0x5f, 0x92, 0x2f, 0xc4, 0x0e, 0x95, 0x90, 0x12, 0x28, 0x2e, 0x4e, 0xd3, 0x2f, 0x4e, 0xcc, 0x2d,
-	0xc8, 0x49, 0x85, 0x48, 0x29, 0x69, 0x71, 0xf1, 0x04, 0x17, 0x24, 0xe6, 0x05, 0xa5, 0x16, 0x17,
-	0xe4, 0xe7, 0x15, 0xa7, 0x0a, 0x49, 0x71, 0x71, 0xa4, 0x17, 0xa5, 0xa6, 0x96, 0x64, 0xe6, 0xa5,
-	0x4b, 0x30, 0x2a, 0x30, 0x6a, 0x70, 0x06, 0xc1, 0xf9, 0x46, 0x0e, 0x5c, 0x1c, 0x20, 0xb5, 0xc1,
-	0x99, 0x79, 0xd9, 0x42, 0x26, 0x5c, 0x9c, 0xc1, 0xa9, 0x79, 0x29, 0x20, 0x7e, 0xb1, 0x10, 0x8f,
-	0x5e, 0x71, 0x71, 0x9a, 0x5e, 0x70, 0xb0, 0x1b, 0x88, 0x2b, 0x25, 0xaa, 0x07, 0xb5, 0x4e, 0x0f,
-	0xd9, 0x64, 0x25, 0x06, 0x0d, 0x46, 0x27, 0x81, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63,
-	0x7c, 0xf0, 0x48, 0x8e, 0x71, 0xc6, 0x63, 0x39, 0x86, 0x24, 0x36, 0xb0, 0x33, 0x8c, 0x01, 0x01,
-	0x00, 0x00, 0xff, 0xff, 0x03, 0x45, 0x35, 0xd2, 0xc2, 0x00, 0x00, 0x00,
+	0xc8, 0x49, 0x85, 0x48, 0x29, 0xb1, 0x73, 0xb1, 0xba, 0xe6, 0x16, 0x94, 0x54, 0x1a, 0x99, 0x70,
+	0x71, 0x04, 0x17, 0x24, 0xe6, 0x05, 0x67, 0xe6, 0x65, 0x0b, 0x69, 0x70, 0x71, 0x04, 0xa7, 0xe6,
+	0xa5, 0x80, 0xf8, 0x42, 0x3c, 0x7a, 0xc5, 0xc5, 0x69, 0x7a, 0xc1, 0xc1, 0x6e, 0x20, 0x9e, 0x14,
+	0x9f, 0x1e, 0xd4, 0x28, 0x3d, 0xb0, 0x2e, 0x27, 0x81, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92,
+	0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x71, 0xc6, 0x63, 0x39, 0x86, 0x24, 0x36, 0xb0, 0xb9, 0xc6, 0x80,
+	0x00, 0x00, 0x00, 0xff, 0xff, 0x55, 0xfd, 0x0a, 0x10, 0x93, 0x00, 0x00, 0x00,
 }

--- a/sinks/grpsink/grpc_sink.proto
+++ b/sinks/grpsink/grpc_sink.proto
@@ -3,10 +3,8 @@ package grpsink;
 
 import "ssf/sample.proto";
 
-message SpanResponse {
-    string greeting = 1;
-}
+message Empty {}
 
 service SpanSink {
-    rpc SendSpans(stream ssf.SSFSpan) returns (SpanResponse) {}
+    rpc SendSpan(ssf.SSFSpan) returns (Empty);
 }

--- a/sinks/grpsink/grpc_stream.go
+++ b/sinks/grpsink/grpc_stream.go
@@ -2,11 +2,7 @@ package grpsink
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
@@ -29,22 +25,16 @@ type GRPCStreamingSpanSink struct {
 	target string
 	// The underlying gRPC connection ("channel") to the target server.
 	grpcConn *grpc.ClientConn
-	// The gRPC client that can generate stream connections.
-	sinkClient SpanSinkClient
-	stream     SpanSink_SendSpansClient
-	// streamMut guards two classes of interaction with the stream: actually
-	// sending over the stream (gRPC requires that only one goroutine send on
-	// a stream at a time), and automatically recreating the stream after a
-	// connection drops.
-	streamMut sync.Mutex
 	// Total counts of sent and dropped spans, respectively
 	sentCount, dropCount uint32
-	// If 1, indicates that the current stream is dead (has seen an EOF)
-	bad         uint32
-	stats       *statsd.Client
-	commonTags  map[string]string
-	traceClient *trace.Client
-	log         *logrus.Logger
+	// Marker to indicate if an error has been logged since the last state
+	// transition. Allows us to guarantee only one error message per state
+	// change.
+	loggedSinceTransition uint32
+	stats                 *statsd.Client
+	commonTags            map[string]string
+	traceClient           *trace.Client
+	log                   *logrus.Logger
 }
 
 var _ sinks.SpanSink = &GRPCStreamingSpanSink{}
@@ -60,14 +50,7 @@ var _ sinks.SpanSink = &GRPCStreamingSpanSink{}
 // connection to the target server (in grpc.DialContext()).
 func NewGRPCStreamingSpanSink(ctx context.Context, target, name string, commonTags map[string]string, log *logrus.Logger, opts ...grpc.DialOption) (*GRPCStreamingSpanSink, error) {
 	name = "grpc-" + name
-	// We want the stream in fail-fast mode. This is the default, but it's
-	// important to the design, so it's worth being explicit: if the streams
-	// weren't in fail-fast mode, then Ingest() calls will block while connections
-	// get re-established in the background, resulting in undesirable backpressure.
-	// For a use case like this sink, unequivocally preferred to fail fast instead,
-	// resulting in dropped spans.
-	dco := grpc.WithDefaultCallOptions(grpc.FailFast(true))
-	conn, err := grpc.DialContext(ctx, target, append(opts, dco)...)
+	conn, err := grpc.DialContext(ctx, target, opts...)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			"name":   name,
@@ -80,7 +63,6 @@ func NewGRPCStreamingSpanSink(ctx context.Context, target, name string, commonTa
 		grpcConn:   conn,
 		name:       name,
 		target:     target,
-		sinkClient: NewSpanSinkClient(conn),
 		commonTags: commonTags,
 		log:        log,
 	}, nil
@@ -91,19 +73,7 @@ func NewGRPCStreamingSpanSink(ctx context.Context, target, name string, commonTa
 func (gs *GRPCStreamingSpanSink) Start(cl *trace.Client) error {
 	gs.traceClient = cl
 
-	var err error
-	gs.stream, err = gs.sinkClient.SendSpans(context.TODO())
-	if err != nil {
-		gs.log.WithFields(logrus.Fields{
-			"name":          gs.name,
-			"target":        gs.target,
-			"chanstate":     gs.grpcConn.GetState().String(),
-			logrus.ErrorKey: err,
-		}).Error("Failed to set up a stream over gRPC channel to sink target")
-		return err
-	}
-
-	go gs.maintainStream(context.TODO())
+	go gs.maintainStream()
 	return nil
 }
 
@@ -115,77 +85,13 @@ func (gs *GRPCStreamingSpanSink) Start(cl *trace.Client) error {
 // connection when it moves back into the 'READY' state. See
 // https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.mdA
 // for details about gRPC's connectivity state machine.
-func (gs *GRPCStreamingSpanSink) maintainStream(ctx context.Context) {
+func (gs *GRPCStreamingSpanSink) maintainStream() {
 	for {
 		// This call will block on a channel receive until the gRPC connection
-		// becomes unhealthy. Then, spring into action!
-		state := gs.grpcConn.GetState()
-		switch state {
-		case connectivity.Idle:
-			// gRPC considers an open stream to be an active RPC, and channels
-			// normally only go idle if there are no active RPC within the
-			// channel's timeout window. It should be nigh-impossible for that
-			// to happen here, so we record entering the Idle state as an error.
-			gs.log.WithFields(logrus.Fields{
-				"name":          gs.name,
-				"target":        gs.target,
-				"chanstate":     gs.grpcConn.GetState().String(),
-				logrus.ErrorKey: fmt.Errorf("gRPC sink became idle; should be nearly impossible"),
-			}).Error("gRPC channel transitioned to idle")
-
-			// With the error sent, now fall through to recreating the stream
-			// as if the channel were ready, as stream creation should force
-			// the channel back out of idle. This isn't ideal - it'll end up
-			// recreating the stream again after re-reaching READY - but it's
-			// not a huge problem, as this case is essentially unreachable.
-			fallthrough
-		case connectivity.Ready:
-			gs.streamMut.Lock()
-			stream, err := gs.sinkClient.SendSpans(ctx)
-			if err != nil {
-				// This is a weird case and probably shouldn't be reachable, but
-				// if stream setup fails after recovery, then just wait and retry.
-				gs.log.WithFields(logrus.Fields{
-					"name":          gs.name,
-					"target":        gs.target,
-					"chanstate":     gs.grpcConn.GetState().String(),
-					logrus.ErrorKey: err,
-				}).Error("Failed to set up a new stream after gRPC channel recovered")
-				gs.streamMut.Unlock()
-				// Wait for 1s before re-attempting to set up the stream.
-				time.Sleep(1 * time.Second)
-				continue
-			}
-			// CAS inside the mutex means that it's impossible for the same stream
-			// instance to log an io.EOF twice.
-			atomic.CompareAndSwapUint32(&gs.bad, 1, 0)
-			gs.stream = stream
-			gs.streamMut.Unlock()
-
-			gs.log.WithFields(logrus.Fields{
-				"name":      gs.name,
-				"target":    gs.target,
-				"chanstate": gs.grpcConn.GetState().String(),
-			}).Info("gRPC channel and stream re-established")
-		case connectivity.Connecting:
-			gs.log.WithFields(logrus.Fields{
-				"name":      gs.name,
-				"target":    gs.target,
-				"chanstate": state,
-			}).Info("Attempting to re-establish gRPC channel connection")
-			// Nothing to do here except wait.
-		case connectivity.TransientFailure:
-			gs.log.WithFields(logrus.Fields{
-				"name":      gs.name,
-				"target":    gs.target,
-				"chanstate": state,
-			}).Warn("gRPC channel now in transient failure")
-		case connectivity.Shutdown:
-			// The current design has no path to actually shutting down the
-			// connection, so this should be unreachable.
-			return
-		}
-		gs.grpcConn.WaitForStateChange(context.Background(), state)
+		// state changes. When it does, flip the marker over to allow another
+		// error to be logged from Ingest().
+		gs.grpcConn.WaitForStateChange(context.Background(), gs.grpcConn.GetState())
+		atomic.StoreUint32(&gs.loggedSinceTransition, 0)
 	}
 }
 
@@ -200,7 +106,6 @@ func (gs *GRPCStreamingSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	if err := protocol.ValidateTrace(ssfSpan); err != nil {
 		return err
 	}
-	// TODO(sdboyer) validation of span, e.g. time bounds like in datadog sink?
 
 	// Apply any common tags, superseding defaults passed in at sink creation
 	// in the event of overlap.
@@ -208,7 +113,9 @@ func (gs *GRPCStreamingSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		ssfSpan.Tags[k] = v
 	}
 
-	err := gs.send(ssfSpan)
+	client := NewSpanSinkClient(gs.grpcConn)
+	_, err := client.SendSpan(context.Background(), ssfSpan)
+
 	if err != nil {
 		atomic.AddUint32(&gs.dropCount, 1)
 
@@ -218,20 +125,12 @@ func (gs *GRPCStreamingSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		serr := status.Convert(err)
 		state := gs.grpcConn.GetState()
 
-		if err == io.EOF {
-			// EOF should be a terminal state for the stream; we only need to
-			// log that we've seen it once.
-			if atomic.CompareAndSwapUint32(&gs.bad, 0, 1) {
-				gs.log.WithFields(logrus.Fields{
-					logrus.ErrorKey: err,
-					"target":        gs.target,
-					"name":          gs.name,
-					"chanstate":     state.String(),
-				}).Warn("Target server closed the span stream")
-			}
-		} else {
-			// Errors that are not io.EOF are more interesting and, presumably,
-			// ephemeral. It's worth logging each one of them.
+		// Log all errors that occur in Ready state - that's weird. Otherwise,
+		// Log only one error per underlying connection state transition. This
+		// should be a reasonable heuristic to get an indicator that problems
+		// are occurring, without resulting in massive log spew while
+		// connections are under duress.
+		if state == connectivity.Ready || atomic.CompareAndSwapUint32(&gs.loggedSinceTransition, 0, 1) {
 			gs.log.WithFields(logrus.Fields{
 				logrus.ErrorKey: err,
 				"target":        gs.target,
@@ -240,29 +139,12 @@ func (gs *GRPCStreamingSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 				"code":          serr.Code(),
 				"details":       serr.Details(),
 				"message":       serr.Message(),
-			}).Warn("Error while streaming trace to gRPC target server")
+			}).Warn("Error sending span to gRPC sink target")
 		}
 	} else {
 		atomic.AddUint32(&gs.sentCount, 1)
 	}
 
-	return err
-}
-
-// send dispatches a span to the backend over the stream.
-//
-// gRPC rules state that it is safe to send and receive on a stream at the
-// same time, but not safe to simultaneously send. Thus, we serialize
-// sends with a mutex.
-//
-// The same mutex is also used by the gRPC channel state machine manager,
-// maintainStream(), when it recreates the channel. This guarantees that
-// sends will never be attempted on a stream that is in the process of
-// being recreated.
-func (gs *GRPCStreamingSpanSink) send(ssfSpan *ssf.SSFSpan) error {
-	gs.streamMut.Lock()
-	err := gs.stream.Send(ssfSpan)
-	gs.streamMut.Unlock()
 	return err
 }
 

--- a/sinks/grpsink/grpc_stream_test.go
+++ b/sinks/grpsink/grpc_stream_test.go
@@ -2,10 +2,8 @@ package grpsink
 
 import (
 	"context"
-	"io"
 	"net"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +13,6 @@ import (
 	"github.com/stripe/veneur/ssf"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/keepalive"
 )
 
 var tags = map[string]string{"foo": "bar"}
@@ -23,26 +20,14 @@ var tags = map[string]string{"foo": "bar"}
 type MockSpanSinkServer struct {
 	spans []*ssf.SSFSpan
 	mut   sync.Mutex
-	got   chan struct{}
 }
 
 // SendSpans mocks base method
-func (m *MockSpanSinkServer) SendSpans(stream SpanSink_SendSpansServer) error {
-	for {
-		span, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				return stream.SendMsg(&SpanResponse{
-					Greeting: "fin",
-				})
-			}
-			return err
-		}
-		m.mut.Lock()
-		m.spans = append(m.spans, span)
-		m.mut.Unlock()
-		m.got <- struct{}{}
-	}
+func (m *MockSpanSinkServer) SendSpan(ctx context.Context, span *ssf.SSFSpan) (*Empty, error) {
+	m.mut.Lock()
+	m.spans = append(m.spans, span)
+	m.mut.Unlock()
+	return &Empty{}, nil
 }
 
 // Extra method and locking to avoid a weird data race
@@ -73,7 +58,7 @@ func TestEndToEnd(t *testing.T) {
 	}
 	testaddr = lis.Addr().String()
 
-	mock, srv := &MockSpanSinkServer{got: make(chan struct{})}, grpc.NewServer()
+	mock, srv := &MockSpanSinkServer{}, grpc.NewServer()
 	RegisterSpanSinkServer(srv, mock)
 
 	block := make(chan struct{})
@@ -109,7 +94,6 @@ func TestEndToEnd(t *testing.T) {
 	}
 
 	err = sink.Ingest(testSpan)
-	<-mock.got
 	testSpan.Tags = map[string]string{
 		"foo": "bar",
 		"baz": "qux",
@@ -147,84 +131,5 @@ func TestEndToEnd(t *testing.T) {
 
 	err = sink.Ingest(testSpan)
 	require.NoError(t, err)
-	<-mock.got
 	require.Equal(t, mock.spanCount(), 2)
-}
-
-// It should be nearly unreachable for an idle state to be reached by the
-// channel, but this test ensures we handle it properly in the event that it
-// does. It can be flaky, though (it's too dependent on sleep timings), so
-// it's disabled, but preserved for future debugging purposes.
-func TestClientIdleRecovery(t *testing.T) {
-	testaddr := "127.0.0.1:0"
-	lis, err := net.Listen("tcp", testaddr)
-	if err != nil {
-		t.Fatalf("Failed to set up net listener with err %s", err)
-	}
-	testaddr = lis.Addr().String()
-
-	mock, srv := &MockSpanSinkServer{got: make(chan struct{})}, grpc.NewServer()
-	RegisterSpanSinkServer(srv, mock)
-
-	block := make(chan struct{})
-	go func() {
-		<-block
-		srv.Serve(lis)
-	}()
-	block <- struct{}{}
-
-	sink, err := NewGRPCStreamingSpanSink(context.Background(),
-		testaddr, "test1", tags, logrus.New(),
-		grpc.WithInsecure(),
-		// Very short timeout in order to ensure the channel becomes idle
-		// almost immediately.
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{Timeout: time.Millisecond}),
-	)
-	require.NoError(t, err)
-	go func() {
-		sink.maintainStream(context.Background())
-	}()
-
-	// Pre-mark the stream as in a bad state.
-	atomic.StoreUint32(&sink.bad, 1)
-
-	// SUT here is the channel and stream maintenance system, so express the
-	// requirement as a series of states through which it should automatically
-	// proceed.
-	waitThroughFiniteStateSequence(t, sink, 5*time.Second,
-		connectivity.Idle,
-		connectivity.Connecting,
-		connectivity.Ready,
-	)
-
-	reconnectWithin(t, sink, 5*time.Second)
-
-	// Send a span, just to be sure.
-	start := time.Now()
-	end := start.Add(2 * time.Second)
-	testSpan := &ssf.SSFSpan{
-		TraceId:        1,
-		ParentId:       1,
-		Id:             2,
-		StartTimestamp: int64(start.UnixNano()),
-		EndTimestamp:   int64(end.UnixNano()),
-		Error:          false,
-		Service:        "farts-srv",
-		Tags: map[string]string{
-			"baz": "qux",
-		},
-		Indicator: false,
-		Name:      "farting farty farts",
-	}
-
-	err = sink.Ingest(testSpan)
-	<-mock.got
-	testSpan.Tags = map[string]string{
-		"foo": "bar",
-		"baz": "qux",
-	}
-
-	assert.NoError(t, err)
-	assert.Equal(t, testSpan, mock.firstSpan())
-	require.Equal(t, mock.spanCount(), 1)
 }

--- a/sinks/grpsink/grpsink.go
+++ b/sinks/grpsink/grpsink.go
@@ -131,7 +131,7 @@ func (gs *GRPCSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 				"code":          serr.Code(),
 				"details":       serr.Details(),
 				"message":       serr.Message(),
-			}).Warn("Error sending span to gRPC sink target")
+			}).Error("Error sending span to gRPC sink target")
 		}
 	} else {
 		atomic.AddUint32(&gs.sentCount, 1)

--- a/sinks/grpsink/grpsink_test.go
+++ b/sinks/grpsink/grpsink_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	ocontext "golang.org/x/net/context"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,7 @@ type MockSpanSinkServer struct {
 }
 
 // SendSpans mocks base method
-func (m *MockSpanSinkServer) SendSpan(ctx context.Context, span *ssf.SSFSpan) (*Empty, error) {
+func (m *MockSpanSinkServer) SendSpan(ctx ocontext.Context, span *ssf.SSFSpan) (*Empty, error) {
 	m.mut.Lock()
 	m.spans = append(m.spans, span)
 	m.mut.Unlock()

--- a/sinks/grpsink/grpsink_test.go
+++ b/sinks/grpsink/grpsink_test.go
@@ -68,7 +68,7 @@ func TestEndToEnd(t *testing.T) {
 	}()
 	block <- struct{}{}
 
-	sink, err := NewGRPCStreamingSpanSink(context.Background(), testaddr, "test1", tags, log, grpc.WithInsecure())
+	sink, err := NewGRPCSpanSink(context.Background(), testaddr, "test1", tags, log, grpc.WithInsecure())
 	require.NoError(t, err)
 	assert.Equal(t, sink.commonTags, tags)
 	assert.NotNil(t, sink.grpcConn)

--- a/sinks/grpsink/state_helper_test18.go
+++ b/sinks/grpsink/state_helper_test18.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-func waitThroughStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration, seq ...connectivity.State) {
+func waitThroughStateSequence(t *testing.T, sink *GRPCSpanSink, dur time.Duration, seq ...connectivity.State) {
 	first, current := seq[0], sink.grpcConn.GetState()
 	require.Equal(t, first, current, "Wanted %q for initial connection state, but got %q", first, current)
 
@@ -24,14 +24,14 @@ func waitThroughStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur tim
 	}
 }
 
-func waitThroughFiniteStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration, seq ...connectivity.State) {
+func waitThroughFiniteStateSequence(t *testing.T, sink *GRPCSpanSink, dur time.Duration, seq ...connectivity.State) {
 	waitThroughStateSequence(t, sink, dur, seq[:len(seq)-1]...)
 
 	last, current := seq[len(seq)-1], sink.grpcConn.GetState()
 	require.Equal(t, last, current, "Wanted %q for final connection state, but got %q", last, current)
 }
 
-func reconnectWithin(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration) {
+func reconnectWithin(t *testing.T, sink *GRPCSpanSink, dur time.Duration) {
 	ctx, cf := context.WithTimeout(context.Background(), dur)
 	for {
 		state := sink.grpcConn.GetState()

--- a/sinks/grpsink/state_helper_test18.go
+++ b/sinks/grpsink/state_helper_test18.go
@@ -4,7 +4,6 @@ package grpsink
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -38,10 +37,6 @@ func reconnectWithin(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duratio
 		state := sink.grpcConn.GetState()
 		switch state {
 		case connectivity.Ready:
-			// Spin on the internal state marker that indicates the stream state is bad
-			for !atomic.CompareAndSwapUint32(&sink.bad, 0, 0) {
-				time.Sleep(time.Millisecond)
-			}
 			cf()
 			return
 		default:

--- a/sinks/grpsink/state_helper_test19.go
+++ b/sinks/grpsink/state_helper_test19.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-func waitThroughStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration, seq ...connectivity.State) {
+func waitThroughStateSequence(t *testing.T, sink *GRPCSpanSink, dur time.Duration, seq ...connectivity.State) {
 	t.Helper()
 
 	first, current := seq[0], sink.grpcConn.GetState()
@@ -31,7 +31,7 @@ func waitThroughStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur tim
 	}
 }
 
-func waitThroughFiniteStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration, seq ...connectivity.State) {
+func waitThroughFiniteStateSequence(t *testing.T, sink *GRPCSpanSink, dur time.Duration, seq ...connectivity.State) {
 	t.Helper()
 
 	waitThroughStateSequence(t, sink, dur, seq[:len(seq)-1]...)
@@ -44,7 +44,7 @@ func waitThroughFiniteStateSequence(t *testing.T, sink *GRPCStreamingSpanSink, d
 	}
 }
 
-func reconnectWithin(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duration) {
+func reconnectWithin(t *testing.T, sink *GRPCSpanSink, dur time.Duration) {
 	t.Helper()
 	ctx, cf := context.WithTimeout(context.Background(), dur)
 	for {

--- a/sinks/grpsink/state_helper_test19.go
+++ b/sinks/grpsink/state_helper_test19.go
@@ -4,7 +4,6 @@ package grpsink
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -52,16 +51,6 @@ func reconnectWithin(t *testing.T, sink *GRPCStreamingSpanSink, dur time.Duratio
 		state := sink.grpcConn.GetState()
 		switch state {
 		case connectivity.Ready:
-			// Spin on the internal state marker that indicates the stream state is bad
-			for atomic.LoadUint32(&sink.bad) != 0 {
-				// Make sure ctx hasn't expired
-				select {
-				case <-ctx.Done():
-					t.Fatal("Connection is READY, but stream was not re-established within alloted time")
-				default:
-					time.Sleep(5 * time.Millisecond)
-				}
-			}
 			cf()
 			return
 		default:


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

This converts the grpcsink to use a unary RPC instead of a streaming one.

The only real question i have about this is whether it's preferable to use a variable-length message in the RPC call, or a single item (as it is right now). The former approach could be useful later if we end up doing internal buffering within the sink and wanting to have a batched flush method. idk.

#### Motivation
<!-- Why are you making this change? -->

This is the appropriate way to handle this kind of interaction in gRPC. The use of streams initially was based on a misunderstanding on my part; they're really intended for sending large quantities of data to a single client, not large quantities of messages.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Automated tests.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

Standard process.

r? @aditya-stripe 