### PR TITLE
fix SSF Go link

### DIFF
--- a/ssf/README.md
+++ b/ssf/README.md
@@ -20,7 +20,7 @@ Because we want to:
 * You can send SSF as UDP packets to Veneur's `ssf_listen_addresses`.
 * Veneur can also read SSF as a [wire protocol](https://github.com/stripe/veneur/blob/master/protocol/wire.go) over connection protocols such as TCP or UNIX domain sockets
 * You can use the CLI tool [veneur-emit](https://github.com/stripe/veneur/tree/master/cmd/veneur-emit).
-* You can use an SSF trace client in [Go](github.com/stripe/veneur/trace) or [Ruby](https://github.com/stripe/ssf-ruby).
+* You can use an SSF trace client in [Go](https://github.com/stripe/veneur/tree/master/trace) or [Ruby](https://github.com/stripe/ssf-ruby).
 
 # Philosophy
 


### PR DESCRIPTION
#### Summary
The link in the SSF README was broken, this PR fixes it.
