### PR TITLE
[wip] Reduce allocations for ConvertSpanUniquenessMetrics

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -441,7 +441,9 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 			}
 			span.StartTimestamp = start.UnixNano()
 			span.EndTimestamp = ended.UnixNano()
-			span.Metrics = append(span.Metrics, ssf.Timing(name, ended.Sub(start), time.Millisecond, tags))
+
+			timing := ssf.Timing(name, ended.Sub(start), time.Millisecond, tags)
+			span.Metrics = append(span.Metrics, &timing)
 		}
 
 		sf, shas := passedFlags["span_starttime"]
@@ -472,7 +474,8 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 			if err != nil {
 				return 0, err
 			}
-			span.Metrics = append(span.Metrics, ssf.Timing(name, duration, time.Millisecond, tags))
+			timing := ssf.Timing(name, duration, time.Millisecond, tags)
+			span.Metrics = append(span.Metrics, &timing)
 		}
 
 		if passedFlags["gauge"] != nil {
@@ -481,7 +484,9 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 			if err != nil {
 				return status, err
 			}
-			span.Metrics = append(span.Metrics, ssf.Gauge(name, float32(value), tags))
+
+			gauge := ssf.Gauge(name, float32(value), tags)
+			span.Metrics = append(span.Metrics, &gauge)
 		}
 
 		if passedFlags["count"] != nil {
@@ -490,7 +495,8 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 			if err != nil {
 				return status, err
 			}
-			span.Metrics = append(span.Metrics, ssf.Count(name, float32(value), tags))
+			cnt := ssf.Count(name, float32(value), tags)
+			span.Metrics = append(span.Metrics, &cnt)
 		}
 	}
 	return status, err
