### PR TITLE
Remove span_name tag from indicator span timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fix a possible crash-before-panic when unable to open UDP socket. Thanks, [gphat](https://github.com/gphat)
 * The `StartSpan` method on `tracer.Tracer` will default to the provided `operationName` if provided. This function is provided for compatibility with OpenTracing, but the package-level `trace.StartSpanFromContext` function is recommended for new users.
 
+## Removed
+* The tag `span_name` has been removed from the timer metric generated for indicator spans. Thanks, [aditya](https://github.com/chimeracoder)!
+
 # 5.0.0, 2018-05-17
 
 ## Added

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -453,7 +453,7 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 		}
 
 		if passedFlags["gauge"] != nil {
-			logrus.Debugf("Sending gauge '%s' -> %f", name, passedFlags["gauge"].String())
+			logrus.Debugf("Sending gauge '%s' -> %s", name, passedFlags["gauge"].String())
 			value, err := strconv.ParseFloat(passedFlags["gauge"].String(), 32)
 			if err != nil {
 				return status, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -189,12 +189,11 @@ func TestParseSSFIndicatorSpan(t *testing.T) {
 		assert.Equal(t, "timer_name", m.Name)
 		assert.Equal(t, "histogram", m.Type)
 		assert.InEpsilon(t, float32(duration/time.Nanosecond), m.Value, 0.001)
-		if assert.Equal(t, 3, len(m.Tags)) {
+		if assert.Equal(t, 2, len(m.Tags)) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)
 			assert.Equal(t, "error:false", tags[0])
 			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[1])
-			assert.Equal(t, fmt.Sprintf("span_name:%s", span.Name), tags[2])
 		}
 	}
 }
@@ -233,12 +232,11 @@ func TestParseSSFIndicatorSpanWithError(t *testing.T) {
 		assert.Equal(t, "histogram", m.Type)
 		assert.InEpsilon(t, float32(duration/time.Nanosecond), m.Value, 0.001,
 			"Duration seems incorrect: %f vs. %d", m.Value, duration/time.Nanosecond)
-		if assert.Equal(t, 3, len(m.Tags)) {
+		if assert.Equal(t, 2, len(m.Tags)) {
 			var tags sort.StringSlice = m.Tags
 			sort.Sort(tags)
 			assert.Equal(t, "error:true", tags[0])
 			assert.Equal(t, fmt.Sprintf("service:%s", span.Service), tags[1])
-			assert.Equal(t, fmt.Sprintf("span_name:%s", span.Name), tags[2])
 		}
 	}
 }

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -103,9 +103,8 @@ func ConvertIndicatorMetrics(span *ssf.SSFSpan, timerName string) (metrics []UDP
 	end := time.Unix(span.EndTimestamp/1e9, span.EndTimestamp%1e9)
 	start := time.Unix(span.StartTimestamp/1e9, span.StartTimestamp%1e9)
 	tags := map[string]string{
-		"span_name": span.Name,
-		"service":   span.Service,
-		"error":     "false",
+		"service": span.Service,
+		"error":   "false",
 	}
 	if span.Error {
 		tags["error"] = "true"

--- a/server.go
+++ b/server.go
@@ -470,7 +470,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		})
 
 		if err != nil {
-			logger.Info("error getting AWS session: %s", err)
+			logger.Infof("error getting AWS session: %s", err)
 			svc = nil
 		} else {
 			logger.Info("Successfully created AWS session")


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Remove the `span_name` tag from the timer metric that is automatically generated for indicator spans.

It's easy to accidentally increase the number of span names generated in a short period of time, which creates new metric timeseries.

#### Motivation
<!-- Why are you making this change? -->

https://jira.corp.stripe.com/browse/OBS-5879

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
r? @stripe/observability 