### PR TITLE
Add a gRPC "import" server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -335,6 +335,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/segmentio/fasthash"
+  packages = ["fnv1a"]
+  revision = "a72b379d632eab4b49e4f4b2c765cfebf0a74796"
+
+[[projects]]
+  branch = "master"
   name = "github.com/signalfx/com_signalfx_metrics_protobuf"
   packages = ["."]
   revision = "93e507b42f43f458a109ca278d1542a26a0b87fc"
@@ -645,6 +651,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4781d35b91bcee0fc1dc4be69225c3d06d1da3d69bb98f1156100281804c78f1"
+  inputs-digest = "e5b41c2cf3c0db563deb76f216cc2782da7189b60e43b0a6af65736f4ad8f120"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -109,3 +109,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/araddon/dateparse"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/segmentio/fasthash"

--- a/importsrv/options.go
+++ b/importsrv/options.go
@@ -1,0 +1,11 @@
+package importsrv
+
+import "github.com/stripe/veneur/trace"
+
+// WithTraceClient sets the trace client for the server.  Otherwise it uses
+// trace.DefaultClient.
+func WithTraceClient(c *trace.Client) Option {
+	return func(opts *options) {
+		opts.traceClient = c
+	}
+}

--- a/importsrv/server.go
+++ b/importsrv/server.go
@@ -48,7 +48,7 @@ type options struct {
 // "With..."
 type Option func(*options)
 
-// New creates a unstarted Server with the input MetricIngester's to send
+// New creates an unstarted Server with the input MetricIngester's to send
 // output to.
 func New(metricOuts []MetricIngester, opts ...Option) *Server {
 	res := &Server{

--- a/importsrv/server.go
+++ b/importsrv/server.go
@@ -84,15 +84,17 @@ func (s *Server) Serve(addr string) error {
 }
 
 // Static maps of tags used in the SendMetrics handler
-var grpcTags = map[string]string{"protocol": "grpc"}
-var responseGroupTags = map[string]string{
-	"protocol": "grpc",
-	"part":     "group",
-}
-var responseSendTags = map[string]string{
-	"protocol": "grpc",
-	"part":     "send",
-}
+var (
+	grpcTags          = map[string]string{"protocol": "grpc"}
+	responseGroupTags = map[string]string{
+		"protocol": "grpc",
+		"part":     "group",
+	}
+	responseSendTags = map[string]string{
+		"protocol": "grpc",
+		"part":     "send",
+	}
+)
 
 // SendMetrics takes a list of metrics and hashes each one (based on the
 // metric key) to a specific metric ingester.

--- a/importsrv/server.go
+++ b/importsrv/server.go
@@ -1,0 +1,142 @@
+// Package importsrv receives metrics over gRPC and sends them to workers.
+//
+// The Server wraps a grpc.Server, and implements the forwardrpc.Forward
+// service.  It receives batches of metrics, then hashes them to a specific
+// "MetricIngester" and forwards them on.
+package importsrv
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"golang.org/x/net/context" // This can be replace with "context" after Go 1.8 support is dropped
+	"google.golang.org/grpc"
+
+	"github.com/stripe/veneur/forwardrpc"
+	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/samplers/metricpb"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+const (
+	responseDurationMetric = "import.response_duration_ns"
+)
+
+// MetricIngester reads metrics from protobufs
+type MetricIngester interface {
+	IngestMetrics([]*metricpb.Metric)
+}
+
+// Server wraps a gRPC server and implements the forwardrpc.Forward service.
+// It reads a list of metrics, and based on the provided key chooses a
+// MetricIngester to send it to.  A unique metric (name, tags, and type)
+// should always be routed to the same MetricIngester.
+type Server struct {
+	*grpc.Server
+	metricOuts []MetricIngester
+	opts       *options
+}
+
+type options struct {
+	traceClient *trace.Client
+}
+
+// Option is returned by functions that serve as options to New, like
+// "With..."
+type Option func(*options)
+
+// New creates a unstarted Server with the input MetricIngester's to send
+// output to.
+func New(metricOuts []MetricIngester, opts ...Option) *Server {
+	res := &Server{
+		Server:     grpc.NewServer(),
+		metricOuts: metricOuts,
+		opts:       &options{},
+	}
+
+	for _, opt := range opts {
+		opt(res.opts)
+	}
+
+	if res.opts.traceClient == nil {
+		res.opts.traceClient = trace.DefaultClient
+	}
+
+	forwardrpc.RegisterForwardServer(res.Server, res)
+
+	return res
+}
+
+// Serve starts a gRPC listener on the specified address and blocks while
+// listening for requests. If listening is interrupted by some means other
+// than Stop or GracefulStop being called, it returns a non-nil error.
+func (s *Server) Serve(addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to bind the import server to '%s': %v",
+			addr, err)
+	}
+
+	return s.Server.Serve(ln)
+}
+
+// Static maps of tags used in the SendMetrics handler
+var grpcTags = map[string]string{"protocol": "grpc"}
+var responseGroupTags = map[string]string{
+	"protocol": "grpc",
+	"part":     "group",
+}
+var responseSendTags = map[string]string{
+	"protocol": "grpc",
+	"part":     "send",
+}
+
+// SendMetrics takes a list of metrics and hashes each one (based on the
+// metric key) to a specific metric ingester.
+func (s *Server) SendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) (*empty.Empty, error) {
+	span, _ := trace.StartSpanFromContext(ctx, "veneur.opentracing.importsrv.handle_send_metrics")
+	span.SetTag("protocol", "grpc")
+	defer span.ClientFinish(s.opts.traceClient)
+
+	h := fnv.New32a()
+	dests := make([][]*metricpb.Metric, len(s.metricOuts))
+
+	// group metrics by their destination
+	groupStart := time.Now()
+	for _, m := range mlist.Metrics {
+		h.Reset()
+
+		// Add the MetricKey to the hash
+		key := samplers.NewMetricKeyFromMetric(m).String()
+		if _, err := h.Write([]byte(key)); err != nil {
+			span.Add(ssf.Count("import.metric_error_total", 1,
+				map[string]string{"cause": "io"}))
+			continue
+		}
+
+		workerIdx := h.Sum32() % uint32(len(dests))
+		dests[workerIdx] = append(dests[workerIdx], m)
+	}
+	span.Add(ssf.Timing(responseDurationMetric, time.Since(groupStart), time.Nanosecond, responseGroupTags))
+
+	// send each set of metrics to its destination.  Since this is typically
+	// implemented with channels, batching the metrics together avoids
+	// repeated channel send operations
+	sendStart := time.Now()
+	for i, ms := range dests {
+		if len(ms) > 0 {
+			s.metricOuts[i].IngestMetrics(ms)
+		}
+	}
+
+	span.Add(
+		ssf.Timing(responseDurationMetric, time.Since(sendStart), time.Nanosecond, responseSendTags),
+		ssf.Count("import.metrics_total", float32(len(mlist.Metrics)), grpcTags),
+	)
+
+	return &empty.Empty{}, nil
+}

