### PR TITLE
Update CHANGELOG for internal memory metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 * SignalFX sink can now handle and convert ssf service checks (represented as a gauge). Thanks, [stealthcode](https://github.com/stealthcode)!
 * Converted the grpsink to use unary instead of stream RPCs. Thanks, [sdboyer](https://github.com/sdboyer)!
 * Bumped version of [SignalFx go client](https://github.com/signalfx/golib) to prevent accidental removal of `-` from tag keys. Thanks, [gphat](https://github.com/gphat)!
+* Added additional metrics for internal memory usage. Thanks, [aditya](https://github.com/chimeracoder)!
+  * `gc.alloc_heap_bytes_total`
+  * `gc.mallocs_objects_total`
+  * `gc.GCCPUFraction`
+
 
 ## Bugfixes
 * The `ignored-labels` and `ignored-metrics` flags for veneur-prometheus will filter no metrics or labels if no filter is specified. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!

--- a/flusher.go
+++ b/flusher.go
@@ -31,7 +31,6 @@ func (s *Server) Flush(ctx context.Context) {
 	span.Add(ssf.Gauge("mem.heap_alloc_bytes", float32(mem.HeapAlloc), nil),
 		ssf.Gauge("gc.number", float32(mem.NumGC), nil),
 		ssf.Gauge("gc.pause_total_ns", float32(mem.PauseTotalNs), nil),
-		ssf.Gauge("gc.alloc_heap_bytes", float32(mem.HeapAlloc), nil),
 		ssf.Gauge("gc.alloc_heap_bytes_total", float32(mem.TotalAlloc), nil),
 		ssf.Gauge("gc.mallocs_objects_total", float32(mem.Mallocs), nil),
 		ssf.Gauge("gc.GCCPUFraction", float32(mem.GCCPUFraction), nil),


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Update CHANGELOG with the new metrics we've added. 

Also remove one redundant metric - since Veneur runs on every host, this saves us 6*N datapoints per minute, where N is the number of hosts we run.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @aubrey-stripe 
cc @stripe/observability 