### PR TITLE
WIP Removing random sampling of proxy byte and import count metrics

### DIFF
--- a/handlers_global.go
+++ b/handlers_global.go
@@ -154,7 +154,7 @@ func unmarshalMetricsFromHTTP(ctx context.Context, client *trace.Client, w http.
 		span.Add(ssf.Count("import.request_error_total", 1, map[string]string{"cause": "unknown_content_encoding"}))
 		return span, nil, err
 	}
-	span.Add(ssf.Count("import.bytes", float32(r.ContentLength), nil))
+	span.Add(ssf.Count("import.bytes", float32(r.ContentLength), map[string]string{"encoding": encoding}))
 
 	if err = json.NewDecoder(body).Decode(&jsonMetrics); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/proxy.go
+++ b/proxy.go
@@ -440,12 +440,7 @@ func (p *Proxy) ProxyMetrics(ctx context.Context, jsonMetrics []samplers.JSONMet
 		defer cancel()
 	}
 	metricCount := len(jsonMetrics)
-	span.Add(ssf.RandomlySample(0.1,
-		ssf.Count("import.metrics_total", float32(metricCount), map[string]string{
-			"remote_addr":      origin,
-			"veneurglobalonly": "",
-		}),
-	)...)
+	span.Add(ssf.Count("import.metrics_total", float32(metricCount), map[string]string{"veneurglobalonly": ""}))
 
 	jsonMetricsByDestination := make(map[string][]samplers.JSONMetric)
 	for _, h := range p.ForwardDestinations.Members() {
@@ -467,10 +462,9 @@ func (p *Proxy) ProxyMetrics(ctx context.Context, jsonMetrics []samplers.JSONMet
 	wg.Wait() // Wait for all the above goroutines to complete
 	log.WithField("count", metricCount).Info("Completed forward")
 
-	span.Add(ssf.RandomlySample(0.1,
+	span.Add(
 		ssf.Timing("proxy.duration_ns", time.Since(span.Start), time.Nanosecond, nil),
-		ssf.Count("proxy.proxied_metrics_total", float32(len(jsonMetrics)), nil),
-	)...)
+		ssf.Count("proxy.proxied_metrics_total", float32(len(jsonMetrics)), nil))
 }
 
 func (p *Proxy) doPost(ctx context.Context, wg *sync.WaitGroup, destination string, batch []samplers.JSONMetric) {


### PR DESCRIPTION
#### Summary
I'm making a series of changes attempting to get accurate understandable measurements of veneur-proxy performance and scale. 
* removes sampling from ingest count.
* removes the tag dimension of `remote_addr` from the ingest count. 
* add encoding as a dimension of the ingest byte count. 
* removes sampling from proxied metrics count. 

#### Motivation
Improve the metrics around performance in veneur and veneur-proxy. 

#### Test plan
Deployed and observed.

#### Rollout/monitoring/revert plan
Standard deployment. This affects the following metrics so be aware and modify any charts or monitors you may have on these metrics. 
* `proxy.proxied_metrics_total`
* `veneur_proxy.import.metrics_total`
* `veneur_proxy.import.bytes` 

r? @asf-stripe 