### PR TITLE
Bump SFx Dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 * SignalFX sink can now handle and convert ssf service checks (represented as a gauge). Thanks, [stealthcode](https://github.com/stealthcode)!
 * Converted the grpsink to use unary instead of stream RPCs. Thanks, [sdboyer](https://github.com/sdboyer)!
+* Bumped version of [SignalFx go client](https://github.com/signalfx/golib) to prevent accidental removal of `-` from tag keys. Thanks, [gphat](https://github.com/gphat)!
 
 # 4.0.0, 2018-04-13
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,7 +363,7 @@
     "sfxclient",
     "timekeeper"
   ]
-  revision = "8321403a729d6c8fa60a3dcf2c60bf20f71f6062"
+  revision = "93885a1b911579ca2ce6caf133916e0554e9ab37"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -651,6 +651,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e5b41c2cf3c0db563deb76f216cc2782da7189b60e43b0a6af65736f4ad8f120"
+  inputs-digest = "0a3554efddd1f94ef045b315c07a582ce672c49a98b8c83230bfcb73ec62d0a2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -98,7 +98,7 @@
 
 [[constraint]]
   name = "github.com/signalfx/golib"
-  revision = "8321403a729d6c8fa60a3dcf2c60bf20f71f6062"
+  revision = "93885a1b911579ca2ce6caf133916e0554e9ab37"
 
 [[constraint]]
   name = "github.com/axiomhq/hyperloglog"

--- a/server.go
+++ b/server.go
@@ -588,6 +588,7 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 		// newline, it's easier to just let them be
 		return nil
 	}
+	fmt.Println(string(packet))
 	samples := &ssf.Samples{}
 	defer metrics.Report(s.TraceClient, samples)
 

--- a/server.go
+++ b/server.go
@@ -588,7 +588,6 @@ func (s *Server) HandleMetricPacket(packet []byte) error {
 		// newline, it's easier to just let them be
 		return nil
 	}
-	fmt.Println(string(packet))
 	samples := &ssf.Samples{}
 	defer metrics.Report(s.TraceClient, samples)
 

--- a/vendor/github.com/signalfx/golib/disco/calc_test.go
+++ b/vendor/github.com/signalfx/golib/disco/calc_test.go
@@ -245,7 +245,7 @@ func (p *AddArgs) Read(iprot thrift.TProtocol) error {
 
 func (p *AddArgs) readField1(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI32(); err != nil {
-		return fmt.Errorf("error reading field 1: %s")
+		return fmt.Errorf("error reading field 1: %s", p)
 	} else {
 		p.Num1 = v
 	}
@@ -254,7 +254,7 @@ func (p *AddArgs) readField1(iprot thrift.TProtocol) error {
 
 func (p *AddArgs) readField2(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI32(); err != nil {
-		return fmt.Errorf("error reading field 2: %s")
+		return fmt.Errorf("error reading field 2: %s", p)
 	} else {
 		p.Num2 = v
 	}
@@ -272,10 +272,10 @@ func (p *AddArgs) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
-		return fmt.Errorf("%T write field stop error: %s", err)
+		return fmt.Errorf("%T write field stop error: %s", p, err)
 	}
 	if err := oprot.WriteStructEnd(); err != nil {
-		return fmt.Errorf("%T write struct stop error: %s", err)
+		return fmt.Errorf("%T write struct stop error: %s", p, err)
 	}
 	return nil
 }
@@ -285,7 +285,7 @@ func (p *AddArgs) writeField1(oprot thrift.TProtocol) (err error) {
 		return fmt.Errorf("%T write field begin error 1:num1: %s", p, err)
 	}
 	if err := oprot.WriteI32(int32(p.Num1)); err != nil {
-		return fmt.Errorf("%T.num1 (1) field write error: %s", p)
+		return fmt.Errorf("%T.num1 (1) field write error: %s", p, err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return fmt.Errorf("%T write field end error 1:num1: %s", p, err)
@@ -298,7 +298,7 @@ func (p *AddArgs) writeField2(oprot thrift.TProtocol) (err error) {
 		return fmt.Errorf("%T write field begin error 2:num2: %s", p, err)
 	}
 	if err := oprot.WriteI32(int32(p.Num2)); err != nil {
-		return fmt.Errorf("%T.num2 (2) field write error: %s", p)
+		return fmt.Errorf("%T.num2 (2) field write error: %s", p, err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return fmt.Errorf("%T write field end error 2:num2: %s", p, err)
@@ -355,7 +355,7 @@ func (p *AddResult) Read(iprot thrift.TProtocol) error {
 
 func (p *AddResult) readField0(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI32(); err != nil {
-		return fmt.Errorf("error reading field 0: %s")
+		return fmt.Errorf("error reading field 0: %s", p)
 	} else {
 		p.Success = v
 	}
@@ -373,10 +373,10 @@ func (p *AddResult) Write(oprot thrift.TProtocol) error {
 		}
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
-		return fmt.Errorf("%T write field stop error: %s", err)
+		return fmt.Errorf("%T write field stop error: %s", p, err)
 	}
 	if err := oprot.WriteStructEnd(); err != nil {
-		return fmt.Errorf("%T write struct stop error: %s", err)
+		return fmt.Errorf("%T write struct stop error: %s", p, err)
 	}
 	return nil
 }
@@ -386,7 +386,7 @@ func (p *AddResult) writeField0(oprot thrift.TProtocol) (err error) {
 		return fmt.Errorf("%T write field begin error 0:success: %s", p, err)
 	}
 	if err := oprot.WriteI32(int32(p.Success)); err != nil {
-		return fmt.Errorf("%T.success (0) field write error: %s", p)
+		return fmt.Errorf("%T.success (0) field write error: %s", p, err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return fmt.Errorf("%T write field end error 0:success: %s", p, err)

--- a/vendor/github.com/signalfx/golib/sfxclient/httpsink.go
+++ b/vendor/github.com/signalfx/golib/sfxclient/httpsink.go
@@ -114,7 +114,7 @@ func (h *HTTPSink) doBottom(ctx context.Context, f func() (io.Reader, bool, erro
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(TokenHeaderName, h.AuthToken)
 	req.Header.Set("User-Agent", h.UserAgent)
-	req.Header.Set("Connection", "Keep-Alive")
+	req.Header.Set("Connection", "keep-alive")
 	if compressed {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
@@ -193,7 +193,7 @@ func filterSignalfxKey(str string) string {
 }
 
 func runeFilterMap(r rune) rune {
-	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' {
+	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' || r == '-' {
 		return r
 	}
 	return '_'


### PR DESCRIPTION
#### Summary
Bump the SFx client lib version to the latest SHA

#### Motivation
We need to bump the SFx client dep to pick up [this change to tag keys](https://github.com/signalfx/golib/pull/90) that is accidentally munging our tag keys and breaking dashboards.

#### Test plan
Looks innocuous, but will verify in QA.

r? @aditya-stripe 