### PR TITLE
Use statsd metrics client for trace ingestion functions

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1318,7 +1318,7 @@ func BenchmarkHandleSSF(b *testing.B) {
 	f := newFixture(b, config, nil, nil)
 	defer f.Close()
 
-	baseTags := map[string]string{"ssf_format": "packet"}
+	baseTags := []string{"ssf_format:packet"}
 
 	b.ResetTimer()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1257,3 +1257,72 @@ func TestGenerateExcludeTags(t *testing.T) {
 		})
 	}
 }
+
+func generateSSFPackets(tb testing.TB, length int) [][]byte {
+	input := make([][]byte, length)
+	for i, _ := range input {
+		p := make([]byte, 10)
+		_, err := rand.Read(p)
+		if err != nil {
+			tb.Fatalf("Error generating data: %s", err)
+		}
+		msg := &ssf.SSFSpan{
+			Version:        1,
+			TraceId:        1,
+			Id:             2,
+			ParentId:       3,
+			StartTimestamp: time.Now().Unix(),
+			EndTimestamp:   time.Now().Add(5 * time.Second).Unix(),
+			Tags: map[string]string{
+				string(p[:4]):  string(p[5:]),
+				string(p[3:7]): string(p[1:3]),
+			},
+		}
+
+		data, err := msg.Marshal()
+		assert.NoError(tb, err)
+
+		input[i] = data
+	}
+	return input
+}
+
+func BenchmarkHandleTracePacket(b *testing.B) {
+	const LEN = 1000
+	input := generateSSFPackets(b, LEN)
+
+	config := localConfig()
+	f := newFixture(b, config, nil, nil)
+
+	defer f.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.server.HandleTracePacket(input[i%LEN])
+	}
+}
+
+func BenchmarkHandleSSF(b *testing.B) {
+	const LEN = 1000
+	packets := generateSSFPackets(b, LEN)
+	spans := make([]*ssf.SSFSpan, len(packets))
+
+	for i, _ := range spans {
+		span, err := protocol.ParseSSF(packets[i])
+		assert.NoError(b, err)
+		spans[i] = span
+	}
+
+	config := localConfig()
+	f := newFixture(b, config, nil, nil)
+	defer f.Close()
+
+	baseTags := map[string]string{"ssf_format": "packet"}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.server.handleSSF(spans[i%LEN], baseTags)
+	}
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add benchmark functions in test code for `protocol.ParseSSF`, (veneur.Server).HandleTracePacket, and (veneur.Server).handleSSF.

From these benchmarks, we can see that HandleTracePacket is using more memory than it needs to - particularly handleSSF. This is great news, because it gives us a great place to squeeze better performance out of the span ingestion portion of Veneur!


#### Motivation
<!-- Why are you making this change? -->

At the time I introduced the benchmark (ie, running on current `master`), handling a trace packet requires 20 allocations for a total of 1.6KB memory usage, and takes 5766ns/op on my laptop.

```
$ go test -run Nothing -benchmem -bench BenchmarkHandleTracePacket
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkHandleTracePacket-8
200000              5766 ns/op            1632 B/op         20 allocs/op
```

By switching back to the statsd client library, each trace packet we handle requires only 15 allocations, 837 bytes, and takes 4813 ns/op on my laptop:

```
$ go test -run Nothing -benchmem -bench BenchmarkHandleTracePacket
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkHandleTracePacket-8
  300000              4813 ns/op             837 B/op         15 allocs/op
```

In other words, we're able to reduce the number of discrete allocations by 25%, and the total garbage generated by 50%. The total performance impact would have to be measured in production, because the real performance hit (the load on the garbage collector) isn't captured by these numbers.

This isn't fully optimized either; for example, we could shave off an extra allocation by prepopulating the `service` tag before handing it off to handleSSF.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Added benchmarks. The only non-test code I changed is for which metrics get reported. I'll deploy to QA to check that we're still reporting each of these metrics correctly.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 
cc @asf-stripe (would prefer he review this, but he's out today)