### PR TITLE
Fix possible NPE by moving defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Added
 * Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
 
+## Bugfixes
+* Fix a possible crash-before-panic when unable to open UDP socket. Thanks, [gphat](https://github.com/gphat)
+
 # 5.0.0, 2018-05-17
 
 ## Added

--- a/networking.go
+++ b/networking.go
@@ -42,10 +42,10 @@ func startProcessingOnUDP(s *Server, protocol string, addr *net.UDPAddr, pool *s
 	// call results in a contrete port.
 	if reusePort {
 		sock, err := NewSocket(addr, s.RcvbufBytes, reusePort)
-		defer sock.Close()
 		if err != nil {
 			panic(fmt.Sprintf("couldn't listen on UDP socket %v: %v", addr, err))
 		}
+		defer sock.Close()
 		addr = sock.LocalAddr().(*net.UDPAddr)
 	}
 	addrChan := make(chan net.Addr, 1)


### PR DESCRIPTION
#### Summary
Fix NPE we saw in prod.

#### Motivation
If for some reason the `NewSocket` call fails, we're setting up our `defer` *before* we `panic`. This means we'll `panic` and then try and `Close()` a nil `sock`.

Moving the `defer` to after the `panic` ensures we don't try and close a thing with no value.

#### Test plan
Existing tests


#### Rollout/monitoring/revert plan
None, just gonna merge it and let it go out naturally.

r? @asf-stripe 