### PR TITLE
Fix veneur-prometheus crash when metrics host is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * `veneur-emit` now takes a new option `-span_tags` for tags that should be applied only to spans. This allows span-specific tags that are not applied to other emitted values. Thanks [gphat](https://github.com/gphat)!
 * `veneur-emit`'s `-tag` flag now applies the supplied tags to any value emitted, be it a span, metric, service check or event. Use other, mode specific flags (e.g. span_tags) to add tags only to those modes. Thanks [gphat](https://github.com/gphat)!
 
+## Bugfixes
+* `veneur-prometheus` no longer crashes when the metrics host is unreachable. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
+
 # 6.0.0, 2018-06-28
 
 ## Added

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -72,7 +72,12 @@ func collect(c *statsd.Client, ignoredLabels []*regexp.Regexp, ignoredMetrics []
 		"ignored_metrics": ignoredMetrics,
 	}).Debug("Beginning collection")
 
-	resp, _ := http.Get(*metricsHost)
+	resp, err := http.Get(*metricsHost)
+	if err != nil {
+		logrus.WithError(err).WithField("metrics_host", *metricsHost).Warn(fmt.Sprintf("Failed to collect metrics"))
+		return
+	}
+
 	d := expfmt.NewDecoder(resp.Body, expfmt.FmtText)
 	var mf dto.MetricFamily
 	for {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
When the metrics host for veneur-prometheus is unavailable or unreachable, the process crashes with the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x63a7ff]

goroutine 1 [running]:
main.collect(0xc42011a000)
    /go/src/github.com/stripe/veneur/cmd/veneur-prometheus/main.go:56 +0x22f
main.main()
    /go/src/github.com/stripe/veneur/cmd/veneur-prometheus/main.go:41 +0xf1
```

In this PR, error handling has been added for the `http.Get()` call that collects metrics.

#### Motivation
Veneur-prometheus shouldn't crash if metric collection fails.

We might want to consider emitting a metric as well, so this type of failure can be monitored. I'm hesitant to introduce a new metric here, but not sure if `veneur.prometheus.decode_errors_total` covers this type of error. I'm open to suggestions... 😄 


#### Test plan
Before applying this patch, running `go build && ./veneur-prometheus` without having a webserver running on `localhost:9090` will crash the process after a few seconds.

After applying this patch, running `go build && ./veneur-prometheus` without having a webserver running on `localhost:9090` will emit the following logs after a few seconds:

```
WARN[0010] Failed to collect metrics                     error="Get http://localhost:9090/metrics: dial tcp [::1]:9090: connect: connection refused" metrics_host="http://localhost:9090/metrics"
WARN[0020] Failed to collect metrics                     error="Get http://localhost:9090/metrics: dial tcp [::1]:9090: connect: connection refused" metrics_host="http://localhost:9090/metrics"
```
