### PR TITLE
Improve performance of ConvertSpanUniquenessMetrics

### DIFF
--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -135,7 +135,7 @@ func ConvertSpanUniquenessMetrics(span *ssf.SSFSpan, rate float32) ([]UDPMetric,
 				"service":   span.Service,
 				"root_span": strconv.FormatBool(span.Id == span.TraceId),
 			}))...)
-	metrics := []UDPMetric{}
+	metrics := make([]UDPMetric, 0, len(ssfMetrics))
 	for _, m := range ssfMetrics {
 		udpM, err := ParseMetricSSF(m)
 		if err != nil {
@@ -206,7 +206,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (UDPMetric, error) {
 		ret.Value = float64(metric.Value)
 	}
 	ret.SampleRate = metric.SampleRate
-	tempTags := make([]string, 0)
+	tempTags := make([]string, 0, len(metric.Tags))
 	for key, value := range metric.Tags {
 		if key == "veneurlocalonly" {
 			ret.Scope = LocalOnly
@@ -216,7 +216,7 @@ func ParseMetricSSF(metric *ssf.SSFSample) (UDPMetric, error) {
 			ret.Scope = GlobalOnly
 			continue
 		}
-		tempTags = append(tempTags, fmt.Sprintf("%s:%s", key, value))
+		tempTags = append(tempTags, key+":"+value)
 	}
 	sort.Strings(tempTags)
 	ret.Tags = tempTags

--- a/samplers/parser_test.go
+++ b/samplers/parser_test.go
@@ -1,0 +1,77 @@
+package samplers
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stripe/veneur/ssf"
+)
+
+func BenchmarkConvertSpanUniquenessMetrics(b *testing.B) {
+	const LEN = 10000
+
+	spans := make([]*ssf.SSFSpan, LEN)
+
+	for i, _ := range spans {
+		p := make([]byte, 10)
+		_, err := rand.Read(p)
+		if err != nil {
+			b.Fatalf("Error generating data: %s", err)
+		}
+		span := &ssf.SSFSpan{
+			Name:    "my.test.span." + string(p[:2]),
+			Service: "bigmouth",
+			Metrics: []*ssf.SSFSample{
+				{
+					Name:       "my.test.metric",
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "false",
+						"yeats":       "false",
+						"wilde":       "true",
+						string(p[:5]): string(p[5:]),
+					},
+				},
+				{
+					Name:       string(p),
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "true",
+						"yeats":       "true",
+						"wilde":       "false",
+						string(p[2:]): string(p[7:]),
+					},
+				},
+				{
+					Name:       string(p[1:]),
+					Value:      rand.Float32(),
+					Timestamp:  time.Now().Unix(),
+					SampleRate: rand.Float32(),
+					Tags: map[string]string{
+						"keats":       "yeats",
+						"wilde":       "weird",
+						string(p[:3]): string(p[2:]),
+					},
+				},
+			},
+		}
+		spans[i] = span
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		result, err := ConvertSpanUniquenessMetrics(spans[(i%LEN)], 1)
+		if err != nil {
+			b.Fatalf("Error converting span uniqueness metrics: %s", err)
+		}
+		if len(result) == 0 {
+			b.Fatalf("Received zero-length uniqueness metric")
+		}
+	}
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Improve performance of ConvertSpanUniquenessMetrics, which is called (albeit asynchronously) in the hot path of our `metric_extraction` sink ingestion during span processing.

Before:

```
BenchmarkConvertSpanUniquenessMetrics-8           500000              2222 ns/op             960 B/op         21 allocs/op
BenchmarkParseMetricSSF-8                        1000000              1786 ns/op             440 B/op         19 allocs/op
```

After:

```
BenchmarkConvertSpanUniquenessMetrics-8          1000000              1536 ns/op             800 B/op         13 allocs/op
BenchmarkParseMetricSSF-8                        1000000              1053 ns/op             264 B/op          9 allocs/op
```

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 