### PR TITLE
check if tag has prefix instead of direct equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.1.0
+
+## Updated 
+* Metric sampler parse function now looks for `veneurlocalonly` and `veneurglobalonly` by prefix instead of direct equality for times where value can't/shouldn't be excluded even if it's blank. Thanks [joeybloggs](https://github.com/joeybloggs)
+
 # 6.0.0
 
 ## Added

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -326,12 +326,12 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 			for i, tag := range tags {
 				// we use this tag as an escape hatch for metrics that always
 				// want to be host-local
-				if tag == "veneurlocalonly" {
+				if strings.HasPrefix(tag, "veneurlocalonly") {
 					// delete the tag from the list
 					tags = append(tags[:i], tags[i+1:]...)
 					ret.Scope = LocalOnly
 					break
-				} else if tag == "veneurglobalonly" {
+				} else if strings.HasPrefix(tag, "veneurglobalonly") {
 					// delete the tag from the list
 					tags = append(tags[:i], tags[i+1:]...)
 					ret.Scope = GlobalOnly

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -21,6 +21,7 @@ func TestRouting(t *testing.T) {
 		sinkNames []string
 	}{
 		{"none specified", []string{"foo:bar", "veneurlocalonly"}, nil, []string{"foosink", "barsink"}},
+		{"none specified", []string{"foo:bar", "veneurlocalonly:"}, nil, []string{"foosink", "barsink"}},
 		{"one sink", []string{"veneursinkonly:foobar"}, map[string]struct{}{"foobar": struct{}{}}, []string{"foobar"}},
 		{
 			"multiple sinks",


### PR DESCRIPTION
#### Summary
I changed the metric sampler parse function to look for `veneurlocalonly` and `veneurglobalonly` by prefix instead of direct equality.


#### Motivation
we are currently implementing this functionality and are using a client stats library across our organization, but when writing the metrics even if we pass a blank value the metric is omitted as `veneurglobalonly:` and not `veneurglobalonly`; changing the library would be a breaking change as values are ok to be blank.


#### Test plan
I added a test in samplers_test.go


#### Rollout/monitoring/revert plan
?
