### PR TITLE
grpsink: Reset counts when flushing metrics

### DIFF
--- a/sinks/grpsink/grpsink.go
+++ b/sinks/grpsink/grpsink.go
@@ -144,11 +144,11 @@ func (gs *GRPCSpanSink) Flush() {
 	samples.Add(
 		ssf.Count(
 			sinks.MetricKeyTotalSpansFlushed,
-			float32(atomic.LoadUint32(&gs.sentCount)),
+			float32(atomic.SwapUint32(&gs.sentCount, 0)),
 			map[string]string{"sink": gs.Name()}),
 		ssf.Count(
 			sinks.MetricKeyTotalSpansDropped,
-			float32(atomic.LoadUint32(&gs.dropCount)),
+			float32(atomic.SwapUint32(&gs.dropCount, 0)),
 			map[string]string{"sink": gs.Name()},
 		),
 	)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

The grpsink was not resetting its internal counters on each flush of its metrics.

#### Motivation
<!-- Why are you making this change? -->

So the counts are right!

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Nothing to test, really.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

The change is to instrumentation.

r? @ChimeraCoder 