### PR TITLE
Removing stripe name from default S3bucket

### DIFF
--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -71,7 +71,8 @@ const (
 	tsvGzFt          = "tsv.gz"
 )
 
-var S3Bucket = "stripe-veneur"
+// S3Bucket name of S3 bucket to post to
+var S3Bucket string
 
 var S3ClientUninitializedError = errors.New("s3 client has not been initialized")
 

--- a/server.go
+++ b/server.go
@@ -477,30 +477,32 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	var svc s3iface.S3API
 	awsID := conf.AwsAccessKeyID
 	awsSecret := conf.AwsSecretAccessKey
+	if conf.AwsS3Bucket != "" {
+		if len(awsID) > 0 && len(awsSecret) > 0 {
+			sess, err := session.NewSession(&aws.Config{
+				Region:      aws.String(conf.AwsRegion),
+				Credentials: credentials.NewStaticCredentials(awsID, awsSecret, ""),
+			})
 
-	if len(awsID) > 0 && len(awsSecret) > 0 {
-		sess, err := session.NewSession(&aws.Config{
-			Region:      aws.String(conf.AwsRegion),
-			Credentials: credentials.NewStaticCredentials(awsID, awsSecret, ""),
-		})
-
-		if err != nil {
-			logger.Infof("error getting AWS session: %s", err)
-			svc = nil
-		} else {
-			logger.Info("Successfully created AWS session")
-			svc = s3.New(sess)
-
-			plugin := &s3p.S3Plugin{
-				Logger:   log,
-				Svc:      svc,
-				S3Bucket: conf.AwsS3Bucket,
-				Hostname: ret.Hostname,
+			if err != nil {
+				logger.Infof("error getting AWS session: %s", err)
+				svc = nil
+			} else {
+				logger.Info("Successfully created AWS session")
+				svc = s3.New(sess)
+				plugin := &s3p.S3Plugin{
+					Logger:   log,
+					Svc:      svc,
+					S3Bucket: conf.AwsS3Bucket,
+					Hostname: ret.Hostname,
+				}
+				ret.registerPlugin(plugin)
 			}
-			ret.registerPlugin(plugin)
+		} else {
+			logger.Info("AWS credentials not found")
 		}
 	} else {
-		logger.Info("AWS credentials not found")
+		logger.Info("AWS S3 bucket not set. Skipping S3 Plugin initialization.")
 	}
 
 	if svc == nil {


### PR DESCRIPTION
#### Summary
Removed the default "stripe-veneur" from the s3 bucket configuration.

#### Motivation
Veneur is OSS and this is a nonsensical configuration for anyone outside of Stripe. 

#### Test plan
I tested locally. 

#### Rollout/monitoring/revert plan
If you use the S3Bucket sink you'll need to explicitly configure the s3 bucket with `aws_s3_bucket`. 