### PR TITLE
Set span name in StartSpan if provided

### DIFF
--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -438,6 +438,9 @@ func (t Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOpt
 			Trace:  trace,
 			tracer: t,
 		}
+		if operationName != "" {
+			span.Name = operationName
+		}
 	}
 
 	for k, v := range sso.Tags {


### PR DESCRIPTION
#### Summary

`StartSpan` should always set the span's name if provided (and non-empty).

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
