### PR TITLE
Report memory and span channel metrics using statsd client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 5.0.0, in development
 
+## Added
+* Added a timeout for sink ingestion to all sinks, which prevents a single slow sink from blocking ingestion on other span sinks indefinitely. Thanks, [aditya](https://github.com/chimeracoder)!
+
 ## Bugfixes
-* Add a timeout to the Kafka sink, which prevents the Kafka client from blocking other span sinks. Thanks, [aditya](https://github.com/chimeracoder)!
+* Added a timeout to the Kafka sink, which prevents the Kafka client from blocking other span sinks. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Removed
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.

--- a/flusher.go
+++ b/flusher.go
@@ -28,15 +28,14 @@ func (s *Server) Flush(ctx context.Context) {
 	mem := &runtime.MemStats{}
 	runtime.ReadMemStats(mem)
 
-	span.Add(ssf.Gauge("mem.heap_alloc_bytes", float32(mem.HeapAlloc), nil),
-		ssf.Gauge("gc.number", float32(mem.NumGC), nil),
-		ssf.Gauge("gc.pause_total_ns", float32(mem.PauseTotalNs), nil),
-		ssf.Gauge("gc.alloc_heap_bytes_total", float32(mem.TotalAlloc), nil),
-		ssf.Gauge("gc.mallocs_objects_total", float32(mem.Mallocs), nil),
-		ssf.Gauge("gc.GCCPUFraction", float32(mem.GCCPUFraction), nil),
-		ssf.Gauge("worker.span_chan.total_elements", float32(len(s.SpanChan)), nil),
-		ssf.Gauge("worker.span_chan.total_capacity", float32(cap(s.SpanChan)), nil),
-	)
+	s.Statsd.Gauge("worker.span_chan.total_elements", float64(len(s.SpanChan)), nil, 1.0)
+	s.Statsd.Gauge("worker.span_chan.total_capacity", float64(cap(s.SpanChan)), nil, 1.0)
+	s.Statsd.Gauge("gc.GCCPUFraction", float64(mem.GCCPUFraction), nil, 1.0)
+	s.Statsd.Gauge("gc.number", float64(mem.NumGC), nil, 1.0)
+	s.Statsd.Gauge("gc.pause_total_ns", float64(mem.PauseTotalNs), nil, 1.0)
+	s.Statsd.Gauge("gc.alloc_heap_bytes_total", float64(mem.TotalAlloc), nil, 1.0)
+	s.Statsd.Gauge("gc.mallocs_objects_total", float64(mem.Mallocs), nil, 1.0)
+	s.Statsd.Gauge("mem.heap_alloc_bytes", float64(mem.HeapAlloc), nil, 1.0)
 
 	samples := s.EventWorker.Flush()
 

--- a/worker.go
+++ b/worker.go
@@ -428,6 +428,7 @@ func (tw *SpanWorker) Work() {
 			tags := tw.sinkTags[i]
 			wg.Add(1)
 			go func(i int, sink sinks.SpanSink, span *ssf.SSFSpan, wg *sync.WaitGroup) {
+				defer wg.Done()
 
 				done := make(chan struct{})
 				start := time.Now()
@@ -469,7 +470,6 @@ func (tw *SpanWorker) Work() {
 					tw.statsd.Incr("worker.span.ingest_timeout_total", t, 1.0)
 				}
 				atomic.AddInt64(&tw.cumulativeTimes[i], int64(time.Since(start)/time.Nanosecond))
-				wg.Done()
 			}(i, s, m, &wg)
 		}
 		wg.Wait()


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add a timeout to sink ingestion, across all sinks.

Also use statsd client to report internal memory and span channel metrics. This way, if there are issues with span processing, we can use metrics about span processing to investigate it.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 
