### PR TITLE
Make ssf.RandomlySample a million times faster

### DIFF
--- a/ssf/samples.go
+++ b/ssf/samples.go
@@ -119,10 +119,7 @@ func RandomlySample(rate float32, samples ...*SSFSample) []*SSFSample {
 
 	r, ok := rngPool.Get().(*rand.Rand)
 	if ok {
-		randFloat = func() float32 {
-			return r.Float32()
-		}
-
+		randFloat = r.Float32
 		defer rngPool.Put(r)
 	}
 

--- a/ssf/samples_test.go
+++ b/ssf/samples_test.go
@@ -123,3 +123,18 @@ func BenchmarkRandomlySample(b *testing.B) {
 	b.ResetTimer()
 	samples = RandomlySample(0.2, samples...)
 }
+
+func BenchmarkRandomlySampleParallel(b *testing.B) {
+
+	samples := make([]*SSFSample, 1000000)
+	for i := range samples {
+		samples[i] = Count("testing.counter", float32(i), nil)
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			samples = RandomlySample(0.2, samples...)
+		}
+	})
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

`ssf.RandomlySample` has been using the default math/rand source, which is protected by an RNG. That wouldn't be so bad in itself, except the default math/rand source is *also* used by the Datadog client, the Lightstep client, and so forth - all of which then are contending for the same mutex.

Because ssf.RandomlySample runs in a hot path, it's faster for us to generate RNGs that only it ever uses, pool those, and sample from them instead of using the default math/rand source. The benchmarks speak for themselves:


Using the default math/rand source:

```
$ go test -run None -bench Bench
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur/ssf
BenchmarkRandomlySample-8               2000000000               0.03 ns/op
BenchmarkRandomlySampleParallel-8             20          55016131 ns/op
PASS
ok      github.com/stripe/veneur/ssf    3.097s
```

Using a sync.Pool to generate RNGs, which in turn generate our random numbers:

```
$ go test -run None -bench Bench
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur/ssf
BenchmarkRandomlySample-8               2000000000               0.03 ns/op
BenchmarkRandomlySampleParallel-8       30000000                41.6 ns/op
PASS
ok      github.com/stripe/veneur/ssf    5.825s
```

or, in other words, improving performance by a factor of 1,341,857.



#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Tested on production canary box. From the mutex profile, there was dramatically less contention (`ssf.RandomlySample` no longer even shows up - the sync.Pool does, but only a very small amount.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
