### PR TITLE
Add timeout to Kafka sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 5.0.0, in development
 
+## Bugfixes
+* Add a timeout to the Kafka sink, which prevents the Kafka client from blocking other span sinks. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Removed
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.

--- a/worker.go
+++ b/worker.go
@@ -435,10 +435,12 @@ func (tw *SpanWorker) Work() {
 						// If a sink goes wacko and errors a lot, we stand to emit a
 						// loooot of metrics towards all span workers here since
 						// span ingest rates can be very high. C'est la vie.
-						t := make([]string, 0, len(tags))
+						t := make([]string, 0, len(tags)+1)
 						for k, v := range tags {
 							t = append(t, k+":"+v)
 						}
+
+						t = append(t, "sink:"+sink.Name())
 						tw.statsd.Incr("worker.span.ingest_error_total", t, 1.0)
 					}
 				}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add a timeout to the Kafka sink. According to the documentation for the Kafka library, [errors are returned on a channel](https://godoc.org/github.com/Shopify/sarama#AsyncProducer), and if the channel isn't read from, the input operation itself will block. 

Eventually, that causes the available goroutines for processing Kafka spans to block, which will bubble up to span ingestion itself.


We could create a new goroutine to consume Kafka errors, but at the moment, we don't need that (we're literally already ignoring them), so disabling error reporting preserves the status quo, except that it also avoids the deadlock situation.


#### Motivation
<!-- Why are you making this change? -->



#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

I already tested the first commit (the functional change) on the canary box. We didn't run into any Kafka errors during this time; they're sporadic.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 