### PR TITLE
Passing trace context to signalfx

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -294,6 +294,8 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 	defer span.ClientFinish(s.TraceClient)
 	jmLength := 0
 	for _, wm := range wms {
+		jmLength += len(wm.globalCounters)
+		jmLength += len(wm.globalGauges)
 		jmLength += len(wm.histograms)
 		jmLength += len(wm.sets)
 		jmLength += len(wm.timers)

--- a/flusher.go
+++ b/flusher.go
@@ -368,7 +368,7 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 		}
 	}
 	s.Statsd.TimeInMilliseconds("forward.duration_ns", float64(time.Since(exportStart).Nanoseconds()), []string{"part:export"}, 1.0)
-	s.Statsd.Gauge("forward.post_metrics_total", float64(len(jsonMetrics)), nil, 1.0)
+	s.Statsd.Count("forward.post_metrics_total", int64(len(jsonMetrics)), nil, 1.0)
 	if len(jsonMetrics) == 0 {
 		log.Debug("Nothing to forward, skipping.")
 		return

--- a/proxy.go
+++ b/proxy.go
@@ -496,7 +496,7 @@ func (p *Proxy) doPost(ctx context.Context, wg *sync.WaitGroup, destination stri
 		}).Warn("Failed to POST metrics to destination")
 	}
 	samples.Add(ssf.RandomlySample(0.1,
-		ssf.Gauge("metrics_by_destination", float32(batchSize), map[string]string{"destination": destination}),
+		ssf.Count("metrics_by_destination", float32(batchSize), map[string]string{"destination": destination}),
 	)...)
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -360,13 +360,9 @@ func (p *Proxy) RefreshDestinations(serviceName string, ring *consistent.Consist
 		return
 	}
 
-	// At the last moment, lock the mutex and defer so we unlock after setting.
-	// We do this after we've fetched info so we don't hold the lock during long
-	// queries, timeouts or errors. The flusher can lock the mutex and prevent us
-	// from updating at the same time.
 	mtx.Lock()
-	defer mtx.Unlock()
 	ring.Set(destinations)
+	mtx.Unlock()
 	samples.Add(ssf.Gauge("discoverer.destination_number", float32(len(destinations)), srvTags))
 }
 


### PR DESCRIPTION
#### Summary

* Preallocating buffers for global metrics
* Using child contexts for more accurate grouping of trace spans
* Minimizing contention in destination refresh for forwarding metrics
* Switching forwarding batch (sent and received) metrics from gauge to counter for accurate representation of batches.

#### Motivation
Attempting to get better visibility out of veneur-proxy forwarding process.

#### Test plan
No additional tests required. Will deploy to a subset in QA for tests when ready. 

#### Rollout/monitoring/revert plan
After deployment traces in the SignalFx sink will be reordered to reflect parent child span processes. 
