### PR TITLE
Fix hardcoded, accidental status failure in DD SC sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bugfixes
 * The `ignored-labels` and `ignored-metrics` flags for veneur-prometheus will filter no metrics or labels if no filter is specified. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
+* Fixed problem were all Datadog service checks were set to `OK` instead of the supplied value. Thanks, [gphat](https://github.com/gphat)!
 
 ## Removed
 * Official support for building Veneur's binaries with Go 1.8 has been dropped. Supported versions of Go for building Veneur 1.9, 1.10, or tip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Bugfixes
 * The `ignored-labels` and `ignored-metrics` flags for veneur-prometheus will filter no metrics or labels if no filter is specified. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
-* Fixed problem were all Datadog service checks were set to `OK` instead of the supplied value. Thanks, [gphat](https://github.com/gphat)!
+* Fixed problem where all Datadog service checks were set to `OK` instead of the supplied value. Thanks, [gphat](https://github.com/gphat)!
 
 ## Removed
 * Official support for building Veneur's binaries with Go 1.8 has been dropped. Supported versions of Go for building Veneur 1.9, 1.10, or tip.

--- a/parser_test.go
+++ b/parser_test.go
@@ -623,6 +623,14 @@ func TestServiceCheckMessageUnescape(t *testing.T) {
 	assert.Equal(t, "foo\nbar\nbaz\n", svcheck.Message, "Should contain newline")
 }
 
+func TestServiceCheckMessageStatus(t *testing.T) {
+	packet := []byte("_sc|foo|1|m:foo")
+	svcheck, err := samplers.ParseServiceCheck(packet)
+	assert.NoError(t, err, "Should have parsed correctly")
+	assert.Equal(t, "foo", svcheck.Message, "Should contain newline")
+	assert.Equal(t, ssf.SSFSample_WARNING, svcheck.Status, "Should parse status correctly")
+}
+
 func TestConsecutiveParseSSF(t *testing.T) {
 
 	span := &ssf.SSFSpan{

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -157,7 +157,7 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 				Name:      sample.Name,
 				Message:   sample.Message,
 				Timestamp: sample.Timestamp,
-				Status:    0, // How to intify? TODO TKTK
+				Status:    int(ssf.SSFSample_Status_value[sample.Status.String()]),
 			}
 
 			// Defensively copy the tags that came in

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -352,7 +352,7 @@ func TestDatadogFlushServiceChecks(t *testing.T) {
 	testCheck := ssf.SSFSample{
 		Name:      "foo",
 		Message:   "bar",
-		Status:    ssf.SSFSample_OK,
+		Status:    ssf.SSFSample_WARNING, // Notably setting this to something that isn't the default value to ensure it works
 		Timestamp: 1136239445,
 		Tags: map[string]string{
 			dogstatsd.CheckIdentifierKey:  "",


### PR DESCRIPTION
#### Summary
Fix leftover `TODO` wondering how to set the status to an integer.

#### Motivation
When I wrote this code I left this in here and we never noticed it. Service checks going into veneur have been set to `0` which is `OK`, meaning they never looked broken. Oops.

#### Test plan
Changed unit test to use a non-default value.

r? @stripe/observability 
cc @evan-stripe 

