### PR TITLE
Use veneur prefix for internal metrics

### DIFF
--- a/server.go
+++ b/server.go
@@ -165,15 +165,12 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	}
 	stats.Namespace = "veneur."
 
+	ret.Statsd = stats
+
 	ret.SpanChan = make(chan *ssf.SSFSpan, conf.SpanChannelCapacity)
 	ret.TraceClient, err = trace.NewChannelClient(ret.SpanChan,
 		trace.ReportStatistics(stats, 1*time.Second, []string{"ssf_format:internal"}),
 	)
-	if err != nil {
-		return ret, err
-	}
-
-	ret.Statsd, err = statsd.NewBuffered(conf.StatsAddress, 1024)
 	if err != nil {
 		return ret, err
 	}


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Effectively, this gives us the `veneur.` prefix for the statsd metrics we reintroduced into the functions that handle trace packets. Without it, we'd be changing existing metric names!

See #446 for full context.

#### Motivation
<!-- Why are you making this change? -->

Consistency with metric names.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @asf-stripe 
cc @stripe/observability 