### PR TITLE
Fixing the handling of parser.ParseMetricSSF for status types

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -390,6 +390,18 @@ func TestParserSSFWithSampleRateAndTags(t *testing.T) {
 	assert.Len(t, m.Tags, 2, "Tags")
 }
 
+func TestParserSSFWithStatusCheck(t *testing.T) {
+	standardMetric := freshSSFMetric()
+	standardMetric.Metric = ssf.SSFSample_STATUS
+	standardMetric.Status = ssf.SSFSample_UNKNOWN
+	m, _ := samplers.ParseMetricSSF(standardMetric)
+	assert.NotNil(t, m, "Got nil metric!")
+	assert.Equal(t, standardMetric.Name, m.Name, "Name")
+	assert.Equal(t, ssf.SSFSample_UNKNOWN, m.Value, "Value")
+	assert.Equal(t, "status", m.Type, "Type")
+	assert.Len(t, m.Tags, 2, "Tags")
+}
+
 func TestParser(t *testing.T) {
 	m, _ := samplers.ParseMetric([]byte("a.b.c:1|c"))
 	assert.NotNil(t, m, "Got nil metric!")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -188,13 +188,18 @@ func ParseMetricSSF(metric *ssf.SSFSample) (UDPMetric, error) {
 		ret.Type = "histogram"
 	case ssf.SSFSample_SET:
 		ret.Type = "set"
+	case ssf.SSFSample_STATUS:
+		ret.Type = "status"
 	default:
 		return UDPMetric{}, invalidMetricTypeError
 	}
 	h = fnv1a.AddString32(h, ret.Type)
-	if metric.Metric == ssf.SSFSample_SET {
+	switch metric.Metric {
+	case ssf.SSFSample_SET:
 		ret.Value = metric.Message
-	} else {
+	case ssf.SSFSample_STATUS:
+		ret.Value = metric.Status
+	default:
 		ret.Value = float64(metric.Value)
 	}
 	ret.SampleRate = metric.SampleRate

--- a/worker.go
+++ b/worker.go
@@ -239,10 +239,11 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 			w.wm.timers[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
 		}
 	case statusTypeName:
+		v := float64(m.Value.(ssf.SSFSample_Status))
 		if m.Scope == samplers.LocalOnly {
-			w.wm.localStatusChecks[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+			w.wm.localStatusChecks[m.MetricKey].Sample(v, m.SampleRate)
 		} else {
-			w.wm.statusChecks[m.MetricKey].Sample(m.Value.(float64), m.SampleRate)
+			w.wm.statusChecks[m.MetricKey].Sample(v, m.SampleRate)
 		}
 	default:
 		log.WithField("type", m.Type).Error("Unknown metric type for processing")


### PR DESCRIPTION
#### Summary
We found that the status check translation in signalfx was failing because of a missing case in the parser code. 

#### Motivation
Provide a functional translation for service check ssf type to a signalfx sink.  

#### Test plan
New unit tests!