### PR TITLE
Report span ingestion errors independently of span pipeline

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -435,8 +435,11 @@ func (tw *SpanWorker) Work() {
 						// If a sink goes wacko and errors a lot, we stand to emit a
 						// loooot of metrics towards all span workers here since
 						// span ingest rates can be very high. C'est la vie.
-						metrics.ReportOne(tw.traceClient,
-							ssf.Count("worker.span.ingest_error_total", 1, tags))
+						t := make([]string, 0, len(tags))
+						for k, v := range tags {
+							t = append(t, k+":"+v)
+						}
+						tw.statsd.Incr("worker.span.ingest_error_total", t, 1.0)
 					}
 				}
 				atomic.AddInt64(&tw.cumulativeTimes[i], int64(time.Since(start)/time.Nanosecond))


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Report span ingestion errors independently of span pipeline. In theory, if the span ingestion pipeline is experiencing issues (or just the metrics pipeline itself), then we wouldn't actually be able to see those reported errors.


Dual-publishing will eventually fix this, but we're still a ways from that.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 