### PR TITLE
Remove WaitGroup from span sink processing

### DIFF
--- a/server.go
+++ b/server.go
@@ -521,7 +521,7 @@ func (s *Server) Start() {
 	// Set up the processors for spans:
 
 	// Use the pre-allocated Workers slice to know how many to start.
-	s.SpanWorker = NewSpanWorker(s.spanSinks, s.TraceClient, s.SpanChan, s.TagsAsMap)
+	s.SpanWorker = NewSpanWorker(s.spanSinks, s.TraceClient, s.Statsd, s.SpanChan, s.TagsAsMap)
 
 	go func() {
 		log.Info("Starting Event worker")

--- a/worker.go
+++ b/worker.go
@@ -455,7 +455,7 @@ func (tw *SpanWorker) Flush() {
 		sinkFlushStart := time.Now()
 		s.Flush()
 		tw.statsd.TimeInMilliseconds("worker.span.flush_duration_ns", float64(time.Since(sinkFlushStart).Nanoseconds()), tags, 1.0)
-		cumulative := time.Duration(atomic.LoadInt64(&tw.cumulativeTimes[i])) * time.Nanosecond
+		cumulative := time.Duration(atomic.SwapInt64(&tw.cumulativeTimes[i], 0)) * time.Nanosecond
 		tw.statsd.TimeInMilliseconds(sinks.MetricKeySpanIngestDuration, float64(cumulative), tags, 1.0)
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -420,11 +420,9 @@ func (tw *SpanWorker) Work() {
 			}
 		}
 
-		var wg sync.WaitGroup
 		for i, s := range tw.sinks {
 			tags := tw.sinkTags[i]
-			wg.Add(1)
-			go func(i int, sink sinks.SpanSink, span *ssf.SSFSpan, wg *sync.WaitGroup) {
+			go func(i int, sink sinks.SpanSink, span *ssf.SSFSpan) {
 				start := time.Now()
 				// Give each sink a change to ingest.
 				err := sink.Ingest(span)
@@ -439,10 +437,8 @@ func (tw *SpanWorker) Work() {
 				}
 				atomic.AddInt64(&tw.cumulativeTimes[i],
 					int64(time.Since(start)/time.Nanosecond))
-				wg.Done()
-			}(i, s, m, &wg)
+			}(i, s, m)
 		}
-		wg.Wait()
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -458,12 +458,11 @@ func (tw *SpanWorker) Flush() {
 		}
 		sinkFlushStart := time.Now()
 		s.Flush()
-		samples.Add(ssf.Timing("worker.span.flush_duration_ns", time.Since(sinkFlushStart), time.Nanosecond, tw.sinkTags[i]))
+		tw.statsd.TimeInMilliseconds("worker.span.flush_duration_ns", float64(time.Since(sinkFlushStart).Nanoseconds()), tags, 1.0)
 		cumulative := time.Duration(atomic.LoadInt64(&tw.cumulativeTimes[i])) * time.Nanosecond
 		tw.statsd.TimeInMilliseconds(sinks.MetricKeySpanIngestDuration, float64(cumulative), tags, 1.0)
 	}
 
 	metrics.Report(tw.traceClient, samples)
-	metrics.ReportOne(tw.traceClient,
-		ssf.Count("worker.span.hit_chan_cap", float32(atomic.SwapInt64(&tw.capCount, 0)), nil))
+	tw.statsd.Count("worker.span.hit_chan_cap", atomic.SwapInt64(&tw.capCount, 0), nil, 1.0)
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -201,8 +201,8 @@ func TestSpanWorkerTagApplication(t *testing.T) {
 	spanChanNone := make(chan *ssf.SSFSpan)
 	spanChanFoo := make(chan *ssf.SSFSpan)
 
-	go NewSpanWorker([]sinks.SpanSink{fake}, cl, spanChanNone, nil).Work()
-	go NewSpanWorker([]sinks.SpanSink{fake}, cl, spanChanFoo, tags["foo"]()).Work()
+	go NewSpanWorker([]sinks.SpanSink{fake}, cl, nil, spanChanNone, nil).Work()
+	go NewSpanWorker([]sinks.SpanSink{fake}, cl, nil, spanChanFoo, tags["foo"]()).Work()
 
 	sendAndWait := func(spanChan chan<- *ssf.SSFSpan, span *ssf.SSFSpan) {
 		fake.wg.Add(1)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

The WaitGroup means that one slow sink can cause the entire span ingestion pipeline to back up. From what I can tell, there's no reason we *need* to have a WaitGroup here. If one sink is particularly slow, instead of backing up (and dropping metrics/spans), we'll end up firing off a lot of goroutines that take a while to finish. As long as they do finish within a reasonable amount of time, the memory burden won't be huge. If it is, we're better off alerting on the slow sinks themselves than we are by degrading the upstream portions of the pipeline.


This PR also updates the span worker to emit internal metrics using UDP, because if the span worker is itself backed up, we won't be able to see those metrics.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @asf-stripe 
cc @stripe/observability 