### PR TITLE
veneur-emit: Improve stdout and stderr handling of subprocess, add stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Metrics can be imported over gRPC if the `grpc_address` parameter is set.  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
+* When timing commands, `veneur-emit` now passes stdin, stdout and stderr through to the child process unmodified. Thanks [antifuchs](https://github.com/antifuchs) and [sdboyer](https://github.com/sdboyer)!
 
 ## Bugfixes
 * Fix a possible crash-before-panic when unable to open UDP socket. Thanks, [gphat](https://github.com/gphat)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR makes veneur-emit no longer stream subprocesses' outputs, instead simply passing the stdout, stderr and stdin FD's through unmodified. Besides hopefully fixing an issue we saw running it in CI,  this has the wonderful side effect of allowing veneur-emit users to time commands that take input!

#### Motivation
We saw a problem in CI where streaming output would get an `EAGAIN` and abort the copy & veneur emit command invocation.

#### Test plan

* Ran a check with stdin redirection: `echo foo | veneur-emit [...] cat` - saw output!
* Ran a check with `yes`: `veneur-emit [...] yes`

Not sure how to verify that the problem we saw in CI is gone, besides running it there; this is probably very heavily dependent on environmental conditions, like which FDs are redirected and what type of unix file they are.


#### Rollout/monitoring/revert plan

Merge, roll to our ci?
