### PR TITLE
Improve the veneur local development story a little

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 6.1.0
 
+## Added
+* Two new options, `debug_ingested_spans` and `debug_flushed_metrics` make veneur log (at level DEBUG) information about the metrics and spans it processes. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 ## Bugfixes
 * When creating timer metrics from indicator spans, veneur no longer prefixes `indicator_span_timer_name` with the string `veneur.`. Thanks, [antifuchs](https://github.com/antifuchs)!
 

--- a/config.go
+++ b/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	DatadogSpanBufferSize        int       `yaml:"datadog_span_buffer_size"`
 	DatadogTraceAPIAddress       string    `yaml:"datadog_trace_api_address"`
 	Debug                        bool      `yaml:"debug"`
+	DebugFlushedMetrics          bool      `yaml:"debug_flushed_metrics"`
+	DebugIngestedSpans           bool      `yaml:"debug_ingested_spans"`
 	EnableProfiling              bool      `yaml:"enable_profiling"`
 	FalconerAddress              string    `yaml:"falconer_address"`
 	FlushFile                    string    `yaml:"flush_file"`

--- a/docs/dev.yaml
+++ b/docs/dev.yaml
@@ -5,8 +5,11 @@
 stats_address: 127.0.0.1:8200
 ssf_listen_addresses:
   - unix:///tmp/veneur.sock
+  - udp://127.0.0.1:8128
 statsd_listen_addresses:
   - udp://127.0.0.1:8200
+trace_max_length_bytes: 16000
 num_workers: 4
+num_readers: 1
 interval: 10s
 debug: true

--- a/docs/dev.yaml
+++ b/docs/dev.yaml
@@ -12,4 +12,10 @@ trace_max_length_bytes: 16000
 num_workers: 4
 num_readers: 1
 interval: 10s
+percentiles:
+  - 0.50
+  - 0.90
+
 debug: true
+debug_ingested_spans: true
+debug_flushed_metrics: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ tool called `veneur-emit`. Much like veneur itself, you don't need to
 compile it before running either:
 
 ``` sh
- run ./cmd/veneur-emit/main.go -ssf -hostport unix:///tmp/veneur.sock -trace_id 999 -parent_span_id 9999 -name hi.there -span_service veneur_ssf_investigation -debug -command /usr/bin/true
+go run ./cmd/veneur-emit/main.go -ssf -hostport unix:///tmp/veneur.sock -trace_id 999 -parent_span_id 9999 -name hi.there -span_service veneur_ssf_investigation -debug -command /usr/bin/true
  ```
 
 This will time the command `/usr/bin/true` and submit an SSF span

--- a/example.yaml
+++ b/example.yaml
@@ -176,6 +176,16 @@ read_buffer_size_bytes: 2097152
 # Sets the log level to DEBUG
 debug: true
 
+# Log (at level DEBUG) information about every ingested span. Be
+# careful with this setting in a real deployment - it is extremely
+# verbose.
+debug_ingested_spans: false
+
+# Log (at level DEBUG) information about every batch of flushed
+# metrics. Be careful with this setting in a real deployment - it is
+# extremely verbose.
+debug_flushed_metrics: false
+
 # runtime.SetMutexProfileFraction
 # The fraction of mutex contention events that are reported in the mutex profile.
 # On average, 1/n events are reported, so higher numbers will sample fewer events.

--- a/server.go
+++ b/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/sinks/datadog"
+	"github.com/stripe/veneur/sinks/debug"
 	"github.com/stripe/veneur/sinks/falconer"
 	"github.com/stripe/veneur/sinks/kafka"
 	"github.com/stripe/veneur/sinks/lightstep"
@@ -457,6 +458,16 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			logger.Info("Configured Kafka span sink")
 		} else {
 			logger.Warn("Kafka span sink skipped due to missing span topic")
+		}
+	}
+
+	{
+		mtx := sync.Mutex{}
+		if conf.DebugFlushedMetrics {
+			ret.metricSinks = append(ret.metricSinks, debug.NewDebugMetricSink(&mtx, log))
+		}
+		if conf.DebugIngestedSpans {
+			ret.spanSinks = append(ret.spanSinks, debug.NewDebugSpanSink(&mtx, log))
 		}
 	}
 

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -1,0 +1,121 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+type debugMetricSink struct {
+	log *logrus.Logger
+	mtx *sync.Mutex
+}
+
+var _ sinks.MetricSink = &debugMetricSink{}
+
+func NewDebugMetricSink(mtx *sync.Mutex, log *logrus.Logger) sinks.MetricSink {
+	return &debugMetricSink{log, mtx}
+}
+
+func (b *debugMetricSink) Name() string {
+	return "blackhole"
+}
+
+func (b *debugMetricSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (b *debugMetricSink) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
+	if len(metrics) == 0 || b.log.Level < logrus.DebugLevel {
+		return nil
+	}
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	b.log.Debugf("Flushing %d metrics:", len(metrics))
+	for _, m := range metrics {
+		var msg = ""
+		if m.Message != "" {
+			msg = fmt.Sprintf("m:%q", m.Message)
+		}
+		b.log.Debugf("  %s: %s(%v) = %f%s", m.Type, m.Name, m.Tags, m.Value, msg)
+	}
+	return nil
+}
+
+func (b *debugMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
+	if len(samples) == 0 || b.log.Level < logrus.DebugLevel {
+		return
+	}
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	b.log.Debugf("Flushing %d other samples:", len(samples))
+	for _, m := range samples {
+		var msg = ""
+		if m.Message != "" {
+			msg = fmt.Sprintf("m:%q", m.Message)
+		}
+		// TODO: more information about events
+		b.log.Debugf("  %s: %s(%v) = %f%s", m.Metric.String(), m.Name, m.Tags, m.Value, msg)
+	}
+	return
+}
+
+type debugSpanSink struct {
+	log *logrus.Logger
+	mtx *sync.Mutex
+}
+
+var _ sinks.SpanSink = &debugSpanSink{}
+
+func NewDebugSpanSink(mtx *sync.Mutex, log *logrus.Logger) sinks.SpanSink {
+	return &debugSpanSink{log, mtx}
+}
+
+func (b *debugSpanSink) Name() string {
+	return "debug"
+}
+
+// Start performs final adjustments on the sink.
+func (b *debugSpanSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (b *debugSpanSink) Ingest(span *ssf.SSFSpan) error {
+	if b.log.Level < logrus.DebugLevel {
+		return nil
+	}
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	info := ""
+	if span.Indicator {
+		info = info + "I"
+	}
+	if span.Error {
+		info = info + "E"
+	}
+	if len(info) > 0 {
+		info = " (" + info + ")"
+	}
+	duration := time.Duration(span.EndTimestamp - span.StartTimestamp)
+	b.log.Debugf("Span %s:%s(%v) %x/%x/%x %v+%v%s (m:%d)",
+		span.Service, span.Name, span.Tags,
+		span.TraceId, span.ParentId, span.Id,
+		span.StartTimestamp, duration,
+		info, len(span.Metrics),
+	)
+	return nil
+}
+
+func (b *debugSpanSink) Flush() {
+	return
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds some things to improve the ergonomics of local development:

* Adjusts the `docs/dev.yaml` file so running it on macOS works
* Fixes docs
* Adds a `debug` span & metrics sink that logs all the information about received spans & flushed metrics.

#### Motivation
I was working on a veneur-emit PR and was annoyed that I have to tcpdump to see it work.

#### Test plan
Ran in dev (and saw it log); tests pass.

#### Rollout/monitoring/revert plan
Just merge.