### PR TITLE
WIP: process internal metrics without span sinks

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1176,7 +1176,7 @@ func TestInternalSSFMetricsEndToEnd(t *testing.T) {
 	f := newFixture(t, config, cms, nil)
 	defer f.Close()
 
-	client, err := trace.NewChannelClient(f.server.SpanChan)
+	client, err := trace.NewChannelClient(f.server.SpanChan, nil)
 	require.NoError(t, err)
 
 	done := make(chan error)

--- a/trace/metrics/client.go
+++ b/trace/metrics/client.go
@@ -39,8 +39,7 @@ func ReportAsync(cl *trace.Client, metrics []*ssf.SSFSample, done chan<- error) 
 	if metrics == nil || len(metrics) == 0 {
 		return NoMetrics{}
 	}
-	span := &ssf.SSFSpan{Metrics: metrics}
-	return trace.Record(cl, span, done)
+	return trace.RecordSamples(cl, metrics, done)
 }
 
 // ReportOne sends a single metric to a veneur using a trace client


### PR DESCRIPTION
#### Summary

This PR exists to explore a world in which veneur's internal trace client doesn't send a whole span to itself in order to report internal metrics. 

While I suspect this won't do much to alleviate memory/allocation pressure on span processing (that part would still allocate tons of `SSFSample` structs on the heap), it should cause fewer spans to be processed by veneur, hopefully improving the whole span processing pipeline that way.

#### Motivation
I wanna see if this is speedier


#### Test plan

Few things: 
- [ ] I'd love to know if there's a benchmark that this moves
- [ ] could roll to a box and see how it behaves


#### Rollout/monitoring/revert plan

Don't. This is experimental.
