### PR TITLE
Allow configuration of various transport properties for Proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 * Isolated a potential resource starvation issue. Added new configuration options for `veneur-proxy` that configure it's [http.Transport](https://golang.org/pkg/net/http/#Transport):
   * `idle_connection_timeout` for controlling how long connections may idle before timing out, corresponds to `IdleConnTimeout`
   * `max_idle_conns` for controlling the maximum number of idle connections in total
-  * `max_idle_conns_per_host` for controlling the maximum number of idle connections per host
+  * `max_idle_conns_per_host` for controlling the maximum number of idle connections per host. Not that this now defaults to `100` for safety!
 
 ## Bugfixes
 * `veneur-prometheus` no longer crashes when the metrics host is unreachable. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!
+
+## Removals
+* `veneur-proxy` now only logs forward counts at Debug level, drastically reducing log volume.
 
 # 6.0.0, 2018-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Added
 * `veneur-emit` now takes a new option `-span_tags` for tags that should be applied only to spans. This allows span-specific tags that are not applied to other emitted values. Thanks [gphat](https://github.com/gphat)!
 * `veneur-emit`'s `-tag` flag now applies the supplied tags to any value emitted, be it a span, metric, service check or event. Use other, mode specific flags (e.g. span_tags) to add tags only to those modes. Thanks [gphat](https://github.com/gphat)!
+* Isolated a potential resource starvation issue. Added new configuration options for `veneur-proxy` that configure it's [http.Transport](https://golang.org/pkg/net/http/#Transport):
+  * `idle_connection_timeout` for controlling how long connections may idle before timing out, corresponds to `IdleConnTimeout`
+  * `max_idle_conns` for controlling the maximum number of idle connections in total
+  * `max_idle_conns_per_host` for controlling the maximum number of idle connections per host
 
 ## Bugfixes
 * `veneur-prometheus` no longer crashes when the metrics host is unreachable. Thanks, [arjenvanderende](https://github.com/arjenvanderende)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * The `StartSpan` method on `tracer.Tracer` will default to the provided `operationName` if provided. This function is provided for compatibility with OpenTracing, but the package-level `trace.StartSpanFromContext` function is recommended for new users.
 * When creating timer metrics from indicator spans, veneur no longer prefixes `indicator_span_timer_name` with the string `veneur.`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * `veneur-prometheus` now exports Histograms properly, with a statsd tag for each bucket
+* Environment config for `veneur-proxy` now uses `VENEUR_PROXY_` as a prefix. Previously used `VENEUR_` which was a bug!
 
 ## Updated
 * Metric sampler parse function now looks for `veneurlocalonly` and `veneurglobalonly` by prefix instead of direct equality for times where value can't/shouldn't be excluded even if it's blank. Thanks [joeybloggs](https://github.com/joeybloggs)

--- a/config_parse.go
+++ b/config_parse.go
@@ -43,7 +43,7 @@ func readProxyConfig(r io.Reader) (ProxyConfig, error) {
 		}
 	}
 
-	err = envconfig.Process("veneur", &c)
+	err = envconfig.Process("veneur_proxy", &c)
 	if err != nil {
 		return c, err
 	}

--- a/config_parse.go
+++ b/config_parse.go
@@ -20,6 +20,10 @@ var defaultConfig = Config{
 	SpanChannelCapacity:    100,
 }
 
+var defaultProxyConfig = ProxyConfig{
+	MaxIdleConnsPerHost: 100,
+}
+
 // ReadProxyConfig unmarshals the proxy config file and slurps in its data.
 func ReadProxyConfig(path string) (c ProxyConfig, err error) {
 	f, err := os.Open(path)
@@ -27,7 +31,22 @@ func ReadProxyConfig(path string) (c ProxyConfig, err error) {
 		return c, err
 	}
 	defer f.Close()
-	return readProxyConfig(f)
+	c, err = readProxyConfig(f)
+	c.applyDefaults()
+	return
+}
+
+func (c *ProxyConfig) applyDefaults() {
+	if c.MaxIdleConnsPerHost == 0 {
+		// It's dangerous to leave this as the default. Since veneur-proxy is
+		// designed for HA environments with lots of globalstats backends we
+		// need higher defaults lest we have too small a connection pool and cause
+		// a glut of TIME_WAIT connections, so set a default.
+		log.WithField(
+			"new value", defaultProxyConfig.MaxIdleConnsPerHost,
+		).Warn("max_idle_conns_per_host being unset may lead to unsafe operations, defaulting!")
+		c.MaxIdleConnsPerHost = defaultProxyConfig.MaxIdleConnsPerHost
+	}
 }
 
 func readProxyConfig(r io.Reader) (ProxyConfig, error) {

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -9,6 +9,9 @@ type ProxyConfig struct {
 	ForwardAddress           string `yaml:"forward_address"`
 	ForwardTimeout           string `yaml:"forward_timeout"`
 	HTTPAddress              string `yaml:"http_address"`
+	IdleConnectionTimeout    string `yaml:"idle_connection_timeout"`
+	MaxIdleConns             int    `yaml:"max_idle_conns"`
+	MaxIdleConnsPerHost      int    `yaml:"max_idle_conns_per_host"`
 	RuntimeMetricsInterval   string `yaml:"runtime_metrics_interval"`
 	SentryDsn                string `yaml:"sentry_dsn"`
 	SsfDestinationAddress    string `yaml:"ssf_destination_address"`

--- a/config_test.go
+++ b/config_test.go
@@ -104,6 +104,17 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, c, expectedConfig, "Should have applied all config defaults")
 }
 
+func TestProxyConfigDefaults(t *testing.T) {
+	const emptyConfig = "---"
+	r := strings.NewReader(emptyConfig)
+	c, err := readProxyConfig(r)
+	assert.Nil(t, err, "Should parsed empty config file: %s", emptyConfig)
+
+	expectedConfig := defaultProxyConfig
+	c.applyDefaults()
+	assert.Equal(t, c, expectedConfig, "Should have applied all config defaults")
+}
+
 func TestVeneurExamples(t *testing.T) {
 	tests := []string{
 		"example.yaml",

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -28,6 +28,17 @@ consul_forward_service_name: "forwardServiceName"
 # within this time.
 forward_timeout: 10s
 
+# Maximum idle time per host, correspends to Go's Transport.IdleConnTimeout
+idle_connection_timeout: 90s
+
+# Maximum number of idle connections across all host, corresponds to Go's
+# Transport.MaxIdleConns
+max_idle_conns: 100
+
+# Maximum number of idle connections per-host, corresponds to Go's
+# Transport.MaxIdleConnsPerHost
+max_idle_conns_per_host: 100
+
 ### TRACING
 # The address on which we will listen for trace data
 trace_address: "127.0.0.1:8128"

--- a/proxy.go
+++ b/proxy.go
@@ -81,19 +81,21 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 
 	p.HTTPAddr = conf.HTTPAddress
 
+	var idleTimeout time.Duration
+	if conf.IdleConnectionTimeout != "" {
+		idleTimeout, err = time.ParseDuration(conf.IdleConnectionTimeout)
+		if err != nil {
+			return p, err
+		}
+	}
 	transport := &http.Transport{
+		IdleConnTimeout: idleTimeout,
 		// Each of these properties DTRT (according to Go docs) when supplied with
 		// zero values as of Go 0.10.3
 		MaxIdleConns:        conf.MaxIdleConns,
 		MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
 	}
-	if conf.IdleConnectionTimeout != "" {
-		idleTimeout, err := time.ParseDuration(conf.IdleConnectionTimeout)
-		if err != nil {
-			return p, err
-		}
-		transport.IdleConnTimeout = idleTimeout
-	}
+
 	p.HTTPClient = &http.Client{
 		Transport: transport,
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -80,14 +80,17 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 	})
 
 	p.HTTPAddr = conf.HTTPAddress
-	idleTimeout, err := time.ParseDuration(conf.IdleConnectionTimeout)
-	if err != nil {
-		return p, err
-	}
+
 	transport := &http.Transport{
-		IdleConnTimeout:     idleTimeout,
 		MaxIdleConns:        conf.MaxIdleConns,
 		MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
+	}
+	if conf.IdleConnectionTimeout != "" {
+		idleTimeout, err := time.ParseDuration(conf.IdleConnectionTimeout)
+		if err != nil {
+			return p, err
+		}
+		transport.IdleConnTimeout = idleTimeout
 	}
 	p.HTTPClient = &http.Client{
 		Transport: transport,

--- a/proxy.go
+++ b/proxy.go
@@ -80,8 +80,18 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 	})
 
 	p.HTTPAddr = conf.HTTPAddress
-	// TODO Timeout?
-	p.HTTPClient = &http.Client{}
+	idleTimeout, err := time.ParseDuration(conf.IdleConnectionTimeout)
+	if err != nil {
+		return p, err
+	}
+	transport := &http.Transport{
+		IdleConnTimeout:     idleTimeout,
+		MaxIdleConns:        conf.MaxIdleConns,
+		MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
+	}
+	p.HTTPClient = &http.Client{
+		Transport: transport,
+	}
 
 	p.enableProfiling = conf.EnableProfiling
 

--- a/proxy.go
+++ b/proxy.go
@@ -82,6 +82,8 @@ func NewProxyFromConfig(logger *logrus.Logger, conf ProxyConfig) (p Proxy, err e
 	p.HTTPAddr = conf.HTTPAddress
 
 	transport := &http.Transport{
+		// Each of these properties DTRT (according to Go docs) when supplied with
+		// zero values as of Go 0.10.3
 		MaxIdleConns:        conf.MaxIdleConns,
 		MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
 	}

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -262,7 +262,7 @@ func (s *Server) sendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) 
 		res = errs
 	} else {
 		// otherwise just print a success message
-		log.Info("Completed forwarding to downstream Veneurs")
+		log.Debug("Completed forwarding to downstream Veneurs")
 	}
 
 	return res


