### PR TITLE
Add sets to veneur-emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Two new options, `debug_ingested_spans` and `debug_flushed_metrics` make veneur log (at level DEBUG) information about the metrics and spans it processes. Thanks, [antifuchs](https://github.com/antifuchs)!
+* `veneur-emit` now takes a new option `-set` with a string argument, which allows counting how many unique values were reported in veneur's flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Bugfixes
 * When creating timer metrics from indicator spans, veneur no longer prefixes `indicator_span_timer_name` with the string `veneur.`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -17,6 +17,8 @@ Full usage:
 
 ```
 Usage of veneur-emit:
+  -command
+        Turns on command-timing mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.
   -count int
         Report a 'count' metric. Value must be an integer.
   -debug
@@ -43,6 +45,8 @@ Usage of veneur-emit:
         Report a 'gauge' metric. Value must be float64.
   -hostport string
         Address of destination (hostport or listening address URL).
+  -indicator
+        Mark the reported span as an indicator span
   -mode string
         Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'. (default "metric")
   -name string
@@ -61,8 +65,14 @@ Usage of veneur-emit:
         Tag(s) for service check, comma separated. Ex: 'service:airflow,host_type:qa'
   -sc_time string
         Add timestamp to check. Default is current Unix epoch timestamp.
-  -command
-        Turns on timeCommand mode. veneur-emit will grab everything after the first non-known-flag argument, time its execution, and report it as a timing metric.
+  -set string
+        Report a 'set' metric with an arbitrary string value.
+  -span_endtime string
+        Date/time to set for the end of the span. Format is same as -span_starttime.
+  -span_service string
+        Service name to associate with the span. (default "veneur-emit")
+  -span_starttime string
+        Date/time to set for the start of the span. See https://github.com/araddon/dateparse#extended-example for formatting.
   -ssf
         Sends packets via SSF instead of StatsD. (https://github.com/stripe/veneur/blob/master/ssf/)
   -tag string
@@ -103,6 +113,12 @@ Submit an event in dogstatsd mode (this isn't supported in SSF yet):
 
 ``` sh
 veneur-emit -hostport udp://127.0.0.1:8200 -e_text "Something went wrong:\\n\\nTell a lie, it's all good." -e_title "I'm just testing" -e_source_type "demonstration"
+```
+
+Submit a "set" metric (the count of unique values across a time interval):
+
+``` sh
+veneur-emit -hostport udp://127.0.0.1:8200 -name some.set.metric -set customer_a
 ```
 
 ## SSF mode

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -110,6 +110,18 @@ func TestTiming(t *testing.T) {
 	assert.Equal(t, float32(3.0), span.Metrics[0].Value)
 }
 
+func TestSet(t *testing.T) {
+	testFlag := make(map[string]flag.Value)
+	testFlag["set"] = newValue("farts")
+	span := &ssf.SSFSpan{}
+	_, err := createMetric(span, testFlag, "testMetric", "")
+	assert.NoError(t, err)
+	assert.Len(t, span.Metrics, 1)
+	assert.Equal(t, ssf.SSFSample_SET, span.Metrics[0].Metric)
+	assert.Equal(t, "testMetric", span.Metrics[0].Name)
+	assert.Equal(t, "farts", span.Metrics[0].Message)
+}
+
 func TestMultiple(t *testing.T) {
 	testFlag := make(map[string]flag.Value)
 	testFlag["gauge"] = newValue("3")


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adds a `-set` option to veneur-emit, which lets users record "set" metrics on the command line.

#### Motivation
It was missing (and @gkk-stripe asked!)

#### Test plan
I wrote a unit test for this, but ultimately it is super tied to #498, since I tested it with this (:

#### Rollout/monitoring/revert plan

Merge & roll it to our systems.