### PR TITLE
Sample service check OK statuses on flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 7.0.0, in progress
 
+## Added
+* Veneur can be set to flush steady OK values for service checks only once per configurable time interval. Veneur will still emit non-OK values and changes to OK from other values. Thanks, [antifuchs][antifuchs]!
+
+[antifuchs]: https://github.com/antifuchs
+
 # 6.0.0, 2018-06-28
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Via an optional [magic tag](#magic-tag) Veneur will forward counters to a global
 
 To clarify how each metric type behaves in Veneur, please use the following:
 * Counters: Locally accrued, flushed to sinks (see [magic tags](#magic-tag) for global version)
-* Gauges: Locally accrued, flushed to sinks  (see [magic tags](#magic-tag) for global version)
+* Gauges: Locally accrued, flushed to sinks (see [magic tags](#magic-tag) for global version)
+* Status Checks: Locally accrued, flushed to sinks (see [magic tags](#magic-tag) for global version)
 * Histograms: Locally accrued, count, max and min flushed to sinks, percentiles forwarded to `forward_address` for global aggregation when set.
 * Timers: Locally accrued, count, max and min flushed to sinks, percentiles forwarded to `forward_address` for global aggregation when set.
 * Sets: Locally accrued, forwarded to `forward_address` for sinks aggregation when set.
@@ -131,6 +132,12 @@ To clarify how each metric type behaves in Veneur, please use the following:
 ## Expiration
 
 Veneur expires all metrics on each flush. If a metric is no longer being sent (or is sent sparsely) Veneur will not send it as zeros! This was chosen because the combination of the approximation's features and the additional hysteresis imposed by *retaining* these approximations over time was deemed more complex than desirable.
+
+## Status Checks
+
+Also known as "service checks" in datadog parlance, these special samples indicate the current status of a service, identified by the check name and its tags. As your infrastructure will ideally have a lot of service checks returning OK, you can limit the amount of data points transferred for each service check that remains at OK, but still send every data point for checks that have a non-OK status (or change status from non-OK to OK).
+
+Configure the [configuration setting](#configuration) `ok_check_status_interval` to tell veneur that it should only report unchanged OK status checks once in this inverval.
 
 ## Other Notes
 

--- a/config.go
+++ b/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	NumReaders                   int       `yaml:"num_readers"`
 	NumSpanWorkers               int       `yaml:"num_span_workers"`
 	NumWorkers                   int       `yaml:"num_workers"`
+	OkCheckStatusInterval        string    `yaml:"ok_check_status_interval"`
 	OmitEmptyHostname            bool      `yaml:"omit_empty_hostname"`
 	Percentiles                  []float64 `yaml:"percentiles"`
 	ReadBufferSizeBytes          int       `yaml:"read_buffer_size_bytes"`

--- a/example.yaml
+++ b/example.yaml
@@ -49,7 +49,7 @@ forward_use_grpc: false
 # series data.
 interval: "10s"
 
-# Veneur can "sychronize" it's flushes with the system clock, flushing at even
+# Veneur can "sychronize" its flushes with the system clock, flushing at even
 # intervals i.e. 0, 10, 20… to align with the `interval`. This is disabled by
 # default for now, as it can cause thundering herds in large installations.
 synchronize_with_interval: false
@@ -115,6 +115,13 @@ aggregates:
  - "min"
  - "max"
  - "count"
+
+# Report OK service check states only once in this interval (veneur
+# will still report as soon as a non-OK state turns OK), effectively
+# sampling on output. If this interval is set to "", veneur will not
+# sample OK check statuses and report them upstream whenever it
+# receives them in a flush interval.
+ok_check_status_interval: "5min"
 
 # == DEPRECATED ==
 

--- a/flusher.go
+++ b/flusher.go
@@ -192,6 +192,7 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 	defer span.ClientFinish(s.TraceClient)
 
 	finalMetrics := make([]samplers.InterMetric, 0, ms.totalLength)
+	s.checkStates.MaybeReset(time.Now())
 	for _, wm := range tempMetrics {
 		for _, c := range wm.counters {
 			finalMetrics = append(finalMetrics, c.Flush(s.interval)...)
@@ -223,7 +224,7 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 		}
 
 		for _, status := range wm.localStatusChecks {
-			finalMetrics = append(finalMetrics, status.Flush()...)
+			finalMetrics = append(finalMetrics, status.Flush(s.checkStates)...)
 		}
 
 		// TODO (aditya) refactor this out so we don't

--- a/samplers/checks.go
+++ b/samplers/checks.go
@@ -1,0 +1,67 @@
+package samplers
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/segmentio/fasthash/fnv1a"
+)
+
+// CheckStates holds the statuses of all status checks that the veneur
+// has received, if a retention time for these checks is configured.
+type CheckStates struct {
+	// statuses maps from one (UDPMetric-like) digest value for a
+	// status check to its success status.
+	statuses map[uint32]float64
+	resetAt  time.Time
+	validFor time.Duration
+}
+
+func NewCheckStatusTracker(validFor time.Duration) *CheckStates {
+	return &CheckStates{
+		statuses: make(map[uint32]float64),
+		resetAt:  time.Now().Add(validFor),
+		validFor: validFor,
+	}
+}
+
+func (c *CheckStates) ShouldRecord(status *StatusCheck) bool {
+	if c == nil {
+		return true
+	}
+
+	// Construct a MetricKey to use for computing the digest:
+	tags := make([]string, len(status.Tags))
+	for i, t := range status.Tags {
+		tags[i] = t
+	}
+	sort.Strings(tags)
+	digest := fnv1a.Init32
+	digest = fnv1a.AddString32(digest, status.Name)
+	digest = fnv1a.AddString32(digest, "status")
+	digest = fnv1a.AddString32(digest, strings.Join(tags, ","))
+
+	// Decide what to do with the check result, depending on its
+	// current and previous value. We always report a non-positive
+	// current result, or one that differs from the previous
+	// result.
+	last, ok := c.statuses[digest]
+	c.statuses[digest] = status.Value
+	if !ok || last != status.Value || status.Value != 0 {
+		return true
+	}
+	return false
+}
+
+// MaybeReset resets the check status if it has become invalid. It is
+// not concurrency-safe.
+func (c *CheckStates) MaybeReset(now time.Time) {
+	if c == nil {
+		return
+	}
+	if c.resetAt.Before(now) {
+		c.statuses = make(map[uint32]float64)
+		c.resetAt = now.Add(c.validFor)
+	}
+}

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -316,7 +316,10 @@ func (s *StatusCheck) Sample(sample float64, sampleRate float32, message string,
 }
 
 // Flush generates an InterMetric from the current state of this status check.
-func (s *StatusCheck) Flush() []InterMetric {
+func (s *StatusCheck) Flush(overall *CheckStates) []InterMetric {
+	if !overall.ShouldRecord(s) {
+		return []InterMetric{}
+	}
 	s.Timestamp = time.Now().Unix()
 	s.Type = StatusMetric
 	s.Sinks = routeInfo(s.Tags)

--- a/server.go
+++ b/server.go
@@ -119,6 +119,7 @@ type Server struct {
 	enableProfiling bool
 
 	HistogramAggregates samplers.HistogramAggregates
+	checkStates         *samplers.CheckStates
 
 	spanSinks   []sinks.SpanSink
 	metricSinks []sinks.MetricSink
@@ -173,6 +174,14 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	ret.interval, err = conf.ParseInterval()
 	if err != nil {
 		return ret, err
+	}
+
+	if conf.OkCheckStatusInterval != "" {
+		interval, err := time.ParseDuration(conf.OkCheckStatusInterval)
+		if err != nil {
+			return ret, err
+		}
+		ret.checkStates = samplers.NewCheckStatusTracker(interval)
 	}
 
 	transport := &http.Transport{


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adjusts veneur's flush behavior for service checks to have a configurable interval in which only one (unchanged) OK value will be emitted. As soon as the value is no longer OK, or the value turns OK from a non-OK value, veneur will emit it again.

#### Motivation

This should help with immense numbers of data points for service checks that are effectively always successful. What we care about are the services that are not ok, and their associated drama!


#### Test plan
Wrote a unit test, but would like to roll this to a portion of our infra first.


#### Rollout/monitoring/revert plan
1. Merge
2. Adjust our config file (a `5min` interval should be ok & reduce our current DPM to 1/5 what we have)
3. Roll it out!