### PR DESCRIPTION
#### Summary
veneur-proxy does not change the default options for the `http.Transport`, which can cause issues for some deployments.

#### Motivation
Specifically, this PR is aimed at allowing the configuration of the `MaxIdleConnsPerHost` parameter which defaults to `2` in Go. This means that in a very busy proxy setup the service will frequently create > 2 connection to a globalstats for forwarding. All the connections that exceed this value will then be left in a `TIME_WAIT` state — as they are no longer in the connection pool and not reused — which may result in starvation of ephemeral ports.

This situation is believed to have occurred 3 times at Stripe in the last year.

#### Other Changes

* Default the `MaxIdleConnsPerHost` to 100 for safety
* Fixed a bug that environment variables for veneur proxy were in the form of `VENEUR_$VAR` instead of `VENEUR_PROXY_$VAR`
* Stopped logging so much from veneur proxy by moving it's "Completed forward" to debug level

#### Test plan
I am unsure if I can test these settings, since the `RoundTripper` type becomes opaque after the `HTTPClient` is set.

The deserialization of config is not necessary to test.

#### Rollout/monitoring/revert plan
Will verify this in QA once master works again with some configured options. The expected outcome is drastically lower counts of `TIME_WAIT` connections to globalstats on proxy boxes, counted via `netstat -n | grep 8200 | grep TIME_WAIT | wc -l`

r? @asf-stripe 
