### PR TITLE
Reduce math/rand and statsd lock contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 5.0.0, in development
 
+
+## Removed
+* The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.
+
 ## Improvements
 * SignalFX sink can now handle and convert ssf service checks (represented as a gauge). Thanks, [stealthcode](https://github.com/stealthcode)!
 * Converted the grpsink to use unary instead of stream RPCs. Thanks, [sdboyer](https://github.com/sdboyer)!

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	AwsRegion                    string    `yaml:"aws_region"`
 	AwsS3Bucket                  string    `yaml:"aws_s3_bucket"`
 	AwsSecretAccessKey           string    `yaml:"aws_secret_access_key"`
+	BlockProfileRate             int       `yaml:"block_profile_rate"`
 	DatadogAPIHostname           string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey                string    `yaml:"datadog_api_key"`
 	DatadogFlushMaxPerBody       int       `yaml:"datadog_flush_max_per_body"`
@@ -44,6 +45,7 @@ type Config struct {
 	LightstepNumClients          int       `yaml:"lightstep_num_clients"`
 	LightstepReconnectPeriod     string    `yaml:"lightstep_reconnect_period"`
 	MetricMaxLength              int       `yaml:"metric_max_length"`
+	MutexProfileFraction         int       `yaml:"mutex_profile_fraction"`
 	NumReaders                   int       `yaml:"num_readers"`
 	NumSpanWorkers               int       `yaml:"num_span_workers"`
 	NumWorkers                   int       `yaml:"num_workers"`

--- a/example.yaml
+++ b/example.yaml
@@ -167,6 +167,18 @@ read_buffer_size_bytes: 2097152
 # Sets the log level to DEBUG
 debug: true
 
+# runtime.SetMutexProfileFraction
+# The fraction of mutex contention events that are reported in the mutex profile.
+# On average, 1/n events are reported, so higher numbers will sample fewer events.
+# Default (0) disables mutex profiling altogether.
+mutex_profile_fraction: 0
+
+# runtime.SetBlockProfileRate.
+# The fraction of goroutine blocking events that are reported in the blocking profile.
+# On average, one blocking event will be sampled for every N nanoseconds spent blocked.
+# Default (0) disables block profiling altogether.
+block_profile_rate: 0
+
 # Providing a Sentry DSN here will send internal exceptions to Sentry
 sentry_dsn: ""
 

--- a/flusher.go
+++ b/flusher.go
@@ -399,7 +399,7 @@ func (s *Server) flushTraces(ctx context.Context) {
 			}).Error("received key of incorrect format")
 		}
 
-		spansReceivedTotal := atomic.SwapInt64(&value.ssfSpansReceivedTotal, 0)
+		spansReceivedTotal := atomic.SwapInt64(&value.ssfSpansReceivedTotal, 0) * internalMetricSampleRate
 		s.Statsd.Count("ssf.spans.received_total", spansReceivedTotal, tags, 1.0)
 		return true
 	})

--- a/server.go
+++ b/server.go
@@ -831,6 +831,7 @@ func (s *Server) ReadSSFStreamSocket(serverConn net.Conn) {
 				Error("Error processing an SSF frame")
 			tags = append(tags, []string{"packet_type:unknown", "reason:processing"}...)
 			s.Statsd.Incr("ssf.error_total", tags, 1.0)
+			tags = tags[:1]
 			continue
 		}
 		s.Statsd.Incr("ssf.received_total", tags, 1)

--- a/server.go
+++ b/server.go
@@ -697,6 +697,9 @@ func (s *Server) handleSSF(span *ssf.SSFSpan, ssfFormat string) {
 	key := "service:" + span.Service + "," + "ssf_format:" + ssfFormat
 
 	if (span.Id % sampleRate) == 1 {
+		// we can't avoid emitting this metric synchronously by aggregating in-memory, but that's okay
+		s.Statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), []string{"service:" + span.Service, "ssf_format:" + ssfFormat}, 1)
+
 		metrics, ok := s.ssfInternalMetrics.Load(key)
 
 		if !ok {

--- a/server.go
+++ b/server.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -186,6 +187,19 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 
 	if conf.Debug {
 		logger.SetLevel(logrus.DebugLevel)
+	}
+
+	if conf.MutexProfileFraction > 0 {
+		mpf := runtime.SetMutexProfileFraction(conf.MutexProfileFraction)
+		log.WithFields(logrus.Fields{
+			"MutexProfileFraction":         conf.MutexProfileFraction,
+			"previousMutexProfileFraction": mpf,
+		}).Info("Set mutex profile fraction")
+	}
+
+	if conf.BlockProfileRate > 0 {
+		runtime.SetBlockProfileRate(conf.BlockProfileRate)
+		log.WithField("BlockProfileRate", conf.BlockProfileRate).Info("Set block profile rate (nanoseconds)")
 	}
 
 	if conf.EnableProfiling {
@@ -651,14 +665,28 @@ func (s *Server) HandleTracePacket(packet []byte) {
 		log.WithError(err).Warn("ParseSSF")
 		return
 	}
-	s.handleSSF(span, []string{"ssf_format:packet"})
+	// we want to keep track of this, because it's a client problem, but still
+	// handle the span normally
+	if span.Id == 0 {
+		reason := "reason:" + "empty_id"
+		s.Statsd.Count("ssf.error_total", 1, []string{"ssf_format:packet", "packet_type:ssf_metric", reason}, 1.0)
+		log.WithError(err).Warn("ParseSSF")
+	}
+
+	tags := make([]string, 0, 2)
+	s.handleSSF(span, append(tags, "ssf_format:packet"))
 }
 
 func (s *Server) handleSSF(span *ssf.SSFSpan, baseTags []string) {
+	// 1/sampleRate packets will be chosen
+	const sampleRate = 10
+
 	tags := append(baseTags, "service:"+span.Service)
 
-	s.Statsd.Incr("ssf.spans.received_total", tags, .1)
-	s.Statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, .1)
+	if (span.Id % sampleRate) == 1 {
+		s.Statsd.Incr("ssf.spans.received_total", tags, 1)
+		s.Statsd.Histogram("ssf.spans.tags_per_span", float64(len(span.Tags)), tags, 1)
+	}
 
 	s.SpanChan <- span
 }
