### PR TITLE
Add trace.SetDefaultClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Added a timeout for sink ingestion to all sinks, which prevents a single slow sink from blocking ingestion on other span sinks indefinitely. Thanks, [aditya](https://github.com/chimeracoder)!
+* Added `trace.SetDefaultClient` to handle overridding the default trace client, and closing the existing one. Thanks, [franklinhu](https://github.com/franklinhu)
 
 ## Bugfixes
 * Added a timeout to the Kafka sink, which prevents the Kafka client from blocking other span sinks. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/trace/client.go
+++ b/trace/client.go
@@ -383,6 +383,17 @@ func NewChannelClient(spanChan chan<- *ssf.SSFSpan, opts ...ClientParam) (*Clien
 	return cl, nil
 }
 
+// SetDefaultClient overrides the default client used for recording
+// traces, and gracefully closes the existing one.
+// This is not safe to run concurrently with other goroutines.
+func SetDefaultClient(client *Client) {
+	oldClient := DefaultClient
+	DefaultClient = client
+
+	// Ensure the old client is closed so it does not leak connections
+	oldClient.Close()
+}
+
 // NeutralizeClient sets up a client such that all Record or Flush
 // operations result in ErrWouldBlock. It dashes all hope of a Client
 // ever successfully recording or flushing spans, and is mostly useful

--- a/trace/client.go
+++ b/trace/client.go
@@ -19,6 +19,10 @@ import (
 )
 
 func init() {
+	initializeDefaultClient()
+}
+
+func initializeDefaultClient() {
 	cl, err := NewClient(DefaultVeneurAddress)
 	if err != nil {
 		return
@@ -391,7 +395,9 @@ func SetDefaultClient(client *Client) {
 	DefaultClient = client
 
 	// Ensure the old client is closed so it does not leak connections
-	oldClient.Close()
+	if oldClient != nil {
+		oldClient.Close()
+	}
 }
 
 // NeutralizeClient sets up a client such that all Record or Flush

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -56,6 +56,23 @@ func TestNoClient(t *testing.T) {
 	assert.Equal(t, ErrNoClient, err)
 }
 
+func TestSetDefaultClient(t *testing.T) {
+	newClient, err := NewBackendClient(&testBackend{})
+	assert.NoError(t, err)
+
+	defer initializeDefaultClient()
+
+	var nilClient *Client = nil
+
+	// Setting nil works
+	SetDefaultClient(nilClient)
+	assert.Equal(t, nilClient, DefaultClient)
+
+	// Replacing nil and setting a client works
+	SetDefaultClient(newClient)
+	assert.Equal(t, newClient, DefaultClient)
+}
+
 func TestUDP(t *testing.T) {
 	// arbitrary
 	const BufferSize = 1087152

--- a/trace/example_test.go
+++ b/trace/example_test.go
@@ -15,10 +15,6 @@ func ExampleNewClient() {
 	}
 
 	// Replace the old client:
-	oldCl := trace.DefaultClient
-
-	// Now close the old default client so we don't leak connections
-	trace.DefaultClient = cl
-	oldCl.Close()
+	trace.SetDefaultClient(cl)
 	// Output:
 }


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Add a helper method to set trace.DefaultClient and close the existing
client (to avoid forgetting and subsequently leaking connections)

#### Motivation
<!-- Why are you making this change? -->
I ran into this case and didn't realize I needed to close the existing client. @asf-stripe suggested doing this

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Added an automated test. I couldn't quite figure out how to test that the client/backend actually gets closed, so would be open to suggestions there

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Presumably need to deploy veneur?

r? @asf-stripe 
cc @stripe/observability 