### PR TITLE
veneur-emit: Validate args for missing dashes

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -541,6 +541,16 @@ func validateFlagCombinations(passedFlags map[string]flag.Value) {
 			logrus.Fatalf("Flag %q is only valid with \"-mode %s\"", flagname, fmode)
 		}
 	}
+
+	// Sniff for args that were missing a dash.
+	for _, arg := range flag.Args() {
+		if fmode, has := flagModeMappings[arg]; has && (fmode&mode) == mode {
+			if _, has := passedFlags[arg]; !has {
+				logrus.Fatalf("Passed %q as an argument, but it's a parameter name. Did you mean \"-%s\"?", arg, arg)
+			}
+		}
+	}
+
 }
 
 func buildEventPacket(passedFlags map[string]flag.Value) (bytes.Buffer, error) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Checks that arguments passed to `veneur-emit` aren't actually parameters just missing a leading `-`. If they are, warn and exit. 

#### Motivation
<!-- Why are you making this change? -->

Silent failure on these typos is too hard to differentiate from success.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

CLI poking

r? @cory-stripe