### PR TITLE
Switch to fasthash library for consistent hashing

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,7 +1,6 @@
 package veneur
 
 import (
-	"hash/fnv"
 	"net/http"
 	"net/http/pprof"
 	"sort"
@@ -12,6 +11,7 @@ import (
 	"github.com/stripe/veneur/trace"
 	"github.com/stripe/veneur/trace/metrics"
 
+	"github.com/segmentio/fasthash/fnv1a"
 	"goji.io"
 	"goji.io/pat"
 	"golang.org/x/net/context"
@@ -82,11 +82,11 @@ func newSortableJSONMetrics(metrics []samplers.JSONMetric, numWorkers int) *sort
 		workerIndices: make([]uint32, 0, len(metrics)),
 	}
 	for _, j := range metrics {
-		h := fnv.New32a()
-		h.Write([]byte(j.Name))
-		h.Write([]byte(j.Type))
-		h.Write([]byte(j.JoinedTags))
-		ret.workerIndices = append(ret.workerIndices, h.Sum32()%uint32(numWorkers))
+		h := fnv1a.Init32
+		h = fnv1a.AddString32(h, j.Name)
+		h = fnv1a.AddString32(h, j.Type)
+		h = fnv1a.AddString32(h, j.JoinedTags)
+		ret.workerIndices = append(ret.workerIndices, h%uint32(numWorkers))
 	}
 	return &ret
 }

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -469,3 +469,34 @@ func TestParseMetricSSF(t *testing.T) {
 	assert.Equal(t, udpMetric.Tags, expected.Tags)
 	assert.Equal(t, udpMetric.Scope, expected.Scope)
 }
+
+func BenchmarkParseMetricSSF(b *testing.B) {
+
+	const LEN = 10000
+
+	samples := make([]*ssf.SSFSample, LEN)
+
+	for i, _ := range samples {
+		p := make([]byte, 10)
+		_, err := rand.Read(p)
+		if err != nil {
+			b.Fatalf("Error generating data: %s", err)
+		}
+		sample := ssf.SSFSample{
+			Name:       "my.test.metric",
+			Value:      rand.Float32(),
+			Timestamp:  time.Now().Unix(),
+			SampleRate: rand.Float32(),
+			Tags: map[string]string{
+				"keats":       "false",
+				"yeats":       "false",
+				"wilde":       "true",
+				string(p[:5]): string(p[5:]),
+			},
+		}
+		samples[i] = &sample
+	}
+	for i := 0; i < b.N; i++ {
+		ParseMetricSSF(samples[i%LEN])
+	}
+}

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -496,6 +496,7 @@ func BenchmarkParseMetricSSF(b *testing.B) {
 		}
 		samples[i] = &sample
 	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ParseMetricSSF(samples[i%LEN])
 	}

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -8,7 +8,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/ssf"
 )
+
+const ε = .01
 
 func TestRouting(t *testing.T) {
 	tests := []struct {
@@ -417,4 +420,52 @@ func TestMetricKeyEquality(t *testing.T) {
 	// Make sure we can stringify that key and get equal!
 	assert.Equal(t, ce1.MetricKey.String(), ce2.MetricKey.String())
 	assert.NotEqual(t, ce1.MetricKey.String(), ce3.MetricKey.String())
+}
+
+func TestParseMetricSSF(t *testing.T) {
+	sample := ssf.SSFSample{
+		Metric: ssf.SSFSample_GAUGE,
+
+		Name:       "my.test.metric",
+		Value:      rand.Float32(),
+		Timestamp:  time.Now().Unix(),
+		Message:    "arbitrary test message",
+		Status:     ssf.SSFSample_WARNING,
+		SampleRate: rand.Float32(),
+		Tags: map[string]string{
+			"keats":            "false",
+			"yeats":            "false",
+			"wilde":            "true",
+			"veneurglobalonly": "true",
+		},
+		Unit: "frobs per second",
+	}
+
+	expected := UDPMetric{
+		MetricKey: MetricKey{
+			Name:       "my.test.metric",
+			Type:       "gauge",
+			JoinedTags: "keats:false,wilde:true,yeats:false",
+		},
+		Digest:     0x7ae783ad,
+		Value:      sample.Value,
+		SampleRate: sample.SampleRate,
+		Tags: []string{
+			"keats:false",
+			"wilde:true",
+			"yeats:false",
+		},
+		Scope: 2,
+	}
+
+	udpMetric, err := ParseMetricSSF(&sample)
+	assert.NoError(t, err)
+	assert.Equal(t, udpMetric.MetricKey, expected.MetricKey)
+	assert.Equal(t, udpMetric.Type, expected.Type)
+	assert.Equal(t, udpMetric.Digest, expected.Digest)
+	assert.InEpsilon(t, udpMetric.Value, expected.Value, ε)
+	assert.InEpsilon(t, udpMetric.SampleRate, expected.SampleRate, ε)
+	assert.Equal(t, udpMetric.JoinedTags, expected.JoinedTags)
+	assert.Equal(t, udpMetric.Tags, expected.Tags)
+	assert.Equal(t, udpMetric.Scope, expected.Scope)
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Switch to the faster [fasthash](https://github.com/segmentio/fasthash) package for consistent hashing, per https://github.com/stripe/veneur/pull/442. This significantly reduces allocations for two functions that are in hot code paths.


#### Motivation
<!-- Why are you making this change? -->

Faster hashing! On my local machine:

```
$ go test -benchmem -bench=BenchmarkParseMetricSSF github.com/stripe/veneur/samplers
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur/samplers
BenchmarkParseMetricSSF-8        1000000              1813 ns/op             516 B/op         23 allocs/op
PASS
ok      github.com/stripe/veneur/samplers       1.876s
```

becomes

```
$ go test -benchmem -bench=BenchmarkParseMetricSSF github.com/stripe/veneur/samplers
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur/samplers
BenchmarkParseMetricSSF-8        1000000              1683 ns/op             444 B/op         19 allocs/op
PASS
ok      github.com/stripe/veneur/samplers       1.745s
```

and


```
$ go test -run MatchNothing -benchmem -bench=BenchmarkNewSortableJSONMetrics github.com/stripe/veneur

<elided>

10000000               200 ns/op              80 B/op          5 allocs/op
PASS
ok      github.com/stripe/veneur        4.416s
```
becomes 

```
$ go test -run MatchNothing -benchmem -bench=BenchmarkNewSortableJSONMetrics github.com/stripe/veneur

<elided>

20000000               100 ns/op              52 B/op          2 allocs/op
PASS
ok      github.com/stripe/veneur        5.429s
```


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 