### PR TITLE
Use the gRPC import server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.
 * The `veneur.ssf.spans.received_total` metric now tracks all SSF data received, in either packet or framed format, whether or not a valid span was extracted.
 
+## Added
+* Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman)!
+
 # 4.0.0, 2018-04-13
 
 ## Improvements

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -80,8 +80,8 @@ func main() {
 	}
 	server.Start()
 
-	if conf.HTTPAddress != "" {
-		server.HTTPServe()
+	if conf.HTTPAddress != "" || conf.GrpcAddress != "" {
+		server.Serve()
 	} else {
 		select {}
 	}

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FlushFile                    string    `yaml:"flush_file"`
 	FlushMaxPerBody              int       `yaml:"flush_max_per_body"`
 	ForwardAddress               string    `yaml:"forward_address"`
+	GrpcAddress                  string    `yaml:"grpc_address"`
 	Hostname                     string    `yaml:"hostname"`
 	HTTPAddress                  string    `yaml:"http_address"`
 	IndicatorSpanTimerName       string    `yaml:"indicator_span_timer_name"`

--- a/example.yaml
+++ b/example.yaml
@@ -56,6 +56,9 @@ stats_address: "localhost:8126"
 # http_address: "einhorn@0"
 http_address: "0.0.0.0:8127"
 
+# The address on which to listen for imports over gRPC.
+grpc_address: "0.0.0.0:8128"
+
 # The name of timer metrics that "indicator" spans should be tracked
 # under. If this is unset, veneur doesn't report an additional timer
 # metric for indicator spans.

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -107,6 +107,30 @@ func TestCounterMerge(t *testing.T) {
 	assert.Equal(t, float64(38), metrics[0].Value)
 }
 
+// Test the Metric and Merge methods on Counter
+func TestCounterMergeMetric(t *testing.T) {
+	c := NewCounter("a.b.c", []string{"tag:val"})
+	c.Sample(5, 0.5)
+	m, err := c.Metric()
+	assert.NoError(t, err, "should have created a metric from a counter successfully")
+
+	// test with a different interval, and ensure the correct rate is passed on
+	c2 := NewCounter("a.b.c", []string{"tag:val"})
+	c2.Sample(14, 0.5)
+	m2, err := c2.Metric()
+	assert.NoError(t, err, "should have created a metric from a counter")
+
+	cGlobal := NewCounter("a.b.c", []string{"tag2: val2"})
+
+	cGlobal.Merge(m.GetCounter())
+	metrics := cGlobal.Flush(10 * time.Second)
+	assert.Equal(t, float64(10), metrics[0].Value)
+
+	cGlobal.Merge(m2.GetCounter())
+	metrics = cGlobal.Flush(10 * time.Second)
+	assert.Equal(t, float64(38), metrics[0].Value)
+}
+
 func TestGaugeMerge(t *testing.T) {
 	g := NewGauge("a.b.c", []string{"tag:val"})
 
@@ -141,6 +165,22 @@ func TestGauge(t *testing.T) {
 	assert.Equal(t, tags[0], "a:b", "Tag contents")
 
 	assert.Equal(t, float64(5), m1.Value, "Value")
+}
+
+// Test the Metric and Merge function on Gauge
+func TestGaugeMergeMetric(t *testing.T) {
+	g := NewGauge("a.b.c", []string{"tag:val"})
+
+	g.Sample(5, 1.0)
+	m, err := g.Metric()
+	assert.NoError(t, err, "a gauge should be able to create a metric")
+
+	gGlobal := NewGauge("a.b.c", []string{"tag2: val2"})
+	gGlobal.value = 1 // So we can overwrite it
+	gGlobal.Merge(m.GetGauge())
+
+	metrics := gGlobal.Flush()
+	assert.Equal(t, float64(5), metrics[0].Value)
 }
 
 func TestSet(t *testing.T) {
@@ -183,6 +223,29 @@ func TestSetMerge(t *testing.T) {
 
 	s2 := NewSet("a.b.c", []string{"a:b"})
 	assert.NoError(t, s2.Combine(jm.Value), "should have combined successfully")
+	// HLLs are approximate, and we've seen error of +-1 here in the past, so
+	// we're giving the test some room for error to reduce flakes
+	count1 := int(s.Hll.Estimate())
+	count2 := int(s2.Hll.Estimate())
+	countDifference := count1 - count2
+	assert.True(t, -1 <= countDifference && countDifference <= 1, "counts did not match after merging (%d and %d)", count1, count2)
+}
+
+// Test the Metric and Merge function on Set
+func TestSetMergeMetric(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	s := NewSet("a.b.c", []string{"a:b"})
+	for i := 0; i < 100; i++ {
+		s.Sample(strconv.Itoa(rand.Int()), 1.0)
+	}
+	assert.Equal(t, uint64(100), s.Hll.Estimate(), "counts did not match")
+
+	m, err := s.Metric()
+	assert.NoError(t, err, "should have made a metric from a set")
+
+	s2 := NewSet("a.b.c", []string{"a:b"})
+	assert.NoError(t, s2.Merge(m.GetSet()), "should have combined successfully")
 	// HLLs are approximate, and we've seen error of +-1 here in the past, so
 	// we're giving the test some room for error to reduce flakes
 	count1 := int(s.Hll.Estimate())
@@ -396,6 +459,31 @@ func TestHistoMerge(t *testing.T) {
 
 	h2 := NewHist("a.b.c", []string{"a:b"})
 	assert.NoError(t, h2.Combine(jm.Value), "should have combined successfully")
+	assert.InEpsilon(t, h.Value.Quantile(0.5), h2.Value.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
+	assert.InDelta(t, 0, h2.LocalWeight, 0.02, "merged histogram should have count of zero")
+	assert.True(t, math.IsInf(h2.LocalMin, +1), "merged histogram should have local minimum of +inf")
+	assert.True(t, math.IsInf(h2.LocalMax, -1), "merged histogram should have local minimum of -inf")
+
+	h2.Sample(1.0, 1.0)
+	assert.InDelta(t, 1.0, h2.LocalWeight, 0.02, "merged histogram should have count of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.LocalMin, 0.02, "merged histogram should have min of 1 after adding a value")
+	assert.InDelta(t, 1.0, h2.LocalMax, 0.02, "merged histogram should have max of 1 after adding a value")
+}
+
+// Test the Metric and Merge function on Set
+func TestHistoMergeMetric(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	h := NewHist("a.b.c", []string{"a:b"})
+	for i := 0; i < 100; i++ {
+		h.Sample(rand.NormFloat64(), 1.0)
+	}
+
+	m, err := h.Metric()
+	assert.NoError(t, err, "should have created a metricpb.Metric from a Histo")
+
+	h2 := NewHist("a.b.c", []string{"a:b"})
+	h2.Merge(m.GetHistogram())
 	assert.InEpsilon(t, h.Value.Quantile(0.5), h2.Value.Quantile(0.5), 0.02, "50th percentiles did not match after merging")
 	assert.InDelta(t, 0, h2.LocalWeight, 0.02, "merged histogram should have count of zero")
 	assert.True(t, math.IsInf(h2.LocalMin, +1), "merged histogram should have local minimum of +inf")

--- a/server.go
+++ b/server.go
@@ -1041,7 +1041,7 @@ func (s *Server) HTTPServe() {
 	graceful.Shutdown()
 }
 
-// gRPCServe starts the gRPC server and block until an error is encountered,
+// gRPCServe starts the gRPC server and blocks until an error is encountered,
 // or the server is shutdown.
 //
 // TODO this doesn't handle SIGUSR2 and SIGHUP on it's own, unlike HTTPServe

--- a/tdigest/histo_test.go
+++ b/tdigest/histo_test.go
@@ -86,6 +86,26 @@ func TestGobEncoding(t *testing.T) {
 	assert.InEpsilon(t, td.Quantile(0.5), td2.Quantile(0.5), 0.02, "50%% quantiles did not match")
 }
 
+// Test that creating a MergingDigestData (for protobuf-encoding) and
+// recreating the original MergingDigest works as expected.
+func TestMergingDigestData(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	td := NewMerging(1000, false)
+	for i := 0; i < 1000; i++ {
+		td.Add(rand.Float64(), 1.0)
+	}
+	validateMergingDigest(t, td)
+
+	// Convert to a MergingDigestData and back again
+	td2 := NewMergingFromData(td.Data())
+
+	assert.InEpsilon(t, td.Count(), td2.Count(), 0.02, "counts did not match")
+	assert.InEpsilon(t, td.Min(), td2.Min(), 0.02, "minimums did not match")
+	assert.InEpsilon(t, td.Max(), td2.Max(), 0.02, "maximums did not match")
+	assert.InEpsilon(t, td.Quantile(0.5), td2.Quantile(0.5), 0.02, "50%% quantiles did not match")
+}
+
 func BenchmarkAdd(b *testing.B) {
 	rand.Seed(time.Now().Unix())
 	td := NewMerging(1000, false)

--- a/worker.go
+++ b/worker.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/samplers/metricpb"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
@@ -25,22 +27,27 @@ const statusTypeName = "status"
 
 // Worker is the doodad that does work.
 type Worker struct {
-	id          int
-	PacketChan  chan samplers.UDPMetric
-	ImportChan  chan []samplers.JSONMetric
-	QuitChan    chan struct{}
-	processed   int64
-	imported    int64
-	mutex       *sync.Mutex
-	traceClient *trace.Client
-	logger      *logrus.Logger
-	wm          WorkerMetrics
-	stats       *statsd.Client
+	id               int
+	PacketChan       chan samplers.UDPMetric
+	ImportChan       chan []samplers.JSONMetric
+	ImportMetricChan chan []*metricpb.Metric
+	QuitChan         chan struct{}
+	processed        int64
+	imported         int64
+	mutex            *sync.Mutex
+	traceClient      *trace.Client
+	logger           *logrus.Logger
+	wm               WorkerMetrics
+	stats            *statsd.Client
 }
 
 // IngestUDP on a Worker feeds the metric into the worker's PacketChan.
 func (w *Worker) IngestUDP(metric samplers.UDPMetric) {
 	w.PacketChan <- metric
+}
+
+func (w *Worker) IngestMetrics(ms []*metricpb.Metric) {
+	w.ImportMetricChan <- ms
 }
 
 // WorkerMetrics is just a plain struct bundling together the flushed contents of a worker
@@ -152,17 +159,18 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 // NewWorker creates, and returns a new Worker object.
 func NewWorker(id int, cl *trace.Client, logger *logrus.Logger, stats *statsd.Client) *Worker {
 	return &Worker{
-		id:          id,
-		PacketChan:  make(chan samplers.UDPMetric, 32),
-		ImportChan:  make(chan []samplers.JSONMetric, 32),
-		QuitChan:    make(chan struct{}),
-		processed:   0,
-		imported:    0,
-		mutex:       &sync.Mutex{},
-		traceClient: cl,
-		logger:      logger,
-		wm:          NewWorkerMetrics(),
-		stats:       stats,
+		id:               id,
+		PacketChan:       make(chan samplers.UDPMetric, 32),
+		ImportChan:       make(chan []samplers.JSONMetric, 32),
+		ImportMetricChan: make(chan []*metricpb.Metric, 32),
+		QuitChan:         make(chan struct{}),
+		processed:        0,
+		imported:         0,
+		mutex:            &sync.Mutex{},
+		traceClient:      cl,
+		logger:           logger,
+		wm:               NewWorkerMetrics(),
+		stats:            stats,
 	}
 }
 
@@ -176,6 +184,10 @@ func (w *Worker) Work() {
 		case m := <-w.ImportChan:
 			for _, j := range m {
 				w.ImportMetric(j)
+			}
+		case ms := <-w.ImportMetricChan:
+			for _, m := range ms {
+				w.ImportMetricGRPC(m)
 			}
 		case <-w.QuitChan:
 			// We have been asked to stop.
@@ -281,6 +293,54 @@ func (w *Worker) ImportMetric(other samplers.JSONMetric) {
 	default:
 		log.WithField("type", other.Type).Error("Unknown metric type for importing")
 	}
+}
+
+// ImportMetricGRPC receives a metric from another veneur instance over gRPC
+func (w *Worker) ImportMetricGRPC(other *metricpb.Metric) (err error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	key := samplers.NewMetricKeyFromMetric(other)
+
+	scope := samplers.MixedScope
+	if other.Type == metricpb.Type_Counter || other.Type == metricpb.Type_Gauge {
+		scope = samplers.GlobalOnly
+	}
+
+	w.wm.Upsert(key, scope, other.Tags)
+	w.imported++
+
+	switch v := other.GetValue().(type) {
+	case *metricpb.Metric_Counter:
+		w.wm.globalCounters[key].Merge(v.Counter)
+	case *metricpb.Metric_Gauge:
+		w.wm.globalGauges[key].Merge(v.Gauge)
+	case *metricpb.Metric_Set:
+		if merr := w.wm.sets[key].Merge(v.Set); merr != nil {
+			err = fmt.Errorf("could not merge a set: %v", err)
+		}
+	case *metricpb.Metric_Histogram:
+		switch other.Type {
+		case metricpb.Type_Histogram:
+			w.wm.histograms[key].Merge(v.Histogram)
+		case metricpb.Type_Timer:
+			w.wm.timers[key].Merge(v.Histogram)
+		}
+	case nil:
+		err = errors.New("Can't import a metric with a nil value")
+	default:
+		err = fmt.Errorf("Unknown metric type for importing: %T", v)
+	}
+
+	if err != nil {
+		log.WithError(err).WithFields(logrus.Fields{
+			"type":     other.Type,
+			"name":     other.Name,
+			"protocol": "grpc",
+		}).Error("Failed to import a metric")
+	}
+
+	return err
 }
 
 // Flush resets the worker's internal metrics and returns their contents.

--- a/worker_test.go
+++ b/worker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/samplers/metricpb"
 )
 
 func TestWorker(t *testing.T) {
@@ -271,4 +272,84 @@ func newTestClient(t *testing.T, num int) (*trace.Client, chan *ssf.SSFSpan) {
 	cl, err := trace.NewBackendClient(&testBackend{ch})
 	require.NoError(t, err)
 	return cl, ch
+}
+
+type testMetricExporter interface {
+	GetName() string
+	Metric() (*metricpb.Metric, error)
+}
+
+func exportMetricAndFlush(t testing.TB, exp testMetricExporter) WorkerMetrics {
+	w := NewWorker(1, nil, logrus.New(), nil)
+	m, err := exp.Metric()
+	assert.NoErrorf(t, err, "exporting the metric '%s' shouldn't have failed",
+		exp.GetName())
+
+	assert.NoError(t, w.ImportMetricGRPC(m), "importing a metric shouldn't "+
+		"have failed")
+	return w.Flush()
+}
+
+func TestWorkerImportMetricGRPC(t *testing.T) {
+	t.Run("histogram", func(t *testing.T) {
+		t.Parallel()
+		h := samplers.NewHist("test.histo", nil)
+		h.Sample(1.0, 1.0)
+
+		assert.Len(t, exportMetricAndFlush(t, h).histograms, 1,
+			"The number of flushed histograms is not correct")
+	})
+	t.Run("gauge", func(t *testing.T) {
+		t.Parallel()
+		g := samplers.NewGauge("test.gauge", nil)
+		g.Sample(2.0, 1.0)
+
+		assert.Len(t, exportMetricAndFlush(t, g).globalGauges, 1,
+			"The number of flushed gauges is not correct")
+	})
+	t.Run("counter", func(t *testing.T) {
+		t.Parallel()
+		c := samplers.NewCounter("test.counter", nil)
+		c.Sample(2.0, 1.0)
+
+		assert.Len(t, exportMetricAndFlush(t, c).globalCounters, 1,
+			"The number of flushed counters is not correct")
+	})
+	t.Run("timer", func(t *testing.T) {
+		t.Parallel()
+		w := NewWorker(1, nil, logrus.New(), nil)
+		h := samplers.NewHist("test.timer", nil)
+		h.Sample(1.0, 1.0)
+
+		m, err := h.Metric()
+		assert.NoErrorf(t, err, "exporting the histogram shouldn't have failed")
+		m.Type = metricpb.Type_Timer
+
+		assert.NoError(t, w.ImportMetricGRPC(m), "importing a timer shouldn't "+
+			"have failed")
+		assert.Len(t, w.Flush().timers, 1, "The number of flushed "+
+			"timers is not correct")
+	})
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+		s := samplers.NewSet("test.set", nil)
+		s.Sample("value", 1.0)
+
+		assert.Len(t, exportMetricAndFlush(t, s).sets, 1,
+			"The number of flushed sets is not correct")
+	})
+}
+
+func TestWorkerImportMetricGRPCNilValue(t *testing.T) {
+	t.Parallel()
+
+	w := NewWorker(1, nil, logrus.New(), nil)
+	metric := &metricpb.Metric{
+		Name:  "test",
+		Type:  metricpb.Type_Histogram,
+		Value: nil,
+	}
+
+	assert.Error(t, w.ImportMetricGRPC(metric), "Importing a metric with "+
+		"a nil value should have failed")
 }


### PR DESCRIPTION
#### Summary

This utilizes the changes in https://github.com/stripe/veneur/pull/442 to allow Veneur to listen for forwarded metrics over gRPC.  The gRPC server is started at the same time as the HTTP server (if both are enabled), and works in a very similar way.  Metrics are received by the "importsrv" package, then processed by workers in the new "ImportMetricGRPC" method that I added.

Note that this does not include the ability to *forward* over gRPC, so this functionality is pretty useless right now.  I decided to split that out into a separate PR to make them both easier to review, but I'm happy to pull that back in if it would be easier that way!

Veneurs should be able to selectively enable both the gRPC and HTTP servers individually.  The gRPC server should be disabled by default unless the `grpc_address` configuration parameter is set.

To go along with this change, I added a bunch of new methods to the "samplers" package to allow the different types to be converted to and from their protobuf-equivalents. They are basically equivalent to the current methods that deal with "JSONMetrics":
* `Metric`: Creates a metricpb.Metric, similar to `Export`.
* `Merge`: Combines the value with that of another sampler, like `Combine`.

#### Motivation

Like I also said in #439, we (@quantcast) would like to contribute gRPC support to eventually enable global histogram aggregations (#390). We are also already running this.

#### Test plan

This includes tests for the following:
* The new `Metric` and `Merge` methods on the different samplers.
* The `NewMergingFromData` and `Data()` methods in "tdigest".
* The `ImportMetricGRPC` method in the `Worker`.
* The new `Serve` method added to the main `Server`.

We're also effectively running this (#407) already in production environment.

I have written a couple large end-to-end tests (which are in #407) that will provide more test coverage as well.  My plan was to just include those with the forwarding code, to make this PR easier to review!

#### Rollout/monitoring/revert plan

This should have no affect when the `grpc_address` parameter isn't set.

Once gRPC is enabled, the only verification to do right now will probably be just checking that the server is listening on the right port.  Another PR with support for forwarding (coming soon 😄 ) will make this easier to verify.

CC: @sdboyer-stripe @cory-stripe @stripe/observability