### PR TITLE
Add trace.InjectHeader convenience function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Metrics can be forwarded over gRPC using veneur-proxy (and Consul).  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
+* Added tracer.InjectHeader convenience function for... convenience! Thanks, [mikeh](https://github.com/mikeh-stripe)!
 
 ## Removals
 * Go 1.9 is no longer supported.

--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -465,7 +465,13 @@ func (t Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOpt
 // InjectRequest injects a trace into an HTTP request header.
 // It is a convenience function for Inject.
 func (tracer Tracer) InjectRequest(t *Trace, req *http.Request) error {
-	carrier := opentracing.HTTPHeadersCarrier(req.Header)
+	return tracer.InjectHeader(t, req.Header)
+}
+
+// InjectHeader injects a trace into an HTTP header.
+// It is a convenience function for Inject.
+func (tracer Tracer) InjectHeader(t *Trace, h http.Header) error {
+	carrier := opentracing.HTTPHeadersCarrier(h)
 	return tracer.Inject(t.context(), opentracing.HTTPHeaders, carrier)
 }
 

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -308,13 +308,15 @@ func TestInjectRequestInjectHeaderExtractRequestChild(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "/test", bytes.NewBuffer(nil))
 	assert.NoError(t, err)
 
-	header := req.Header
+	req2, err := http.NewRequest(http.MethodPost, "/test2", bytes.NewBuffer(nil))
+	assert.NoError(t, err)
+
 	err = tracer.InjectRequest(trace, req)
 	assert.NoError(t, err)
 
-	err = tracer.InjectHeader(trace, header)
+	err = tracer.InjectHeader(trace, req2.Header)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(req.Header, header), "injected HTTP headers should be the same")
+	assert.True(t, reflect.DeepEqual(req.Header, req2.Header), "injected HTTP headers should be the same")
 
 	span, err := tracer.ExtractRequestChild(childResource, req, traceName)
 	assert.NoError(t, err)

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -7,15 +7,15 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/stripe/veneur/ssf"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/ssf"
 )
 
 // Test that the Tracer can correctly create a root-level
@@ -297,9 +297,9 @@ func assertTagEqual(t *testing.T, tagName string, expected *Trace, sample *ssf.S
 	assert.Equal(t, expected.Tags[tagName], sample.Tags[tagName], "Tag '%s' has wrong value", tagName)
 }
 
-// TestInjectRequestExtractRequestChild tests the InjectRequest
+// TestInjectRequestExtractRequestChild tests the InjectRequest, InjectHeader,
 // and ExtractRequestChild helper functions
-func TestInjectRequestExtractRequestChild(t *testing.T) {
+func TestInjectRequestInjectHeaderExtractRequestChild(t *testing.T) {
 	const childResource = "my child resource"
 	const traceName = "my.child.name"
 	trace := DummySpan().Trace
@@ -308,8 +308,13 @@ func TestInjectRequestExtractRequestChild(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "/test", bytes.NewBuffer(nil))
 	assert.NoError(t, err)
 
+	header := req.Header
 	err = tracer.InjectRequest(trace, req)
 	assert.NoError(t, err)
+
+	err = tracer.InjectHeader(trace, header)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(req.Header, header), "injected HTTP headers should be the same")
 
 	span, err := tracer.ExtractRequestChild(childResource, req, traceName)
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Summary
This PR adds the `trace.InjectHeader` convenience function, which does the same thing as the `trace.InjectRequest` function, but only requires an `http.Header` rather than a `*http.Request`.

#### Motivation
I needed to inject a trace into a header in a spot where I only had access to the header -- the original `http.Request` struct was unavailable.

#### Test plan
I've tested this change in development.

#### Rollout/monitoring/revert plan
This change can be easily reverted without issue.

cc @stripe/observability
cc @stripe/observability-stripe