### PR TITLE
Log warning if extra config options are provided, but don't exit

### DIFF
--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -26,7 +26,11 @@ func main() {
 
 	conf, err := veneur.ReadProxyConfig(*configFile)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error reading config file")
+		if _, ok := err.(*veneur.UnknownConfigKeys); ok {
+			logrus.WithError(err).Warn("Config contains invalid or deprecated keys")
+		} else {
+			logrus.WithError(err).Fatal("Error reading config file")
+		}
 	}
 
 	logger := logrus.StandardLogger()

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -29,7 +29,11 @@ func main() {
 
 	conf, err := veneur.ReadConfig(*configFile)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error reading config file")
+		if _, ok := err.(*veneur.UnknownConfigKeys); ok {
+			logrus.WithError(err).Warn("Config contains invalid or deprecated keys")
+		} else {
+			logrus.WithError(err).Fatal("Error reading config file")
+		}
 	}
 
 	logger := logrus.StandardLogger()


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Log (at WARN) if extra config options are provided to veneur or veneur-proxy, but don't exit the application as long as a valid config was extracted.

#### Motivation

At the moment, adding an extra field to Veneur's config will cause it to crashloop. That makes it awkward to roll Veneur back, because if a new configuration has been added in the interim, the entire process will crashloop, and we'll lose all data.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @asf-stripe 
cc @stripe/observability 