### PR TITLE
Ensure the indicator span timer name is un-prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 6.1.0
 
-## Updated 
+## Bugfixes
+* When creating timer metrics from indicator spans, veneur no longer prefixes `indicator_span_timer_name` with the string `veneur.`. Thanks, [antifuchs](https://github.com/antifuchs)!
+
+## Updated
 * Metric sampler parse function now looks for `veneurlocalonly` and `veneurglobalonly` by prefix instead of direct equality for times where value can't/shouldn't be excluded even if it's blank. Thanks [joeybloggs](https://github.com/joeybloggs)
 
 # 6.0.0

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -110,6 +110,8 @@ func ConvertIndicatorMetrics(span *ssf.SSFSpan, timerName string) (metrics []UDP
 		tags["error"] = "true"
 	}
 	ssfTimer := ssf.Timing(timerName, end.Sub(start), time.Nanosecond, tags)
+	ssfTimer.Name = timerName // Ensure the name is free from any name prefixes, like "veneur."
+
 	timer, err := ParseMetricSSF(ssfTimer)
 	if err != nil {
 		return metrics, err


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR changes the indicator metric generation to name metrics with precisely the name given in veneur.yaml.


#### Motivation

We discovered that the indicator metric name was wrong, prefixed by `veneur.`. We currently fixed this by removing the `veneur.` from our config files, but that's not great. The metric name should match the config file's instead.

#### Test plan

- [x] roll to qa
- [x] see if that fixes things

#### Rollout/monitoring/revert plan

This is a bit complicated for us because the config file we have also needs to change. I believe having slightly incorrectly-named metrics for the duratoin of the cutover (order of minutes) is probably peaceful though.