### PR TITLE
Sample all atomic metrics and 0.1% of internal statsd metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Removed
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.
+* The `veneur.ssf.spans.received_total` metric now tracks all SSF data received, in either packet or framed format, whether or not a valid span was extracted.
 
 ## Improvements
 * SignalFX sink can now handle and convert ssf service checks (represented as a gauge). Thanks, [stealthcode](https://github.com/stealthcode)!

--- a/flusher.go
+++ b/flusher.go
@@ -399,7 +399,7 @@ func (s *Server) flushTraces(ctx context.Context) {
 			}).Error("received key of incorrect format")
 		}
 
-		spansReceivedTotal := atomic.SwapInt64(&value.ssfSpansReceivedTotal, 0) * internalMetricSampleRate
+		spansReceivedTotal := atomic.SwapInt64(&value.ssfSpansReceivedTotal, 0)
 		s.Statsd.Count("ssf.spans.received_total", spansReceivedTotal, tags, 1.0)
 		return true
 	})

--- a/server.go
+++ b/server.go
@@ -68,9 +68,6 @@ var tracer = trace.GlobalTracer
 
 const defaultTCPReadTimeout = 10 * time.Minute
 
-// 1/internalMetricSampleRate packets will be chosen
-const internalMetricSampleRate = 10
-
 // A Server is the actual veneur instance that will be run.
 type Server struct {
 	Workers              []*Worker
@@ -693,6 +690,9 @@ func (s *Server) HandleTracePacket(packet []byte) {
 }
 
 func (s *Server) handleSSF(span *ssf.SSFSpan, ssfFormat string) {
+	// 1/internalMetricSampleRate packets will be chosen
+	const internalMetricSampleRate = 1000
+
 	key := "service:" + span.Service + "," + "ssf_format:" + ssfFormat
 
 	if (span.Id % internalMetricSampleRate) == 1 {


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

From the profiling data, the atomic increments are much faster, and we are probably fine sampling 100% of them. 


The statsd metrics are much more expensive - despite doing the randomization out-of-band, it still invokes math/rand internally, which is a significant source of contention.

Because tags-per-span is pretty stable for a given service - in fact, nearly constant - sampling 10% of them (as we were before) is overkill. Reducing it to 0.1% won't affect the distribution. For any service that processes more than 1000 spans per flush cycle (100 spans/second), this shouldn't even be visible.


This diff is best viewed with ?w=1.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 