### PR TITLE
Fix veneur-prometheus filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Converted the grpsink to use unary instead of stream RPCs. Thanks, [sdboyer](https://github.com/sdboyer)!
 * Bumped version of [SignalFx go client](https://github.com/signalfx/golib) to prevent accidental removal of `-` from tag keys. Thanks, [gphat](https://github.com/gphat)!
 
+## Bugfixes
+* The `ignored-labels` and `ignored-metrics` flags for veneur-prometheus will filter no metrics or labels if no filter is specified. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
+
 # 4.0.0, 2018-04-13
 
 ## Improvements

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -44,10 +44,14 @@ func main() {
 	ignoredMetrics := []*regexp.Regexp{}
 
 	for _, ignoredLabelStr := range strings.Split(*ignoredLabelsStr, ",") {
-		ignoredLabels = append(ignoredLabels, regexp.MustCompile(ignoredLabelStr))
+		if len(ignoredLabelStr) > 0 {
+			ignoredLabels = append(ignoredLabels, regexp.MustCompile(ignoredLabelStr))
+		}
 	}
 	for _, ignoredMetricStr := range strings.Split(*ignoredMetricsStr, ",") {
-		ignoredMetrics = append(ignoredMetrics, regexp.MustCompile(ignoredMetricStr))
+		if len(ignoredMetricStr) > 0 {
+			ignoredMetrics = append(ignoredMetrics, regexp.MustCompile(ignoredMetricStr))
+		}
 	}
 
 	ticker := time.NewTicker(i)

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -66,9 +66,9 @@ func main() {
 
 func collect(c *statsd.Client, ignoredLabels []*regexp.Regexp, ignoredMetrics []*regexp.Regexp) {
 	logrus.WithFields(logrus.Fields{
-		"stats_host":   *statsHost,
-		"metrics_host": *metricsHost,
-		"ignored_labels": ignoredLabels,
+		"stats_host":      *statsHost,
+		"metrics_host":    *metricsHost,
+		"ignored_labels":  ignoredLabels,
 		"ignored_metrics": ignoredMetrics,
 	}).Debug("Beginning collection")
 

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -47,7 +47,7 @@ func main() {
 		ignoredLabels = append(ignoredLabels, regexp.MustCompile(ignoredLabelStr))
 	}
 	for _, ignoredMetricStr := range strings.Split(*ignoredMetricsStr, ",") {
-		ignoredMetrics = append(ignoredLabels, regexp.MustCompile(ignoredMetricStr))
+		ignoredMetrics = append(ignoredMetrics, regexp.MustCompile(ignoredMetricStr))
 	}
 
 	ticker := time.NewTicker(i)

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -64,6 +64,8 @@ func collect(c *statsd.Client, ignoredLabels []*regexp.Regexp, ignoredMetrics []
 	logrus.WithFields(logrus.Fields{
 		"stats_host":   *statsHost,
 		"metrics_host": *metricsHost,
+		"ignored_labels": ignoredLabels,
+		"ignored_metrics": ignoredMetrics,
 	}).Debug("Beginning collection")
 
 	resp, _ := http.Get(*metricsHost)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Fixes for filtering of metrics in `veneur-prometheus` that were introduced in #414.


#### Motivation
The filtering for `veneur-prometheus` that was introduced in #414 is partially broken. When no filter is specified, it adds an empty regex which matches *all* metrics. This causes all metrics to be dropped. This will likely happen to anyone who updates to this version.

Additionally when building the list of `ignored-metrics` the wrong arrays are appended. Only the last ignored metric is retained and combined with all ignored labels. 

I've added the filters to the debug logs so it's visible which filters are applied.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Run `veneur-prometheus` with debugging enabled and verify that the correct filters are logged.

For instance, running:

```
veneur-prometheus -d -ignored-labels label1,label2 -ignored-metrics metric1,metric2
```

should result in the following log:

```
DEBU[0010] Beginning collection                          ignored_labels="[label1 label2]" ignored_metrics="[metric1 metric2]" metrics_host="http://localhost:9090/metrics" stats_host="127.0.0.1:8126"
DEBU[0020] Beginning collection                          ignored_labels="[label1 label2]" ignored_metrics="[metric1 metric2]" metrics_host="http://localhost:9090/metrics" stats_host="127.0.0.1:8126"
DEBU[0030] Beginning collection                          ignored_labels="[label1 label2]" ignored_metrics="[metric1 metric2]" metrics_host="http://localhost:9090/metrics" stats_host="127.0.0.1:8126"
```



#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
