### PR TITLE
Report KPI metrics using statsd client

### DIFF
--- a/server.go
+++ b/server.go
@@ -224,7 +224,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 
 	// Use the pre-allocated Workers slice to know how many to start.
 	for i := range ret.Workers {
-		ret.Workers[i] = NewWorker(i+1, ret.TraceClient, log)
+		ret.Workers[i] = NewWorker(i+1, ret.TraceClient, log, ret.Statsd)
 		// do not close over loop index
 		go func(w *Worker) {
 			defer func() {
@@ -234,7 +234,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		}(ret.Workers[i])
 	}
 
-	ret.EventWorker = NewEventWorker(ret.TraceClient)
+	ret.EventWorker = NewEventWorker(ret.TraceClient, ret.Statsd)
 
 	// Set up a span sink that extracts metrics from SSF spans and
 	// reports them via the metric workers:

--- a/server_test.go
+++ b/server_test.go
@@ -956,7 +956,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Simulate a metrics worker:
-	w := NewWorker(0, nil, nullLogger())
+	w := NewWorker(0, nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 	go func() {
 	}()
@@ -1029,7 +1029,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	require.NoError(b, err)
 
 	// Simulate a metrics worker:
-	w := NewWorker(0, nil, nullLogger())
+	w := NewWorker(0, nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 
 	go func() {

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger)
+	worker := veneur.NewWorker(0, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestMetricExtractor(t *testing.T) {
 
 func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger)
+	worker := veneur.NewWorker(0, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	if err != nil {
@@ -134,7 +134,7 @@ func BenchmarkParallelMetricExtractor(b *testing.B) {
 
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger)
+	worker := veneur.NewWorker(0, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", nil, logger)
 	require.NoError(t, err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -32,7 +32,7 @@ func TestWorker(t *testing.T) {
 }
 
 func TestWorkerLocal(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -52,7 +52,7 @@ func TestWorkerLocal(t *testing.T) {
 }
 
 func TestWorkerGlobal(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 
 	gc := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -85,7 +85,7 @@ func TestWorkerGlobal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo", 1.0)
 	testset.Sample("bar", 1.0)
@@ -100,7 +100,7 @@ func TestWorkerImportSet(t *testing.T) {
 }
 
 func TestWorkerImportHistogram(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 	testhisto := samplers.NewHist("a.b.c", nil)
 	testhisto.Sample(1.0, 1.0)
 	testhisto.Sample(2.0, 1.0)
@@ -115,7 +115,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerStatusMetric(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New())
+	w := NewWorker(1, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Report Veneur's key performance indicator metrics using the statsd client.

Ideally, these should actually be dual-published with separate namespaces for the statsd and SSF clients, so we can monitor the health of both halves of the pipeline by inspecting the difference between the reported metrics on each.


This does *not* affect `veneur.sink.*` metrics - those were refactored heavily, and switching them back to statsd metrics would be rather difficult. However, it *does* affect `worker.metrics_flushed_total`, which provides the overall aggregate count (just not the per-sink view).

#### Motivation
<!-- Why are you making this change? -->

KPI metrics rely only on the internal metrics pipeline, instead of both the internal metrics pipeline *and* the internal tracing pipeline.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Tested on QA and the canary box in prod, did not see any changes in those metrics on the graphs.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 