### PR TITLE
Forward metrics over gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
+* Metrics can be forwarded over gRPC (currently only to a single Veneur) using `forward_use_grpc`. Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
 
 # 5.0.0, 2018-05-17
 

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FlushFile                    string    `yaml:"flush_file"`
 	FlushMaxPerBody              int       `yaml:"flush_max_per_body"`
 	ForwardAddress               string    `yaml:"forward_address"`
+	ForwardUseGrpc               bool      `yaml:"forward_use_grpc"`
 	GrpcAddress                  string    `yaml:"grpc_address"`
 	Hostname                     string    `yaml:"hostname"`
 	HTTPAddress                  string    `yaml:"http_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -40,7 +40,7 @@ tls_authority_certificate: ""
 #forward_address: "veneur.example.com"
 forward_address: ""
 
-# Weather or not to forward to an upstream Veneur over gRPC.  If this is false
+# Whether or not to forward to an upstream Veneur over gRPC.  If this is false
 # or unset, HTTP will be used.
 forward_use_grpc: false
 

--- a/example.yaml
+++ b/example.yaml
@@ -36,7 +36,13 @@ tls_authority_certificate: ""
 
 # Use a static host for forwarding
 #forward_address: "http://veneur.example.com"
+# Do not add a prefix when setting the forward address for gRPC.
+#forward_address: "veneur.example.com"
 forward_address: ""
+
+# Weather or not to forward to an upstream Veneur over gRPC.  If this is false
+# or unset, HTTP will be used.
+forward_use_grpc: false
 
 # How often to flush. When flushing to Datadog, changing this
 # value when you've already emitted metrics will break your time

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -1,0 +1,65 @@
+package veneur
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/internal/forwardtest"
+	"github.com/stripe/veneur/samplers/metricpb"
+)
+
+func TestServerFlushGRPC(t *testing.T) {
+	done := make(chan []string)
+	testServer := forwardtest.NewServer(func(ms []*metricpb.Metric) {
+		var names []string
+		for _, m := range ms {
+			names = append(names, m.Name)
+		}
+		done <- names
+	})
+	testServer.Start(t)
+	defer testServer.Stop()
+
+	localCfg := localConfig()
+	localCfg.ForwardAddress = testServer.Addr().String()
+	localCfg.ForwardUseGrpc = true
+	local := setupVeneurServer(t, localCfg, nil, nil, nil)
+	defer local.Shutdown()
+
+	inputs := forwardGRPCTestMetrics()
+	for _, input := range inputs {
+		local.Workers[0].ProcessMetric(input)
+	}
+
+	local.Flush(context.Background())
+
+	expected := []string{
+		testGRPCMetric("histogram"),
+		testGRPCMetric("timer"),
+		testGRPCMetric("counter"),
+		testGRPCMetric("gauge"),
+		testGRPCMetric("set"),
+	}
+
+	select {
+	case v := <-done:
+		assert.ElementsMatch(t, expected, v,
+			"Flush didn't output the right metrics")
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for the gRPC server to receive the flush")
+	}
+}
+
+// Just test that a flushing to a bad address is handled without panicing
+func TestServerFlushGRPCBadAddress(t *testing.T) {
+	localCfg := localConfig()
+	localCfg.ForwardAddress = "bad-address:123"
+	localCfg.ForwardUseGrpc = true
+	local := setupVeneurServer(t, localCfg, nil, nil, nil)
+	defer local.Shutdown()
+
+	local.Workers[0].ProcessMetric(forwardGRPCTestMetrics()[0])
+	local.Flush(context.Background())
+}

--- a/forward_grpc_test.go
+++ b/forward_grpc_test.go
@@ -1,0 +1,79 @@
+package veneur
+
+import (
+	"github.com/stripe/veneur/samplers"
+)
+
+const (
+	grpcTestMetricPrefix = "test.grpc."
+)
+
+// TODO This file will contain additional end-to-end tests for gRPC forwarding.
+// For now it just contains some helper functions that are utilized elsewhere.
+
+func testGRPCMetric(name string) string {
+	return grpcTestMetricPrefix + name
+}
+
+func forwardGRPCTestMetrics() []*samplers.UDPMetric {
+	return []*samplers.UDPMetric{
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("histogram"),
+				Type: histogramTypeName,
+			},
+			Value:      20.0,
+			Digest:     12345,
+			SampleRate: 1.0,
+			Scope:      samplers.MixedScope,
+		},
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("gauge"),
+				Type: gaugeTypeName,
+			},
+			Value:      1.0,
+			SampleRate: 1.0,
+			Scope:      samplers.GlobalOnly,
+		},
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("counter"),
+				Type: counterTypeName,
+			},
+			Value:      2.0,
+			SampleRate: 1.0,
+			Scope:      samplers.GlobalOnly,
+		},
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("timer"),
+				Type: timerTypeName,
+			},
+			Value:      100.0,
+			Digest:     12345,
+			SampleRate: 1.0,
+			Scope:      samplers.GlobalOnly,
+		},
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("set"),
+				Type: setTypeName,
+			},
+			Value:      "test",
+			SampleRate: 1.0,
+			Scope:      samplers.GlobalOnly,
+		},
+		// Only global metrics should be forwarded
+		&samplers.UDPMetric{
+			MetricKey: samplers.MetricKey{
+				Name: testGRPCMetric("counter.local"),
+				Type: counterTypeName,
+			},
+			Value:      100.0,
+			Digest:     12345,
+			SampleRate: 1.0,
+			Scope:      samplers.MixedScope,
+		},
+	}
+}

--- a/worker.go
+++ b/worker.go
@@ -190,13 +190,8 @@ type metricExporter interface {
 
 // appendExportedMetric appends the exported version of the input metric, with
 // the inputted type.  If the export fails, the original slice is returned
-// and an error is logged
-func (wm WorkerMetrics) appendExportedMetric(
-	res []*metricpb.Metric,
-	exp metricExporter,
-	mType metricpb.Type,
-	cl *trace.Client,
-) []*metricpb.Metric {
+// and an error is logged.
+func (wm WorkerMetrics) appendExportedMetric(res []*metricpb.Metric, exp metricExporter, mType metricpb.Type, cl *trace.Client) []*metricpb.Metric {
 	m, err := exp.Metric()
 	if err != nil {
 		log.WithFields(logrus.Fields{

--- a/worker.go
+++ b/worker.go
@@ -156,6 +156,66 @@ func (wm WorkerMetrics) Upsert(mk samplers.MetricKey, Scope samplers.MetricScope
 	return !present
 }
 
+// ForwardableMetrics converts all metrics that should be forwarded to
+// metricpb.Metric (protobuf-compatible).
+func (wm WorkerMetrics) ForwardableMetrics(cl *trace.Client) []*metricpb.Metric {
+	bufLen := len(wm.histograms) + len(wm.sets) + len(wm.timers) +
+		len(wm.globalCounters) + len(wm.globalGauges)
+
+	metrics := make([]*metricpb.Metric, 0, bufLen)
+	for _, count := range wm.globalCounters {
+		metrics = wm.appendExportedMetric(metrics, count, metricpb.Type_Counter, cl)
+	}
+	for _, gauge := range wm.globalGauges {
+		metrics = wm.appendExportedMetric(metrics, gauge, metricpb.Type_Gauge, cl)
+	}
+	for _, histo := range wm.histograms {
+		metrics = wm.appendExportedMetric(metrics, histo, metricpb.Type_Histogram, cl)
+	}
+	for _, set := range wm.sets {
+		metrics = wm.appendExportedMetric(metrics, set, metricpb.Type_Set, cl)
+	}
+	for _, timer := range wm.timers {
+		metrics = wm.appendExportedMetric(metrics, timer, metricpb.Type_Timer, cl)
+	}
+
+	return metrics
+}
+
+// A type implemented by all valid samplers
+type metricExporter interface {
+	GetName() string
+	Metric() (*metricpb.Metric, error)
+}
+
+// appendExportedMetric appends the exported version of the input metric, with
+// the inputted type.  If the export fails, the original slice is returned
+// and an error is logged
+func (wm WorkerMetrics) appendExportedMetric(
+	res []*metricpb.Metric,
+	exp metricExporter,
+	mType metricpb.Type,
+	cl *trace.Client,
+) []*metricpb.Metric {
+	m, err := exp.Metric()
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"type":          mType,
+			"name":          exp.GetName(),
+		}).Error("Could not export metric")
+		metrics.ReportOne(cl,
+			ssf.Count("worker_metrics.export_metric.errors", 1, map[string]string{
+				"type": mType.String(),
+			}),
+		)
+		return res
+	}
+
+	m.Type = mType
+	return append(res, m)
+}
+
 // NewWorker creates, and returns a new Worker object.
 func NewWorker(id int, cl *trace.Client, logger *logrus.Logger, stats *statsd.Client) *Worker {
 	return &Worker{


### PR DESCRIPTION
#### Summary

This adds support for forwarding metrics over gRPC from one Veneur to another.  A new method is added to Server (forwardGRPC) that performs the bulk of the work along with some new helper methods on the WorkerMetric type.

I added a new configuration option that allows gRPC forwarding to be
activated, specifically `forward_use_grpc`.  This is then used in the
Server initialization to setup a gRPC connection to the forwarding
destination.

#### Motivation

Again, we (@quantcast) would like to contribute gRPC support to eventually enable global histogram aggregations (#390).

#### Test plan

This includes the following tests:
* A couple different sub-tests for the `(WorkerMetrics).ForwardableMetrics` function.
* Two tests for the new `forwardGRPC` function (in "flusher_test.go").

I also have written some full end-to-end tests that verify the gRPC forwarding functionality from a local Veneur, through a Veneur Proxy, and finally to a Global Veneur.  These require the last round of changes which make gRPC support fully available in the proxies.

We have also been running this (or very similar) in production for about 2 months now without issues.

#### Rollout/monitoring/revert plan

This should have no affect on existing functionality unless the `forward_use_grpc` flag is set, so it should be completely safe to deploy without that option.  When deploying with the flag set, you'll obviously need to have configured the gRPC listener through `grpc_address` on the Global Veneur.

CC: @sdboyer-stripe @cory-stripe @stripe/observability