@@ -735,37 +763,37 @@ func (s *Server) ReadSSFStreamSocket(serverConn net.Conn) {
 	defer func() {
 		serverConn.Close()
 	}()
-	tags := map[string]string{"ssf_format": "framed"}
+
+	// initialize the capacity to the max size
+	// based on the number of tags we add later
+	tags := make([]string, 1, 3)
+	tags[0] = "ssf_format:framed"
+
 	for {
 		msg, err := protocol.ReadSSF(serverConn)
 		if err != nil {
 			if err == io.EOF {
 				// Client hangup, close this
-				metrics.ReportOne(s.TraceClient, ssf.Count("frames.disconnects", 1, nil))
+				s.Statsd.Count("frames.disconnects", 1, nil, 1.0)
 				return
 			}
 			if protocol.IsFramingError(err) {
 				log.WithError(err).
 					WithField("remote", serverConn.RemoteAddr()).
 					Info("Frame error reading from SSF connection. Closing.")
-				sample := ssf.Count("ssf.error_total", 1, tags)
-				sample.Tags["packet_type"] = "unknown"
-				sample.Tags["reason"] = "framing"
-				metrics.ReportOne(s.TraceClient, sample)
+				tags = append(tags, []string{"packet_type:unknown", "reason:framing"}...)
+				s.Statsd.Incr("ssf.error_total", tags, 1.0)
 				return
 			}
 			// Non-frame errors means we can continue reading:
 			log.WithError(err).
 				WithField("remote", serverConn.RemoteAddr()).
 				Error("Error processing an SSF frame")
-			sample := ssf.Count("ssf.error_total", 1, tags)
-			sample.Tags["packet_type"] = "unknown"
-			sample.Tags["reason"] = "processing"
-			metrics.ReportOne(s.TraceClient, sample)
+			tags = append(tags, []string{"packet_type:unknown", "reason:processing"}...)
+			s.Statsd.Incr("ssf.error_total", tags, 1.0)
 			continue
 		}
-		metrics.ReportBatch(s.TraceClient,
-			ssf.RandomlySample(0.01, ssf.Count("ssf.received_total", 1, tags)))
+		s.Statsd.Incr("ssf.received_total", tags, 1)
 		s.handleSSF(msg, []string{"ssf_format:framed"})
 	}
 }

--- a/server.go
+++ b/server.go
@@ -189,18 +189,20 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		logger.SetLevel(logrus.DebugLevel)
 	}
 
+	mpf := 0
 	if conf.MutexProfileFraction > 0 {
-		mpf := runtime.SetMutexProfileFraction(conf.MutexProfileFraction)
-		log.WithFields(logrus.Fields{
-			"MutexProfileFraction":         conf.MutexProfileFraction,
-			"previousMutexProfileFraction": mpf,
-		}).Info("Set mutex profile fraction")
+		mpf = runtime.SetMutexProfileFraction(conf.MutexProfileFraction)
 	}
+
+	log.WithFields(logrus.Fields{
+		"MutexProfileFraction":         conf.MutexProfileFraction,
+		"previousMutexProfileFraction": mpf,
+	}).Info("Set mutex profile fraction")
 
 	if conf.BlockProfileRate > 0 {
 		runtime.SetBlockProfileRate(conf.BlockProfileRate)
-		log.WithField("BlockProfileRate", conf.BlockProfileRate).Info("Set block profile rate (nanoseconds)")
 	}
+	log.WithField("BlockProfileRate", conf.BlockProfileRate).Info("Set block profile rate (nanoseconds)")
 
 	if conf.EnableProfiling {
 		ret.enableProfiling = true

--- a/server_test.go
+++ b/server_test.go
@@ -1318,11 +1318,9 @@ func BenchmarkHandleSSF(b *testing.B) {
 	f := newFixture(b, config, nil, nil)
 	defer f.Close()
 
-	baseTags := []string{"ssf_format:packet"}
-
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		f.server.handleSSF(spans[i%LEN], baseTags)
+		f.server.handleSSF(spans[i%LEN], "packet")
 	}
 }


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Reduce contention around math/rand, and also contention around the internal channel that the Datadog statsd client uses for reporting metrics. 

This improves performance of `handleSSF` significantly.

Before:
```
$ go test -run None -benchmem -bench BenchmarkHandleSSF
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkHandleSSF-8
  500000              3090 ns/op             354 B/op          6 allocs/op
```

After:

```
$ go test -run None -benchmem -bench BenchmarkHandleSSF
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkHandleSSF-8
500000              2309 ns/op             160 B/op          3 allocs/op
```

We dropped the `veneur.ssf.received_total` metric as well. This metric was reported inconsistently between framed and packet formats - for framed format, only non-errors were counted, but all packet-formatted SSF data was counted. In addition, it is largely redundant with `veneur.ssf.spans.received_total`, except when a large number of metrics are reported independently of spans (ie, with spanId == 0). 

If we sampled `veneur.ssf.spans.received_total` at rate=1, then these two metrics would be identical; we could consider doing that to offset the removal of the former metric.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->



r? @stripe/observability 