### PR TITLE
Add global and span-specific tags to veneur-emit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ before_script:
   - go install github.com/gogo/protobuf/protoc-gen-gofast
   - go get -u github.com/golang/dep/cmd/dep
   - go get -u golang.org/x/tools/cmd/stringer
+  - pushd $GOPATH/src/golang.org/x/tools/cmd/stringer
+  - git checkout 25101aadb97aa42907eee6a238d6d26a6cb3c756
+  - go install
+  - popd
 
   - go generate
   # We need to ignore changes to this one file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 7.0.0, in progress
 
+## Added
+* `veneur-emit` now takes a new option `-span_tags` for tags that should be applied only to spans. This allows span-specific tags that are not applied to other emitted values. Thanks [gphat](https://github.com/gphat)!
+* `veneur-emit`'s `-tag` flag now applies the supplied tags to any value emitted, be it a span, metric, service check or event. Use other, mode specific flags (e.g. span_tags) to add tags only to those modes. Thanks [gphat](https://github.com/gphat)!
+
 # 6.0.0, 2018-06-28
 
 ## Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN go install github.com/gogo/protobuf/protoc-gen-gofast
 WORKDIR /go
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u -v golang.org/x/tools/cmd/stringer
+WORKDIR /go/src/golang.org/x/tools/cmd/stringer
+RUN git checkout d11f6ec946130207fd66b479a9a6def585b5110b
+RUN go install
+WORKDIR /go
 RUN wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip
 RUN unzip protoc-3.1.0-linux-x86_64.zip
 RUN cp bin/protoc /usr/bin/protoc

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -283,6 +283,8 @@ func tagsFromString(csv string) map[string]string {
 		if len(elem) == 0 {
 			continue
 		}
+		// Use SplitN here so we don't mess up on
+		// values with colons inside them
 		tag := strings.SplitN(elem, ":", 2)
 		switch len(tag) {
 		case 2:

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -69,7 +69,7 @@ var (
 	spanEnd   = flag.String("span_endtime", "", "Date/time to set for the end of the span. Format is same as -span_starttime.")
 	service   = flag.String("span_service", "veneur-emit", "Service name to associate with the span.")
 	indicator = flag.Bool("indicator", false, "Mark the reported span as an indicator span")
-	sTag      = flag.String("span_tags", "", "Tag(s) for span, comma separated. Ex 'service:airflow,host_type:qa'")
+	sTag      = flag.String("span_tags", "", "Tag(s) for span, comma separated. Useful for avoiding high cardinality tags. Ex 'user_id:ac0b23,widget_id:284802'")
 )
 
 type EmitMode uint

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -189,7 +189,7 @@ func TestNilHostport(t *testing.T) {
 func TestTags(t *testing.T) {
 	testTag := "tag1,tag2,tag3,,tag4:value"
 	expectedOutput := map[string]string{"tag1": "", "tag2": "", "tag3": "", "tag4": "value"}
-	output := ssfTags(testTag)
+	output := tagsFromString(testTag)
 	assert.Equal(t, expectedOutput, output)
 }
 
@@ -278,18 +278,20 @@ func (tb *testBackend) FlushSync(ctx context.Context) error {
 }
 
 func TestSetupSpanWithTracing(t *testing.T) {
-	span, err := setupSpan(proto.Int64(1), proto.Int64(2), "oink", "hi:there")
+	span, err := setupSpan(proto.Int64(1), proto.Int64(2), "oink", "hi:there", "foo:bar")
 	if assert.NoError(t, err) {
 		assert.NotZero(t, span.Id)
 		assert.Equal(t, int64(1), span.TraceId)
 		assert.Equal(t, int64(2), span.ParentId)
 		assert.Equal(t, "oink", span.Name)
-		assert.Equal(t, 1, len(span.Tags))
+		assert.Equal(t, 2, len(span.Tags))
+		assert.Equal(t, span.Tags["hi"], "there")
+		assert.Equal(t, span.Tags["foo"], "bar")
 	}
 }
 
 func TestSetupSpanWithoutTracing(t *testing.T) {
-	span, err := setupSpan(nil, nil, "oink", "hi:there")
+	span, err := setupSpan(nil, nil, "oink", "hi:there", "")
 	if assert.NoError(t, err) {
 		assert.Zero(t, span.Id)
 		assert.Zero(t, span.TraceId)

--- a/parser_test.go
+++ b/parser_test.go
@@ -136,6 +136,8 @@ func TestParseSSFValid(t *testing.T) {
 	trace.TraceId = 1
 	trace.StartTimestamp = 1
 	trace.EndTimestamp = 5
+	trace.Tags = map[string]string{}
+	trace.Tags["foo"] = "bar"
 
 	trace.Metrics = make([]*ssf.SSFSample, 0)
 	trace.Metrics = append(trace.Metrics, metric)
@@ -153,6 +155,7 @@ func TestParseSSFValid(t *testing.T) {
 			assert.Equal(t, metric.Name, m.Name, "Name")
 			assert.Equal(t, float64(metric.Value), m.Value, "Value")
 			assert.Equal(t, "counter", m.Type, "Type")
+			assert.NotContains(t, m.Tags, "foo", "Metric should not inherit tags from its parent span")
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Adds span-specific tags and formalizes that the `tag` flag applies to all emitted things.

#### Motivation
One of our users is emitting spans who's metrics are leaking into metrics. This is normally fine, but the tags are very high cardinality. Since there's no way to limit a tag to a span, we have no way to satisfy their need for span-tags that don't leak into metrics.

This adds that! While I'm here it also makes `tag` apply to service checks and events so that things are consistent.

#### Test plan
Tests included

#### Rollout/monitoring/revert plan
Merge!

r? @asf-stripe 