### PR TITLE
Fix prometheus histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ## Bugfixes
 * When creating timer metrics from indicator spans, veneur no longer prefixes `indicator_span_timer_name` with the string `veneur.`. Thanks, [antifuchs](https://github.com/antifuchs)!
+* `veneur-prometheus` now exports Histograms properly, with a statsd tag for each bucket
 
 ## Updated
 * Metric sampler parse function now looks for `veneurlocalonly` and `veneurglobalonly` by prefix instead of direct equality for times where value can't/shouldn't be excluded even if it's blank. Thanks [joeybloggs](https://github.com/joeybloggs)
+* `veneur-prometheus` now exports a tag for each quartile rather than a seperate metric
 
 # 6.0.0
 

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -110,15 +110,16 @@ func collect(c *statsd.Client, ignoredLabels []*regexp.Regexp, ignoredMetrics []
 				name := mf.GetName()
 				data := summary.GetSummary()
 				c.Gauge(fmt.Sprintf("%s.sum", name), data.GetSampleSum(), tags, 1.0)
-				c.Gauge(fmt.Sprintf("%s.count", name), float64(data.GetSampleCount()), tags, 1.0)
+				c.Count(fmt.Sprintf("%s.count", name), int64(data.GetSampleCount()), tags, 1.0)
+				metricCount += 2 // One for sum, one for count, one for each percentile bucket
+
 				for _, quantile := range data.GetQuantile() {
 					v := quantile.GetValue()
 					if !math.IsNaN(v) {
-						t := append(tags, fmt.Sprintf("%dpercentile", int(quantile.GetQuantile()*100)))
-						c.Gauge(name, v, t, 1.0)
+						c.Gauge(fmt.Sprintf("%s.%dpercentile", name, int(quantile.GetQuantile()*100)), v, tags, 1.0)
+						metricCount++
 					}
 				}
-				metricCount += 3 // One for sum, one for count, one for bucketed summary
 			}
 		case dto.MetricType_HISTOGRAM:
 			for _, histo := range mf.GetMetric() {
@@ -126,15 +127,16 @@ func collect(c *statsd.Client, ignoredLabels []*regexp.Regexp, ignoredMetrics []
 				name := mf.GetName()
 				data := histo.GetHistogram()
 				c.Gauge(fmt.Sprintf("%s.sum", name), data.GetSampleSum(), tags, 1.0)
-				c.Gauge(fmt.Sprintf("%s.count", name), float64(data.GetSampleCount()), tags, 1.0)
+				c.Count(fmt.Sprintf("%s.count", name), int64(data.GetSampleCount()), tags, 1.0)
+				metricCount += 2 // One for sum, one for count, one for each histo bucket
+
 				for _, bucket := range data.GetBucket() {
 					b := bucket.GetUpperBound()
 					if !math.IsNaN(b) {
-						t := append(tags, fmt.Sprintf("le%f", b))
-						c.Count(name, int64(bucket.GetCumulativeCount()), t, 1.0)
+						c.Count(fmt.Sprintf("%s.le%f", name, b), int64(bucket.GetCumulativeCount()), tags, 1.0)
+						metricCount++
 					}
 				}
-				metricCount += 3 // One for sum, one for count, one for bucketed histogram
 			}
 		default:
 			c.Count("veneur.prometheus.unknown_metric_type_total", 1, nil, 1.0)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR fixes a bug that causes histograms to not work in `veneur-prometheus`. Rather than calling `GetSummary` for both Histograms and Summaries, this calls `GetHistogram` for histograms. 

To be consistent with the SignalFX and DataDog scrapers (https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html?highlight=events and https://github.com/DataDog/dd-agent/blob/master/checks/prometheus_mixins.py#L483 respectively) this exports a tag per each histogram bucket and changes the summary scraper to do the same. 

r? @cory-stripe 
#### Motivation
Bugfix

#### Test plan
I'm not sure what the best way of testing this is. I can try and write unit tests, but the others for `veneur-prometheus` are relatively sparse.

#### Rollout/monitoring/revert plan
N/a