--- a/importsrv/server_test.go
+++ b/importsrv/server_test.go
@@ -1,0 +1,137 @@
+package importsrv
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/forwardrpc"
+	"github.com/stripe/veneur/samplers/metricpb"
+	metrictest "github.com/stripe/veneur/samplers/metricpb/testutils"
+	"github.com/stripe/veneur/trace"
+)
+
+type testMetricIngester struct {
+	metrics []*metricpb.Metric
+}
+
+func (mi *testMetricIngester) IngestMetrics(ms []*metricpb.Metric) {
+	mi.metrics = append(mi.metrics, ms...)
+}
+
+func (mi *testMetricIngester) clear() {
+	mi.metrics = mi.metrics[:0]
+}
+
+// Test that sending the same metric to a Veneur results in it being hashed
+// to the same worker every time
+func TestSendMetrics_ConsistentHash(t *testing.T) {
+	ingesters := []*testMetricIngester{&testMetricIngester{}, &testMetricIngester{}}
+
+	casted := make([]MetricIngester, len(ingesters))
+	for i, ingester := range ingesters {
+		casted[i] = ingester
+	}
+	s := New(casted)
+
+	inputs := []*metricpb.Metric{
+		&metricpb.Metric{Name: "test.counter", Type: metricpb.Type_Counter, Tags: []string{"tag:1"}},
+		&metricpb.Metric{Name: "test.gauge", Type: metricpb.Type_Gauge},
+		&metricpb.Metric{Name: "test.histogram", Type: metricpb.Type_Histogram, Tags: []string{"type:histogram"}},
+		&metricpb.Metric{Name: "test.set", Type: metricpb.Type_Set},
+		&metricpb.Metric{Name: "test.gauge3", Type: metricpb.Type_Gauge},
+	}
+
+	// Send the same inputs many times
+	for i := 0; i < 10; i++ {
+		s.SendMetrics(context.Background(), &forwardrpc.MetricList{inputs})
+
+		assert.Equal(t, []*metricpb.Metric{inputs[0], inputs[4]},
+			ingesters[0].metrics, "Ingester 0 has the wrong metrics")
+		assert.Equal(t, []*metricpb.Metric{inputs[1], inputs[2], inputs[3]},
+			ingesters[1].metrics, "Ingester 1 has the wrong metrics")
+
+		for _, ingester := range ingesters {
+			ingester.clear()
+		}
+	}
+}
+
+func TestSendMetrics_Empty(t *testing.T) {
+	ingester := &testMetricIngester{}
+	s := New([]MetricIngester{ingester})
+	s.SendMetrics(context.Background(), &forwardrpc.MetricList{})
+
+	assert.Empty(t, ingester.metrics, "The server shouldn't have submitted "+
+		"any metrics")
+}
+
+func TestOptions_WithTraceClient(t *testing.T) {
+	c, err := trace.NewClient(trace.DefaultVeneurAddress)
+	if err != nil {
+		t.Fatalf("failed to initialize a trace client: %v", err)
+	}
+
+	s := New([]MetricIngester{}, WithTraceClient(c))
+	assert.Equal(t, c, s.opts.traceClient, "WithTraceClient didn't correctly "+
+		"set the trace client")
+}
+
+type noopChannelMetricIngester struct {
+	in   chan []*metricpb.Metric
+	quit chan struct{}
+}
+
+func newNoopChannelMetricIngester() *noopChannelMetricIngester {
+	return &noopChannelMetricIngester{
+		in:   make(chan []*metricpb.Metric),
+		quit: make(chan struct{}),
+	}
+}
+
+func (mi *noopChannelMetricIngester) start() {
+	go func() {
+		for {
+			select {
+			case <-mi.in:
+			case <-mi.quit:
+				return
+			}
+		}
+	}()
+}
+
+func (mi *noopChannelMetricIngester) stop() {
+	mi.quit <- struct{}{}
+}
+
+func (mi *noopChannelMetricIngester) IngestMetrics(ms []*metricpb.Metric) {
+	mi.in <- ms
+}
+
+func BenchmarkImportServerSendMetrics(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+
+	metrics := metrictest.RandomForwardMetrics(10000)
+	for _, inputSize := range []int{10, 100, 1000, 10000} {
+		ingesters := make([]MetricIngester, 100)
+		for i := range ingesters {
+			ingester := newNoopChannelMetricIngester()
+			ingester.start()
+			defer ingester.stop()
+			ingesters[i] = ingester
+		}
+		s := New(ingesters)
+		ctx := context.Background()
+		input := &forwardrpc.MetricList{Metrics: metrics[:inputSize]}
+
+		b.Run(fmt.Sprintf("InputSize=%d", inputSize), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s.SendMetrics(ctx, input)
+			}
+		})
+	}
+}

