### PR TITLE
Replace internal mutex with sync.Map

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -384,8 +384,8 @@ func (s *Server) flushTraces(ctx context.Context) {
 		key, ok := keyI.(string)
 		if !ok {
 			log.WithFields(logrus.Fields{
-				"key":  key,
-				"type": reflect.TypeOf(key),
+				"key":  keyI,
+				"type": reflect.TypeOf(keyI),
 			}).Error("received non-string key")
 			return true
 		}
@@ -393,8 +393,8 @@ func (s *Server) flushTraces(ctx context.Context) {
 		value, ok := valueI.(*ssfServiceSpanMetrics)
 		if !ok {
 			log.WithFields(logrus.Fields{
-				"value": value,
-				"type":  reflect.TypeOf(value),
+				"value": valueI,
+				"type":  reflect.TypeOf(valueI),
 			}).Error("received non-struct value")
 			return true
 		}

--- a/sinks/lightstep/lightstep_test.go
+++ b/sinks/lightstep/lightstep_test.go
@@ -109,7 +109,7 @@ func TestLSSpanSinkIngest(t *testing.T) {
 	tracer := &testLSTracer{}
 	ls := &LightStepSpanSink{
 		tracers:      []opentracing.Tracer{tracer},
-		serviceCount: make(map[string]int64),
+		serviceCount: sync.Map{},
 		mutex:        &sync.Mutex{},
 	}
 	start := time.Now()
@@ -133,9 +133,9 @@ func TestLSSpanSinkIngest(t *testing.T) {
 	assert.NoError(t, err)
 
 	if assert.Equal(t, 1, len(tracer.finishedSpans)) {
-		count, ok := ls.serviceCount["farts-srv"]
+		count, ok := ls.serviceCount.Load("farts-srv")
 		assert.True(t, ok, "should have counted")
-		assert.EqualValues(t, 1, count)
+		assert.EqualValues(t, 1, *count.(*int64))
 
 		span := tracer.finishedSpans[0]
 		assert.Equal(t, "farting farty farts", span.name)


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

A sync.Map should perform a little better here, because this is the exact case for a sync.Map (multiple goroutines writing to different keys, so we don't need to lock all ingestion). It's not going to be a huge difference, though, because in reality, we generally have only one service per Veneur instance that emits spans in the first place.

If we want, we could just remove the `service` tag from `veneur.sink.spans_flushed_total`, and use an atomic increment here, which would definitely be faster.


This isn't the primary source of mutex contention - `FinishWithSpan` actually is, but that's within the client library code, so we can't change that.



#### Motivation
<!-- Why are you making this change? -->

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 