### PR TITLE
Adding metrics to report bytes of metrics proxied

### DIFF
--- a/handlers_global.go
+++ b/handlers_global.go
@@ -154,6 +154,7 @@ func unmarshalMetricsFromHTTP(ctx context.Context, client *trace.Client, w http.
 		span.Add(ssf.Count("import.request_error_total", 1, map[string]string{"cause": "unknown_content_encoding"}))
 		return span, nil, err
 	}
+	span.Add(ssf.Count("import.bytes", float32(r.ContentLength), nil))
 
 	if err = json.NewDecoder(body).Decode(&jsonMetrics); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/http/http.go
+++ b/http/http.go
@@ -196,7 +196,7 @@ func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, 
 	// Len reports the unread length, so we have to record this before the
 	// http client consumes it
 	bodyLength := bodyBuffer.Len()
-	span.Add(ssf.Histogram(action+".content_length_bytes", float32(bodyLength), nil))
+	span.Add(ssf.Count(action+".content_length_bytes", float32(bodyLength), nil))
 
 	req, err := http.NewRequest(method, endpoint, &bodyBuffer)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
#### Summary
Adding metrics of bytes rcvd and bytes sent through the veneur-proxy. 


#### Motivation
Add metrics to understand the work done by the veneur-proxy. 

#### Test plan
They're just added metrics. This is pretty low risk. 

#### Rollout/monitoring/revert plan
Standard deployment.

r? @sdboyer-stripe 