--- a/proxysrv/server_test.go
+++ b/proxysrv/server_test.go
@@ -187,7 +187,7 @@ func TestCountActiveHandlers(t *testing.T) {
 			tick := time.NewTicker(10 * time.Nanosecond)
 			defer tick.Stop()
 
-			timeout := time.NewTicker(100 * time.Millisecond)
+			timeout := time.NewTicker(3 * time.Second)
 			defer timeout.Stop()
 			for int64(n) != atomic.LoadInt64(s.activeProxyHandlers) {
 				select {
@@ -204,7 +204,7 @@ func TestCountActiveHandlers(t *testing.T) {
 
 			// Stop all of the servers and check that the counter goes to zero
 			close(done)
-			timeout = time.NewTicker(100 * time.Millisecond)
+			timeout = time.NewTicker(3 * time.Second)
 			defer timeout.Stop()
 			for atomic.LoadInt64(s.activeProxyHandlers) != 0 {
 				select {

--- a/vendor/github.com/segmentio/fasthash/.circleci/config.yml
+++ b/vendor/github.com/segmentio/fasthash/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    working_directory: /go/src/github.com/segmentio/fasthash
+    docker:
+      - image: circleci/golang
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t ./...
+      - run: go vet ./...
+      - run: go test -v -race ./...

--- a/vendor/github.com/segmentio/fasthash/.gitignore
+++ b/vendor/github.com/segmentio/fasthash/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Emacs
+*~

--- a/vendor/github.com/segmentio/fasthash/LICENSE
+++ b/vendor/github.com/segmentio/fasthash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/segmentio/fasthash/README.md
+++ b/vendor/github.com/segmentio/fasthash/README.md
@@ -1,0 +1,54 @@
+# fasthash [![CircleCI](https://circleci.com/gh/segmentio/fasthash.svg?style=shield)](https://circleci.com/gh/segmentio/fasthash) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/fasthash)](https://goreportcard.com/report/github.com/segmentio/fasthash) [![GoDoc](https://godoc.org/github.com/segmentio/fasthash?status.svg)](https://godoc.org/github.com/segmentio/fasthash)
+Go package porting the standard hashing algorithms to a more efficient implementation.
+
+## Motivations
+
+Go has great support for hashing algorithms in the standard library, but the
+APIs are all exposed as interfaces, which means passing strings or byte slices
+to those require dynamic memory allocations. Hashing a string typically requires
+2 allocations, one for the Hash value, and one to covert the string to a byte
+slice.
+
+This package attempts to solve this issue by exposing functions that implement
+string hashing algorithms and don't require dynamic memory alloations.
+
+## Testing
+
+To ensure consistency between the `fasthash` package and the standard library,
+all tests must be implemented to run against the standard hash functions and
+validate that both packages produced the same results.
+
+## Benchmarks
+
+The implementations also have to prove that they are more efficient in terms of
+CPU and memory usage than the functions found in the standard library.  
+Here's an example with fnv-1a:
+```
+BenchmarkHash64/standard_hash_function 20000000   105.0 ns/op   342.31 MB/s   56 B/op   2 allocs/op
+BenchmarkHash64/hash_function          50000000    38.6 ns/op   932.35 MB/s    0 B/op   0 allocs/op
+```
+
+# Usage Example: FNV-1a
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/segmentio/fasthash/fnv1a"
+)
+
+func main() {
+    // Hash a single string.
+    h1 := fnv1a.HashString64("Hello World!")
+    fmt.Println("FNV-1a hash of 'Hello World!':", h1)
+
+    // Incrementally compute a hash value from a sequence of strings.
+    h2 := fnv1a.Init64
+    h2 = fnv1a.AddString64(h2, "A")
+    h2 = fnv1a.AddString64(h2, "B")
+    h2 = fnv1a.AddString64(h2, "C")
+    fmt.Println("FNV-1a hash of 'ABC':", h2)
+}
+```

--- a/vendor/github.com/segmentio/fasthash/fasthash.go
+++ b/vendor/github.com/segmentio/fasthash/fasthash.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString64 makes a hashing function from the hashing algorithm returned by f.
+func HashString64(f func() hash.Hash64) func(string) uint64 {
+	return func(s string) uint64 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum64()
+	}
+}
+
+// HashUint64 makes a hashing function from the hashing algorithm return by f.
+func HashUint64(f func() hash.Hash64) func(uint64) uint64 {
+	return func(u uint64) uint64 {
+		b := [8]byte{}
+		binary.BigEndian.PutUint64(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum64()
+	}
+}

--- a/vendor/github.com/segmentio/fasthash/fasthash32.go
+++ b/vendor/github.com/segmentio/fasthash/fasthash32.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString32 makes a hashing function from the hashing algorithm returned by f.
+func HashString32(f func() hash.Hash32) func(string) uint32 {
+	return func(s string) uint32 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum32()
+	}
+}
+
+// HashUint32 makes a hashing function from the hashing algorithm return by f.
+func HashUint32(f func() hash.Hash32) func(uint32) uint32 {
+	return func(u uint32) uint32 {
+		b := [4]byte{}
+		binary.BigEndian.PutUint32(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum32()
+	}
+}

--- a/vendor/github.com/segmentio/fasthash/fasthashtest/fasthashtest.go
+++ b/vendor/github.com/segmentio/fasthash/fasthashtest/fasthashtest.go
@@ -1,0 +1,63 @@
+package fasthashtest
+
+import "testing"
+
+// TestHashString64 is the implementation of a test suite to verify the
+// behavior of a hashing algorithm.
+func TestHashString64(t *testing.T, name string, reference func(string) uint64, algorithm func(string) uint64) {
+	t.Run(name, func(t *testing.T) {
+		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2"} {
+			t.Run(s, func(t *testing.T) {
+				if reference == nil {
+					algorithm(s)
+				} else {
+					sum1 := reference(s)
+					sum2 := algorithm(s)
+
+					if sum1 != sum2 {
+						t.Errorf("invalid hash, expected %x but got %x", sum1, sum2)
+					}
+				}
+			})
+		}
+	})
+}
+
+// TestHashUint64 is the implementation of a test suite to verify the
+// behavior of a hashing algorithm.
+func TestHashUint64(t *testing.T, name string, reference func(uint64) uint64, algorithm func(uint64) uint64) {
+	t.Run(name, func(t *testing.T) {
+		if reference == nil {
+			algorithm(42)
+		} else {
+			sum1 := reference(42)
+			sum2 := algorithm(42)
+
+			if sum1 != sum2 {
+				t.Errorf("invalid hash, expected %x but got %x", sum1, sum2)
+			}
+		}
+	})
+}
+
+// BenchmarkHashString64 is the implementation of a benchmark suite to compare
+// the CPU and memory efficiency of a hashing algorithm against a reference
+// implementation.
+func BenchmarkHashString64(b *testing.B, name string, reference func(string) uint64, algorithm func(string) uint64) {
+	b.Run(name, func(b *testing.B) {
+		if reference != nil {
+			b.Run("reference", func(b *testing.B) { benchmark(b, reference) })
+		}
+		b.Run("algorithm", func(b *testing.B) { benchmark(b, algorithm) })
+	})
+}
+
+func benchmark(b *testing.B, hash func(string) uint64) {
+	const uuid = "DAB45194-42CC-4106-AB9F-2447FA4D35C2"
+
+	for i := 0; i != b.N; i++ {
+		hash(uuid)
+	}
+
+	b.SetBytes(int64(len(uuid)))
+}

--- a/vendor/github.com/segmentio/fasthash/fasthashtest/fasthashtest32.go
+++ b/vendor/github.com/segmentio/fasthash/fasthashtest/fasthashtest32.go
@@ -1,0 +1,63 @@
+package fasthashtest
+
+import "testing"
+
+// TestHashString32 is the implementation of a test suite to verify the
+// behavior of a hashing algorithm.
+func TestHashString32(t *testing.T, name string, reference func(string) uint32, algorithm func(string) uint32) {
+	t.Run(name, func(t *testing.T) {
+		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2"} {
+			t.Run(s, func(t *testing.T) {
+				if reference == nil {
+					algorithm(s)
+				} else {
+					sum1 := reference(s)
+					sum2 := algorithm(s)
+
+					if sum1 != sum2 {
+						t.Errorf("invalid hash, expected %x but got %x", sum1, sum2)
+					}
+				}
+			})
+		}
+	})
+}
+
+// TestHashUint32 is the implementation of a test suite to verify the
+// behavior of a hashing algorithm.
+func TestHashUint32(t *testing.T, name string, reference func(uint32) uint32, algorithm func(uint32) uint32) {
+	t.Run(name, func(t *testing.T) {
+		if reference == nil {
+			algorithm(42)
+		} else {
+			sum1 := reference(42)
+			sum2 := algorithm(42)
+
+			if sum1 != sum2 {
+				t.Errorf("invalid hash, expected %x but got %x %v %v", sum1, sum2, sum1, sum2)
+			}
+		}
+	})
+}
+
+// BenchmarkHashString32 is the implementation of a benchmark suite to compare
+// the CPU and memory efficiency of a hashing algorithm against a reference
+// implementation.
+func BenchmarkHashString32(b *testing.B, name string, reference func(string) uint32, algorithm func(string) uint32) {
+	b.Run(name, func(b *testing.B) {
+		if reference != nil {
+			b.Run("reference", func(b *testing.B) { benchmark32(b, reference) })
+		}
+		b.Run("algorithm", func(b *testing.B) { benchmark32(b, algorithm) })
+	})
+}
+
+func benchmark32(b *testing.B, hash func(string) uint32) {
+	const uuid = "DAB45194-42CC-4106-AB9F-2447FA4D35C2"
+
+	for i := 0; i != b.N; i++ {
+		hash(uuid)
+	}
+
+	b.SetBytes(int64(len(uuid)))
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1/hash.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1/hash.go
@@ -1,0 +1,58 @@
+package fnv1
+
+const (
+	// FNV-1
+	offset64 = uint64(14695981039346656037)
+	prime64  = uint64(1099511628211)
+
+	// Init64 is what 64 bits hash values should be initialized with.
+	Init64 = offset64
+)
+
+// HashString64 returns the hash of s.
+func HashString64(s string) uint64 {
+	return AddString64(Init64, s)
+}
+
+// HashUint64 returns the hash of u.
+func HashUint64(u uint64) uint64 {
+	return AddUint64(Init64, u)
+}
+
+// AddString64 adds the hash of s to the precomputed hash value h.
+func AddString64(h uint64, s string) uint64 {
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h * prime64) ^ uint64(s[i])
+		h = (h * prime64) ^ uint64(s[i+1])
+		h = (h * prime64) ^ uint64(s[i+2])
+		h = (h * prime64) ^ uint64(s[i+3])
+		h = (h * prime64) ^ uint64(s[i+4])
+		h = (h * prime64) ^ uint64(s[i+5])
+		h = (h * prime64) ^ uint64(s[i+6])
+		h = (h * prime64) ^ uint64(s[i+7])
+
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h * prime64) ^ uint64(c)
+	}
+
+	return h
+}
+
+// AddUint64 adds the hash value of the 8 bytes of u to h.
+func AddUint64(h uint64, u uint64) uint64 {
+	h = (h * prime64) ^ ((u >> 56) & 0xFF)
+	h = (h * prime64) ^ ((u >> 48) & 0xFF)
+	h = (h * prime64) ^ ((u >> 40) & 0xFF)
+	h = (h * prime64) ^ ((u >> 32) & 0xFF)
+	h = (h * prime64) ^ ((u >> 24) & 0xFF)
+	h = (h * prime64) ^ ((u >> 16) & 0xFF)
+	h = (h * prime64) ^ ((u >> 8) & 0xFF)
+	h = (h * prime64) ^ ((u >> 0) & 0xFF)
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1/hash32.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1/hash32.go
@@ -1,0 +1,54 @@
+package fnv1
+
+const (
+	// FNV-1
+	offset32 = uint32(2166136261)
+	prime32  = uint32(16777619)
+
+	// Init32 is what 32 bits hash values should be initialized with.
+	Init32 = offset32
+)
+
+// HashString32 returns the hash of s.
+func HashString32(s string) uint32 {
+	return AddString32(Init32, s)
+}
+
+// HashUint32 returns the hash of u.
+func HashUint32(u uint32) uint32 {
+	return AddUint32(Init32, u)
+}
+
+// AddString32 adds the hash of s to the precomputed hash value h.
+func AddString32(h uint32, s string) uint32 {
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h * prime32) ^ uint32(s[i])
+		h = (h * prime32) ^ uint32(s[i+1])
+		h = (h * prime32) ^ uint32(s[i+2])
+		h = (h * prime32) ^ uint32(s[i+3])
+		h = (h * prime32) ^ uint32(s[i+4])
+		h = (h * prime32) ^ uint32(s[i+5])
+		h = (h * prime32) ^ uint32(s[i+6])
+		h = (h * prime32) ^ uint32(s[i+7])
+
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h * prime32) ^ uint32(c)
+	}
+
+	return h
+}
+
+// AddUint32 adds the hash value of the 8 bytes of u to h.
+func AddUint32(h, u uint32) uint32 {
+	h = (h * prime32) ^ ((u >> 24) & 0xFF)
+	h = (h * prime32) ^ ((u >> 16) & 0xFF)
+	h = (h * prime32) ^ ((u >> 8) & 0xFF)
+	h = (h * prime32) ^ ((u >> 0) & 0xFF)
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1/hash32_test.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1/hash32_test.go
@@ -1,0 +1,18 @@
+package fnv1
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
+)
+
+func TestHash32(t *testing.T) {
+	fasthashtest.TestHashString32(t, "fnv1", fasthash.HashString32(fnv.New32), HashString32)
+	fasthashtest.TestHashUint32(t, "fnv1", fasthash.HashUint32(fnv.New32), HashUint32)
+}
+
+func BenchmarkHash32(b *testing.B) {
+	fasthashtest.BenchmarkHashString32(b, "fnv1", fasthash.HashString32(fnv.New32a), HashString32)
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1/hash_test.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1/hash_test.go
@@ -1,0 +1,18 @@
+package fnv1
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
+)
+
+func TestHash64(t *testing.T) {
+	fasthashtest.TestHashString64(t, "fnv1", fasthash.HashString64(fnv.New64), HashString64)
+	fasthashtest.TestHashUint64(t, "fnv1", fasthash.HashUint64(fnv.New64), HashUint64)
+}
+
+func BenchmarkHash64(b *testing.B) {
+	fasthashtest.BenchmarkHashString64(b, "fnv1", fasthash.HashString64(fnv.New64a), HashString64)
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash.go
@@ -1,0 +1,71 @@
+package fnv1a
+
+const (
+	// FNV-1a
+	offset64 = uint64(14695981039346656037)
+	prime64  = uint64(1099511628211)
+
+	// Init64 is what 64 bits hash values should be initialized with.
+	Init64 = offset64
+)
+
+// HashString64 returns the hash of s.
+func HashString64(s string) uint64 {
+	return AddString64(Init64, s)
+}
+
+// HashUint64 returns the hash of u.
+func HashUint64(u uint64) uint64 {
+	return AddUint64(Init64, u)
+}
+
+// AddString64 adds the hash of s to the precomputed hash value h.
+func AddString64(h uint64, s string) uint64 {
+	/*
+		This is an unrolled version of this algorithm:
+
+		for _, c := range s {
+			h = (h ^ uint64(c)) * prime64
+		}
+
+		It seems to be ~1.5x faster than the simple loop in BenchmarkHash64:
+
+		- BenchmarkHash64/hash_function-4   30000000   56.1 ns/op   642.15 MB/s   0 B/op   0 allocs/op
+		- BenchmarkHash64/hash_function-4   50000000   38.6 ns/op   932.35 MB/s   0 B/op   0 allocs/op
+
+	*/
+
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h ^ uint64(s[i])) * prime64
+		h = (h ^ uint64(s[i+1])) * prime64
+		h = (h ^ uint64(s[i+2])) * prime64
+		h = (h ^ uint64(s[i+3])) * prime64
+		h = (h ^ uint64(s[i+4])) * prime64
+		h = (h ^ uint64(s[i+5])) * prime64
+		h = (h ^ uint64(s[i+6])) * prime64
+		h = (h ^ uint64(s[i+7])) * prime64
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h ^ uint64(c)) * prime64
+	}
+
+	return h
+}
+
+// AddUint64 adds the hash value of the 8 bytes of u to h.
+func AddUint64(h uint64, u uint64) uint64 {
+	h = (h ^ ((u >> 56) & 0xFF)) * prime64
+	h = (h ^ ((u >> 48) & 0xFF)) * prime64
+	h = (h ^ ((u >> 40) & 0xFF)) * prime64
+	h = (h ^ ((u >> 32) & 0xFF)) * prime64
+	h = (h ^ ((u >> 24) & 0xFF)) * prime64
+	h = (h ^ ((u >> 16) & 0xFF)) * prime64
+	h = (h ^ ((u >> 8) & 0xFF)) * prime64
+	h = (h ^ ((u >> 0) & 0xFF)) * prime64
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash32.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash32.go
@@ -1,0 +1,53 @@
+package fnv1a
+
+const (
+	// FNV-1a
+	offset32 = uint32(2166136261)
+	prime32  = uint32(16777619)
+
+	// Init32 is what 32 bits hash values should be initialized with.
+	Init32 = offset32
+)
+
+// HashString32 returns the hash of s.
+func HashString32(s string) uint32 {
+	return AddString32(Init32, s)
+}
+
+// HashUint32 returns the hash of u.
+func HashUint32(u uint32) uint32 {
+	return AddUint32(Init32, u)
+}
+
+// AddString32 adds the hash of s to the precomputed hash value h.
+func AddString32(h uint32, s string) uint32 {
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h ^ uint32(s[i])) * prime32
+		h = (h ^ uint32(s[i+1])) * prime32
+		h = (h ^ uint32(s[i+2])) * prime32
+		h = (h ^ uint32(s[i+3])) * prime32
+		h = (h ^ uint32(s[i+4])) * prime32
+		h = (h ^ uint32(s[i+5])) * prime32
+		h = (h ^ uint32(s[i+6])) * prime32
+		h = (h ^ uint32(s[i+7])) * prime32
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h ^ uint32(c)) * prime32
+	}
+
+	return h
+}
+
+// AddUint32 adds the hash value of the 8 bytes of u to h.
+func AddUint32(h, u uint32) uint32 {
+	h = (h ^ ((u >> 24) & 0xFF)) * prime32
+	h = (h ^ ((u >> 16) & 0xFF)) * prime32
+	h = (h ^ ((u >> 8) & 0xFF)) * prime32
+	h = (h ^ ((u >> 0) & 0xFF)) * prime32
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash32_test.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash32_test.go
@@ -1,0 +1,18 @@
+package fnv1a
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
+)
+
+func TestHash32(t *testing.T) {
+	fasthashtest.TestHashString32(t, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
+	fasthashtest.TestHashUint32(t, "fnv1a", fasthash.HashUint32(fnv.New32a), HashUint32)
+}
+
+func BenchmarkHash32(b *testing.B) {
+	fasthashtest.BenchmarkHashString32(b, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash_test.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash_test.go
@@ -1,0 +1,18 @@
+package fnv1a
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
+)
+
+func TestHash64(t *testing.T) {
+	fasthashtest.TestHashString64(t, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
+	fasthashtest.TestHashUint64(t, "fnv1a", fasthash.HashUint64(fnv.New64a), HashUint64)
+}
+
+func BenchmarkHash64(b *testing.B) {
+	fasthashtest.BenchmarkHashString64(b, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
+}

--- a/vendor/github.com/segmentio/fasthash/jody/hash.go
+++ b/vendor/github.com/segmentio/fasthash/jody/hash.go
@@ -1,0 +1,118 @@
+package jody
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const (
+	shift    = 11
+	constant = 0x1f3d5b79
+
+	// Init64 is what 64 bits hash values should be initialized with.
+	Init64 = uint64(0)
+)
+
+var mask64 = [...]uint64{
+	0x0000000000000000,
+	0x00000000000000ff,
+	0x000000000000ffff,
+	0x0000000000ffffff,
+	0x00000000ffffffff,
+	0x000000ffffffffff,
+	0x0000ffffffffffff,
+	0x00ffffffffffffff,
+	0xffffffffffffffff,
+}
+
+// HashString64 returns the hash of s.
+func HashString64(s string) uint64 {
+	return AddString64(Init64, s)
+}
+
+// HashUint64 returns the hash of u.
+func HashUint64(u uint64) uint64 {
+	return AddUint64(Init64, u)
+}
+
+// AddString64 adds the hash of s to the precomputed hash value h.
+func AddString64(h uint64, s string) uint64 {
+	/*
+		This is an implementation of the jody hashing algorithm as found here:
+
+		- https://github.com/jbruchon/jodyhash
+
+		It was revisited a bit and only the 64 bit version is available for now,
+		but it's indeed really fast:
+
+		- BenchmarkHash64/jody/algorithm-4   100000000   11.8 ns/op   3050.83 MB/s   0 B/op   0 allocs/op
+
+		Here's what the reference implementation looks like:
+
+		hash_t hash = start_hash;
+		hash_t element;
+		hash_t partial_salt;
+		size_t len;
+
+		len = count / sizeof(hash_t);
+		for (; len > 0; len--) {
+			element = *data;
+			hash += element;
+			hash += constant;
+			hash = (hash << shift) | hash >> (sizeof(hash_t) * 8 - shift);
+			hash ^= element;
+			hash = (hash << shift) | hash >> (sizeof(hash_t) * 8 - shift);
+			hash ^= constant;
+			hash += element;
+			data++;
+		}
+
+		len = count & (sizeof(hash_t) - 1);
+		if (len) {
+			partial_salt = constant & tail_mask[len];
+			element = *data & tail_mask[len];
+			hash += element;
+			hash += partial_salt;
+			hash = (hash << shift) | hash >> (sizeof(hash_t) * 8 - shift);
+			hash ^= element;
+			hash = (hash << shift) | hash >> (sizeof(hash_t) * 8 - shift);
+			hash ^= partial_salt;
+			hash += element;
+		}
+
+		return hash;
+	*/
+
+	r := *(*reflect.StringHeader)(unsafe.Pointer(&s))
+	p := unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data)
+
+	for n := r.Len / 8; n != 0; n-- {
+		v := *(*uint64)(p)
+
+		h = h + v + constant
+		h = (h<<shift | h>>(64-shift)) ^ v
+		h = ((h<<shift | h>>(64-shift)) ^ constant) + v
+
+		p = unsafe.Pointer(uintptr(p) + 8)
+	}
+
+	if n := (r.Len & 7); n != 0 {
+		m := mask64[n]
+		c := constant & m
+		v := *(*uint64)(p) & m // risk of segfault here?
+
+		h = h + v + c
+		h = (h<<shift | h>>(64-shift)) ^ v
+		h = ((h<<shift | h>>(64-shift)) ^ c) + v
+	}
+
+	return h
+}
+
+// AddUint64 adds the hash value of the 8 bytes of u to h.
+func AddUint64(h uint64, u uint64) uint64 {
+	h = h + u + constant
+	h = (h<<shift | h>>(64-shift)) ^ u
+	h = ((h<<shift | h>>(64-shift)) ^ constant) + u
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/jody/hash_test.go
+++ b/vendor/github.com/segmentio/fasthash/jody/hash_test.go
@@ -1,0 +1,43 @@
+package jody
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/segmentio/fasthash/fasthashtest"
+)
+
+func TestHash64(t *testing.T) {
+	// I couldn't find a reference implementation in Go, so this is a hacky
+	// test that checks for values generated from the jodyhash command line
+	// utility.
+
+	referenceString64 := func(s string) uint64 {
+		switch s {
+		case "":
+			return 0x0000000000000000
+		case "A":
+			return 0x000000002e8208ba
+		case "Hello World!":
+			return 0x60be57b5a53eb1c7
+		case "DAB45194-42CC-4106-AB9F-2447FA4D35C2":
+			return 0x587861d2b41e1997
+		default:
+			panic("test not implemented: " + s)
+		}
+	}
+
+	referenceUint64 := func(u uint64) uint64 {
+		if u != 42 {
+			panic(fmt.Sprint("test not implemented:", u))
+		}
+		return 0x0007cf56f7fc0ba3
+	}
+
+	fasthashtest.TestHashString64(t, "jody", referenceString64, HashString64)
+	fasthashtest.TestHashUint64(t, "jody", referenceUint64, HashUint64)
+}
+
+func BenchmarkHash64(b *testing.B) {
+	fasthashtest.BenchmarkHashString64(b, "jody", nil, HashString64)
+}


### PR DESCRIPTION
### This PR contains a subset of the changes in #407, which enables full gRPC support

#### Summary

This adds a gRPC "import" server, which receives metrics and outputs them to a set of generic `MetricIngesters`.  This should be used to receive metrics forwarded from another Veneur.

##### `importsrv` package

The importsrv package defines a gRPC server that implements the `forwardrpc.Forward` service.  It receives batches of metrics, and sends them on to a set of sinks based on their key.  To facilitate easy testing of this RPC, I made the server accept an interface `MetricIngester`, which is what is used to forward the metrics.  `Worker` will later implement this interface, allowing for them to be passed directly into this server.

##### Optimizations for gRPC imports

From profiling global Veneurs in our production environment, we see that the garbage collector is generally dominating the CPU usage.  Digging in a little more, it looks like the process to hash a metric to a destination worker in the "importsrv" package is actually doing a ton of allocations (about 20% of total allocated objects).  

To optimize this, I pulled in an external fnv hash implementation [github.com/segmentio/fasthash](https://github.com/segmentio/fasthash) that handles strings with zero allocations and doesn't use interface types.  I also removed usages of "MetricKey", as it does a lot of string manipulations that perform a ton of allocations, in favor of just writing strings directly into the hash.

[The benchmarks](https://gist.github.com/noahgoldman/034fb2a52aadd60c383321fe9d3a4ba3) show nice improvements in the number of allocations. There is a 2x reduction for a small number of metrics (10 to be specific) and a 6x reduction for 100 metrics, which is closer to our average of around 180 currently.

While this seems like a nice improvement to me, it does require the additional dependency.  I put these changes in a separate commit (fc6634a), and I'm happy to revert it if the performance gain doesn't seem worth it!

#### Motivation

Like I also said in #439, we (@quantcast) would like to contribute gRPC support to eventually enable global histogram aggregations (#390). We are also already running this.

#### Test plan

I wrote a number of tests for the new package.  Very similar code is also currently running in our production environment and handling almost our entire metric volume without issues.

#### Rollout/monitoring/revert plan

As with #439, all of the new code is (so far) unused, and so there should be no functional changes and any deployment should be a no-op!

CC: @sdboyer-stripe @cory-stripe @stripe/observability
