### PR TITLE
Fix #454 incorrectly editing the v5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.0
+
+## Added
+* Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
+
 # 5.0.0, 2018-05-17
 
 ## Added
@@ -27,9 +32,6 @@
 * Veneur's trace client library can still be used in applications that are built with Go 1.8, but it is no longer tested against Go 1.8.
 * The `veneur.ssf.received_total` metric has been removed, as it is mostly redundant with `veneur.ssf.spans.received_total`, and was not reported consistently between packet and framed formats.
 * The `veneur.ssf.spans.received_total` metric now tracks all SSF data received, in either packet or framed format, whether or not a valid span was extracted.
-
-## Added
-* Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman)!
 
 # 4.0.0, 2018-04-13
 


### PR DESCRIPTION
#### Summary

Back in the day when I created #454, v5 was still unreleased and I had edited the appropriate section in the changelog.  By the time we merged it yesterday, v5 had already been tagged and the changes had no longer made it into that release.

This updates the changelog to show that gRPC import support was only added for v6.  I'm happy to omit this if you all would prefer, but I added in @quantcast to the changelog, as a lot of the work done for these features was on their time!

#### Motivation

Just trying to clean up the history 😄 

CC: @sdboyer-stripe @cory-stripe @stripe/observability