@@ -499,7 +505,7 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 // sendSSF sends a whole span to an SSF receiver.
 func sendSSF(client *trace.Client, span *ssf.SSFSpan) error {
 	done := make(chan error)
-	err := trace.Record(client, span, done)
+	err := trace.Record(client, *span, done)
 	if err != nil {
 		return err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stripe/veneur/ssf"
 )
 
-func freshSSFMetric() *ssf.SSFSample {
-	return &ssf.SSFSample{
+func freshSSFMetric() ssf.SSFSample {
+	return ssf.SSFSample{
 		Metric:     0,
 		Name:       "test.ssf_metric",
 		Value:      5,

--- a/parser_test.go
+++ b/parser_test.go
@@ -103,7 +103,7 @@ func TestParseSSFInvalidTraceValidMetric(t *testing.T) {
 
 	trace := &ssf.SSFSpan{}
 	trace.Metrics = make([]*ssf.SSFSample, 0)
-	trace.Metrics = append(trace.Metrics, metric)
+	trace.Metrics = append(trace.Metrics, &metric)
 
 	buff, err := proto.Marshal(trace)
 	assert.Nil(t, err)
@@ -137,7 +137,7 @@ func TestParseSSFValid(t *testing.T) {
 	trace.EndTimestamp = 5
 
 	trace.Metrics = make([]*ssf.SSFSample, 0)
-	trace.Metrics = append(trace.Metrics, metric)
+	trace.Metrics = append(trace.Metrics, &metric)
 
 	buff, err := proto.Marshal(trace)
 	assert.Nil(t, err)
@@ -310,7 +310,7 @@ func TestParseSSFBadMetric(t *testing.T) {
 	trace := &ssf.SSFSpan{}
 
 	trace.Metrics = make([]*ssf.SSFSample, 0)
-	trace.Metrics = append(trace.Metrics, metric)
+	trace.Metrics = append(trace.Metrics, &metric)
 
 	buff, err := proto.Marshal(trace)
 	assert.Nil(t, err)

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -63,7 +63,7 @@ func ConvertMetrics(m *ssf.SSFSpan) ([]UDPMetric, error) {
 	invalid := []*ssf.SSFSample{}
 
 	for _, metricPacket := range samples {
-		metric, err := ParseMetricSSF(metricPacket)
+		metric, err := ParseMetricSSF(*metricPacket)
 		if err != nil || !ValidMetric(metric) {
 			invalid = append(invalid, metricPacket)
 			continue
@@ -113,7 +113,7 @@ func ConvertSpanUniquenessMetrics(span *ssf.SSFSpan, rate float32) ([]UDPMetric,
 	if span.Service == "" {
 		return []UDPMetric{}, nil
 	}
-	ssfMetrics := []*ssf.SSFSample{}
+	ssfMetrics := []ssf.SSFSample{}
 	ssfMetrics = append(ssfMetrics,
 		ssf.RandomlySample(rate,
 			ssf.Set("ssf.names_unique", span.Name, map[string]string{
@@ -161,7 +161,7 @@ func (err *invalidMetrics) Samples() []*ssf.SSFSample {
 }
 
 // ParseMetricSSF converts an incoming SSF packet to a Metric.
-func ParseMetricSSF(metric *ssf.SSFSample) (UDPMetric, error) {
+func ParseMetricSSF(metric ssf.SSFSample) (UDPMetric, error) {
 	ret := UDPMetric{
 		SampleRate: 1.0,
 	}

--- a/samplers/parser_test.go
+++ b/samplers/parser_test.go
@@ -20,6 +20,8 @@ func BenchmarkConvertSpanUniquenessMetrics(b *testing.B) {
 			b.Fatalf("Error generating data: %s", err)
 		}
 		span := &ssf.SSFSpan{
+			Name:    "my.test.span." + string(p[:2]),
+			Service: "bigmouth",
 			Metrics: []*ssf.SSFSample{
 				{
 					Name:       "my.test.metric",
@@ -64,9 +66,12 @@ func BenchmarkConvertSpanUniquenessMetrics(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := ConvertSpanUniquenessMetrics(spans[(i%LEN)], .01)
+		result, err := ConvertSpanUniquenessMetrics(spans[(i%LEN)], 1)
 		if err != nil {
 			b.Fatalf("Error converting span uniqueness metrics: %s", err)
+		}
+		if len(result) == 0 {
+			b.Fatalf("Received zero-length uniqueness metric")
 		}
 	}
 }

--- a/samplers/parser_test.go
+++ b/samplers/parser_test.go
@@ -1,0 +1,72 @@
+package samplers
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stripe/veneur/ssf"
+)
+
+func BenchmarkConvertSpanUniquenessMetrics(b *testing.B) {
+	const LEN = 10000
+
+	spans := make([]*ssf.SSFSpan, LEN)
+
+	for i, _ := range spans {
+		p := make([]byte, 10)
+		_, err := rand.Read(p)
+		if err != nil {
+			b.Fatalf("Error generating data: %s", err)
+		}
+		span := &ssf.SSFSpan{
+			Metrics: []*ssf.SSFSample{
+				{
+					Name:       "my.test.metric",
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "false",
+						"yeats":       "false",
+						"wilde":       "true",
+						string(p[:5]): string(p[5:]),
+					},
+				},
+				{
+					Name:       string(p),
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "true",
+						"yeats":       "true",
+						"wilde":       "false",
+						string(p[2:]): string(p[7:]),
+					},
+				},
+				{
+					Name:       string(p[1:]),
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "yeats",
+						"wilde":       "weird",
+						string(p[:3]): string(p[2:]),
+					},
+				},
+			},
+		}
+		spans[i] = span
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := ConvertSpanUniquenessMetrics(spans[(i%LEN)], .01)
+		if err != nil {
+			b.Fatalf("Error converting span uniqueness metrics: %s", err)
+		}
+	}
+}

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -418,7 +418,6 @@ func (dd *DatadogSpanSink) Ingest(span *ssf.SSFSpan) error {
 // it's beneficial to performance to defer these until the normal 10s flush.
 func (dd *DatadogSpanSink) Flush() {
 	samples := &ssf.Samples{}
-	defer metrics.Report(dd.traceClient, samples)
 	dd.mutex.Lock()
 
 	flushStart := time.Now()
@@ -553,4 +552,5 @@ func (dd *DatadogSpanSink) Flush() {
 	} else {
 		dd.log.Info("No traces to flush to Datadog, skipping.")
 	}
+	defer metrics.Report(dd.traceClient, *samples)
 }

--- a/sinks/grpsink/grpc_stream.go
+++ b/sinks/grpsink/grpc_stream.go
@@ -272,7 +272,7 @@ func (gs *GRPCStreamingSpanSink) send(ssfSpan *ssf.SSFSpan) error {
 // No data is sent to the target sink on Flush(), as this sink operates entirely
 // over a stream on Ingest().
 func (gs *GRPCStreamingSpanSink) Flush() {
-	samples := &ssf.Samples{}
+	samples := ssf.Samples{}
 	samples.Add(
 		ssf.Count(
 			sinks.MetricKeyTotalSpansFlushed,

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -173,7 +173,7 @@ func (k *KafkaMetricSink) Start(cl *trace.Client) error {
 // Flush sends a slice of metrics to Kafka
 func (k *KafkaMetricSink) Flush(ctx context.Context, interMetrics []samplers.InterMetric) error {
 	samples := &ssf.Samples{}
-	defer metrics.Report(k.traceClient, samples)
+	defer metrics.Report(k.traceClient, *samples)
 
 	if len(interMetrics) == 0 {
 		k.logger.Info("Nothing to flush, skipping.")
@@ -290,7 +290,6 @@ func (k *KafkaSpanSink) Start(cl *trace.Client) error {
 // the bytes, messages and interval settings to your tastes!
 func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 	samples := &ssf.Samples{}
-	defer metrics.Report(k.traceClient, samples)
 	// If we're sampling less than 100%, we should check whether a span should
 	// be sampled:
 	if k.sampleTag != "" || k.sampleThreshold < uint32(math.MaxUint32) {
@@ -360,6 +359,7 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 	}
 	atomic.AddInt64(&k.spansFlushed, 1)
 
+	metrics.Report(k.traceClient, *samples)
 	return nil
 }
 

--- a/sinks/lightstep/lightstep.go
+++ b/sinks/lightstep/lightstep.go
@@ -199,7 +199,6 @@ func (ls *LightStepSpanSink) Flush() {
 	defer ls.mutex.Unlock()
 
 	samples := &ssf.Samples{}
-	defer metrics.Report(ls.traceClient, samples)
 
 	totalCount := int64(0)
 	for service, count := range ls.serviceCount {
@@ -209,4 +208,5 @@ func (ls *LightStepSpanSink) Flush() {
 	}
 	ls.serviceCount = make(map[string]int64)
 	ls.log.WithField("total_spans", totalCount).Debug("Checkpointing flushed spans for Lightstep")
+	metrics.Report(ls.traceClient, *samples)
 }

--- a/sinks/ssfmetrics/metrics.go
+++ b/sinks/ssfmetrics/metrics.go
@@ -58,7 +58,7 @@ func (m *metricExtractionSink) sendMetrics(metrics []samplers.UDPMetric) {
 	}
 }
 
-func (m *metricExtractionSink) sendSample(sample *ssf.SSFSample) error {
+func (m *metricExtractionSink) sendSample(sample ssf.SSFSample) error {
 	metric, err := samplers.ParseMetricSSF(sample)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (m *metricExtractionSink) Ingest(span *ssf.SSFSpan) error {
 
 func (m *metricExtractionSink) Flush() {
 	tags := map[string]string{"sink": m.Name()}
-	metrics.ReportBatch(m.traceClient, []*ssf.SSFSample{
+	metrics.ReportBatch(m.traceClient, []ssf.SSFSample{
 		ssf.Count(sinks.MetricKeyTotalSpansFlushed, float32(atomic.SwapInt64(&m.spansProcessed, 0)), tags),
 		ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(atomic.SwapInt64(&m.metricsGenerated, 0)), tags),
 	})

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -29,7 +29,7 @@ func TestMetricExtractor(t *testing.T) {
 		TraceId:        5,
 		StartTimestamp: start.UnixNano(),
 		EndTimestamp:   end.UnixNano(),
-		Metrics: []*ssf.SSFSample{
+		Metrics: []ssf.SSFSample{
 			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
 			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
 		},
@@ -71,7 +71,7 @@ func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 		TraceId:        5,
 		StartTimestamp: start.UnixNano(),
 		EndTimestamp:   end.UnixNano(),
-		Metrics: []*ssf.SSFSample{
+		Metrics: []ssf.SSFSample{
 			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
 			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
 		},

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -22,6 +22,9 @@ func TestMetricExtractor(t *testing.T) {
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	require.NoError(t, err)
 
+	cnt := ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"})
+	gauge := ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"})
+
 	start := time.Now()
 	end := start.Add(5 * time.Second)
 	span := &ssf.SSFSpan{
@@ -29,9 +32,9 @@ func TestMetricExtractor(t *testing.T) {
 		TraceId:        5,
 		StartTimestamp: start.UnixNano(),
 		EndTimestamp:   end.UnixNano(),
-		Metrics: []ssf.SSFSample{
-			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
-			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
+		Metrics: []*ssf.SSFSample{
+			&cnt,
+			&gauge,
 		},
 	}
 	done := make(chan int)
@@ -64,6 +67,9 @@ func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 		panic(err)
 	}
 
+	cnt := ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"})
+	gauge := ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"})
+
 	start := time.Now()
 	end := start.Add(5 * time.Second)
 	span := &ssf.SSFSpan{
@@ -71,9 +77,9 @@ func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 		TraceId:        5,
 		StartTimestamp: start.UnixNano(),
 		EndTimestamp:   end.UnixNano(),
-		Metrics: []ssf.SSFSample{
-			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
-			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
+		Metrics: []*ssf.SSFSample{
+			&cnt,
+			&gauge,
 		},
 	}
 

--- a/ssf/example_randomly_sample_test.go
+++ b/ssf/example_randomly_sample_test.go
@@ -23,6 +23,6 @@ func ExampleRandomlySample() {
 		ssf.Count("expensive.counter", 20, nil))...)
 
 	// Report these metrics:
-	metrics.Report(trace.DefaultClient, samples)
+	metrics.Report(trace.DefaultClient, *samples)
 	// Output:
 }

--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -27,8 +27,8 @@ var NamePrefix string
 
 // Unit is a functional option for creating an SSFSample. It sets the
 // sample's unit name to the name passed.
-func Unit(name string) func(*SSFSample) {
-	return func(s *SSFSample) {
+func Unit(name string) func(SSFSample) {
+	return func(s SSFSample) {
 		s.Unit = name
 	}
 }

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type constructor func(name string, value float32, tags map[string]string) *SSFSample
+type constructor func(name string, value float32, tags map[string]string) SSFSample
 
 func TestValidity(t *testing.T) {
 	tests := map[string]constructor{"count": Count, "gauge": Gauge, "histogram": Histogram}
@@ -50,7 +50,7 @@ func TestTimingMS(t *testing.T) {
 
 var testTypes = []string{"count", "gauge", "histogram", "set"}
 
-func testSample(t *testing.T, name string) *SSFSample {
+func testSample(t *testing.T, name string) SSFSample {
 	tags := map[string]string{"purpose": "testing"}
 	switch name {
 	case "count":
@@ -63,14 +63,14 @@ func testSample(t *testing.T, name string) *SSFSample {
 		return Set("foo", "bar", tags)
 	}
 	t.Fatalf("Unknown sample type %s", name)
-	return nil // not reached
+	return SSFSample{} // not reached
 }
 
 func TestOptions(t *testing.T) {
 	testOpts := []struct {
 		name  string
-		cons  SampleOption
-		check func(*SSFSample)
+		cons  func(SSFSample)
+		check func(SSFSample)
 	}{
 		{
 			"unit",

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -66,36 +66,6 @@ func testSample(t *testing.T, name string) SSFSample {
 	return SSFSample{} // not reached
 }
 
-func TestOptions(t *testing.T) {
-	testOpts := []struct {
-		name  string
-		cons  func(SSFSample)
-		check func(SSFSample)
-	}{
-		{
-			"unit",
-			Unit("frobnizzles"),
-			func(s *SSFSample) {
-				assert.Equal(t, "frobnizzles", s.Unit, "units do not match")
-			},
-		},
-	}
-	for _, name := range testTypes {
-		test := name
-		t.Run(fmt.Sprintf("%s", name), func(t *testing.T) {
-			t.Parallel()
-			for _, elt := range testOpts {
-				opt := elt
-				t.Run(opt.name, func(t *testing.T) {
-					t.Parallel()
-					sample := testSample(t, test)
-					opt.check(sample)
-				})
-			}
-		})
-	}
-}
-
 func TestPrefix(t *testing.T) {
 	NamePrefix = "testing.the.prefix."
 	for _, elt := range testTypes {
@@ -108,9 +78,10 @@ func TestPrefix(t *testing.T) {
 }
 
 func BenchmarkRandomlySample(b *testing.B) {
-	samples := make([]*SSFSample, 1000000)
+	samples := make([]SSFSample, 1000000)
 	for i := range samples {
-		samples[i] = Count("testing.counter", float32(i), nil)
+		cnt := Count("testing.counter", float32(i), nil)
+		samples[i] = cnt
 	}
 	b.ResetTimer()
 	samples = RandomlySample(0.2, samples...)

--- a/trace/backend_test.go
+++ b/trace/backend_test.go
@@ -84,6 +84,9 @@ func BenchmarkSerialization(b *testing.B) {
 		},
 	}
 
+	cnt := ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"})
+	hist := ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"})
+
 	spanWithMetrics := &ssf.SSFSpan{
 		Name:     "realistic_span",
 		Service:  "hi-there-srv",
@@ -95,8 +98,8 @@ func BenchmarkSerialization(b *testing.B) {
 			"span_purpose": "testing",
 		},
 		Metrics: []*ssf.SSFSample{
-			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
-			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}),
+			&cnt,
+			&hist,
 		},
 	}
 
@@ -114,8 +117,8 @@ func BenchmarkSerialization(b *testing.B) {
 
 	emptySpanWithMetrics := &ssf.SSFSpan{
 		Metrics: []*ssf.SSFSample{
-			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
-			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}),
+			&cnt,
+			&hist,
 		},
 	}
 

--- a/trace/backend_test.go
+++ b/trace/backend_test.go
@@ -96,7 +96,7 @@ func BenchmarkSerialization(b *testing.B) {
 		},
 		Metrics: []*ssf.SSFSample{
 			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
-			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}, ssf.Unit("absolute")),
+			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}),
 		},
 	}
 
@@ -115,7 +115,7 @@ func BenchmarkSerialization(b *testing.B) {
 	emptySpanWithMetrics := &ssf.SSFSpan{
 		Metrics: []*ssf.SSFSample{
 			ssf.Count("oh.hai", 1, map[string]string{"purpose": "testing"}),
-			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}, ssf.Unit("lad")),
+			ssf.Histogram("hello.there", 1, map[string]string{"purpose": "testing"}),
 		},
 	}
 

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -52,7 +52,7 @@ func mustFlush(t *testing.T, client *Client) (retries int) {
 }
 
 func TestNoClient(t *testing.T) {
-	err := Record(nil, nil, nil)
+	err := Record(nil, ssf.SSFSpan{}, nil)
 	assert.Equal(t, ErrNoClient, err)
 }
 

--- a/trace/metrics/client.go
+++ b/trace/metrics/client.go
@@ -18,14 +18,14 @@ func (nm NoMetrics) Error() string {
 // Report sends one-off metric samples encapsulated in a Samples
 // structure to a trace client without waiting for a reply.  If the
 // batch of metrics is empty, an error NoMetrics is returned.
-func Report(cl *trace.Client, samples *ssf.Samples) error {
+func Report(cl *trace.Client, samples ssf.Samples) error {
 	return ReportBatch(cl, samples.Batch)
 }
 
 // ReportBatch sends a batch of one-off metrics to a trace client without
 // waiting for a reply.  If the batch of metrics is empty, an error
 // NoMetrics is returned.
-func ReportBatch(cl *trace.Client, samples []*ssf.SSFSample) error {
+func ReportBatch(cl *trace.Client, samples []ssf.SSFSample) error {
 	return ReportAsync(cl, samples, nil)
 }
 
@@ -35,16 +35,22 @@ func ReportBatch(cl *trace.Client, samples []*ssf.SSFSample) error {
 //
 // If metrics is empty, an error NoMetrics is returned and done does
 // not receive any data.
-func ReportAsync(cl *trace.Client, metrics []*ssf.SSFSample, done chan<- error) error {
+func ReportAsync(cl *trace.Client, metrics []ssf.SSFSample, done chan<- error) error {
 	if metrics == nil || len(metrics) == 0 {
 		return NoMetrics{}
 	}
-	span := &ssf.SSFSpan{Metrics: metrics}
+
+	mtrs := make([]*ssf.SSFSample, len(metrics))
+	for i, _ := range metrics {
+		mtrs[i] = &metrics[i]
+	}
+
+	span := ssf.SSFSpan{Metrics: mtrs}
 	return trace.Record(cl, span, done)
 }
 
 // ReportOne sends a single metric to a veneur using a trace client
 // without waiting for a reply.
-func ReportOne(cl *trace.Client, metric *ssf.SSFSample) error {
-	return ReportAsync(cl, []*ssf.SSFSample{metric}, nil)
+func ReportOne(cl *trace.Client, metric ssf.SSFSample) error {
+	return ReportAsync(cl, []ssf.SSFSample{metric}, nil)
 }

--- a/trace/metrics/client_test.go
+++ b/trace/metrics/client_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func TestEmptyMetrics(t *testing.T) {
-	err := Report(trace.DefaultClient, &ssf.Samples{})
+	err := Report(trace.DefaultClient, ssf.Samples{})
 	assert.Error(t, err)
 	assert.IsType(t, NoMetrics{}, err)
 
-	assert.Error(t, ReportBatch(trace.DefaultClient, []*ssf.SSFSample{}))
+	assert.Error(t, ReportBatch(trace.DefaultClient, []ssf.SSFSample{}))
 	assert.Error(t, err)
 	assert.IsType(t, NoMetrics{}, err)
 
-	assert.Error(t, ReportAsync(trace.DefaultClient, []*ssf.SSFSample{}, nil))
+	assert.Error(t, ReportAsync(trace.DefaultClient, []ssf.SSFSample{}, nil))
 	assert.Error(t, err)
 	assert.IsType(t, NoMetrics{}, err)
 }
@@ -56,9 +56,9 @@ func TestDeferring(t *testing.T) {
 	}()
 
 	samples := &ssf.Samples{}
-	defer Report(client, samples)
 
 	samples.Add(ssf.Count("foo", 1, nil))
 	samples.Add(ssf.Count("bar", 2, nil),
 		ssf.Gauge("baz", 3, nil))
+	Report(client, *samples)
 }

--- a/trace/metrics/example_report_async_test.go
+++ b/trace/metrics/example_report_async_test.go
@@ -8,7 +8,7 @@ import (
 
 func ExampleReportAsync() {
 	// Create a slice of metrics and report them in one batch at the end of the function:
-	samples := []*ssf.SSFSample{}
+	samples := []ssf.SSFSample{}
 
 	// Let's add some metrics to the batch:
 	samples = append(samples, ssf.Count("a.counter", 2, nil))

--- a/trace/metrics/example_report_test.go
+++ b/trace/metrics/example_report_test.go
@@ -8,12 +8,12 @@ import (
 
 func ExampleReport() {
 	// Create a slice of metrics and report them in one batch at the end of the function:
-	samples := &ssf.Samples{}
-	defer metrics.Report(trace.DefaultClient, samples)
+	samples := ssf.Samples{}
 
 	// Let's add some metrics to the batch:
 	samples.Add(ssf.Count("a.counter", 2, nil))
 	samples.Add(ssf.Gauge("a.gauge", 420, nil))
+	metrics.Report(trace.DefaultClient, samples)
 
 	// Output:
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -165,8 +165,16 @@ func (t *Trace) SSFSpan() *ssf.SSFSpan {
 }
 
 // Add adds a number of metrics/samples to a Trace.
-func (t *Trace) Add(samples ...*ssf.SSFSample) {
-	t.Samples = append(t.Samples, samples...)
+func (t *Trace) Add(samples ...ssf.SSFSample) {
+	samplePtrs := make([]*ssf.SSFSample, 0, len(samples)+len(t.Samples))
+
+	for i, _ := range samples {
+		samplePtrs = append(samplePtrs, &samples[i])
+	}
+
+	samplePtrs = append(samplePtrs, t.Samples...)
+
+	t.Samples = samplePtrs
 }
 
 // ProtoMarshalTo writes the Trace as a protocol buffer
@@ -204,7 +212,7 @@ func (t *Trace) ClientRecord(cl *Client, name string, tags map[string]string) er
 	span := t.SSFSpan()
 	span.Name = name
 
-	return Record(cl, span, t.Sent)
+	return Record(cl, *span, t.Sent)
 }
 
 func (t *Trace) Error(err error) {

--- a/worker.go
+++ b/worker.go
@@ -287,7 +287,7 @@ func (w *Worker) Flush() WorkerMetrics {
 	w.mutex.Unlock()
 
 	// Track how much time each worker takes to flush.
-	metrics.ReportBatch(w.traceClient, []*ssf.SSFSample{
+	metrics.ReportBatch(w.traceClient, []ssf.SSFSample{
 		ssf.Timing("flush.worker_duration_ns", time.Since(start), time.Millisecond, nil),
 		ssf.Count("worker.metrics_processed_total", float32(processed), nil),
 		ssf.Count("worker.metrics_imported_total", float32(imported), nil),
@@ -427,7 +427,7 @@ func (tw *SpanWorker) Flush() {
 		samples.Add(ssf.Timing(sinks.MetricKeySpanIngestDuration, cumulative, time.Nanosecond, tags))
 	}
 
-	metrics.Report(tw.traceClient, samples)
+	metrics.Report(tw.traceClient, *samples)
 	metrics.ReportOne(tw.traceClient,
 		ssf.Count("worker.span.hit_chan_cap", float32(atomic.SwapInt64(&tw.capCount, 0)), nil))
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Basic sketch of reducing allocations in emitting metrics. I made no effort to preserve non-essential functionality; this is a sketch to see what the effects are.

The effects aren't massive right now. We'll need to rework this if we want to improve allocations noticeably. 

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


cc @stripe/observability 