### PR TITLE
Remove support for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.8
   - 1.9
   - "1.10"
   - tip
@@ -11,7 +10,7 @@ install:
   - sudo cp /tmp/bin/protoc /usr/bin/protoc
   - sudo chmod 777 /usr/bin/protoc
   - rm protoc-3.1.0-linux-x86_64.zip
-  # After 1.9 hits stable, replace this link
+  # After a new major version hits stable, replace this link
   # It is only used for gofmt
   - wget https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
   - tar -C /tmp -xvf go1.10.linux-amd64.tar.gz go/bin/gofmt
@@ -29,10 +28,6 @@ before_script:
   - go install github.com/gogo/protobuf/protoc-gen-gofast
   - go get -u github.com/golang/dep/cmd/dep
   - go get -u golang.org/x/tools/cmd/stringer
-
-  # This is needed to fix https://github.com/golang/go/issues/21387
-  - if [ "$TRAVIS_GO_VERSION" = "1.8" ]; then go install; fi
-
 
   - go generate
   # We need to ignore changes to this one file
@@ -54,5 +49,4 @@ before_script:
   - git diff-index --cached --exit-code HEAD
 
 script:
-  - if [ "$TRAVIS_GO_VERSION" = "1.8" ]; then go list ./... | grep -v vendor | xargs go test -race -v -timeout 60s; fi
-  - if [ "$TRAVIS_GO_VERSION" != "1.8" ]; then echo $TRAVIS_GO_VERSION; go test -race -v -timeout 60s ./...; fi
+  - go test -race -v -timeout 60s ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ## Bugfixes
 * The `ignored-labels` and `ignored-metrics` flags for veneur-prometheus will filter no metrics or labels if no filter is specified. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
 
+## Removed
+* Official support for building Veneur's binaries with Go 1.8 has been dropped. Supported versions of Go for building Veneur 1.9, 1.10, or tip.
+* Veneur's trace client library can still be used in applications that are built with Go 1.8, but it is no longer tested against Go 1.8.
+
 # 4.0.0, 2018-04-13
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ We wanted percentiles, histograms and sets to be global. We wanted to unify our 
 
 Veneur is currently handling all metrics for Stripe and is considered production ready. It is under active development and maintenance! Starting with v1.6, Veneur operates on a six-week release cycle, and all releases are tagged in git. If you'd like to contribute, see [CONTRIBUTING](https://github.com/stripe/veneur/blob/master/CONTRIBUTING.md)!
 
-Building Veneur requires Go 1.8 or later.
+Building Veneur requires Go 1.9 or later.
 
 # Features
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

In general, we try to preserve compatibility with older versions of Go as long as possible. However, https://github.com/stripe/veneur/pull/461 is an important change, and it requires `sync.Map`, which isn't available in Go 1.8. 

Since Go 1.8 has not received official upstream support for more than two months, there is a fairly small impact from dropping it here.


Note that libraries in this repository can still be imported by other programs built using a Go 1.8 toolchain; however, we will no longer be testing Go 1.8 builds here.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 