### PR TITLE
Use getrandom(2) to seed generation of span IDs

### DIFF
--- a/trace/client.go
+++ b/trace/client.go
@@ -2,8 +2,12 @@ package trace
 
 import (
 	"context"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
 	"net"
 	"time"
 
@@ -289,6 +293,12 @@ func newFlushNofifier(backend ClientBackend) flushNotifier {
 // to addrStr (an address in veneur URL format) using the parameters
 // in opts. It returns the constructed client or an error.
 func NewClient(addrStr string, opts ...ClientParam) (*Client, error) {
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	rand.Seed(n.Int64())
+
 	addr, err := protocol.ResolveAddr(addrStr)
 	if err != nil {
 		return nil, err

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -27,10 +27,6 @@ import (
 // Experimental
 const ResourceKey = "resource"
 
-func init() {
-	rand.Seed(time.Now().Unix())
-}
-
 // (Experimental)
 // If this is set to true,
 // traces will be generated but not actually sent.


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Use a truly ("truly") random number to seed the RNG. On Linux, this is getrandom(2), though it falls back to /dev/urandom if that's not available.

We don't use crypto/rand, because that introduces a noticeable performance hit twice for every span creation. Even with buffering to amortize the overhead of a syscall, it's noticeable and probably not desirable.


We're using the default source, so it is safe to call `NewClient` concurrently with client usage, though it's unlikely for people to create multiple clients concurrently or create clients concurrently with other clients' usage.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 
cc @mikeh-stripe @evan-stripe 