### PR TITLE
Avoid logging spurious errors during reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 * Added a timeout to the Kafka sink, which prevents the Kafka client from blocking other span sinks. Thanks, [aditya](https://github.com/chimeracoder)!
+* Prevented some spurious error logging on reconnection by the grpsink. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Removed
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -651,6 +651,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0e2a924965542647fcbd9042b27e4e748f3fcc6c09ae90fd18e5665807933da1"
+  inputs-digest = "5bf8512d014e920706926c51ca6f9db7247d2af1dbdfd650517fdd2c976dbf16"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

While connections were cycling (e.g., on target sink restarts), it was possible for some RPCs to erroneously emit an error log. This _should_ preclude that possibility.

#### Motivation
<!-- Why are you making this change? -->

Unnecessary error-level logs are alerty and badsauce.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

It's hard to construct an artificial test, so testing in production works much better.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

Test first, then merge if it appears to behave correctly.