### PR TITLE
Clean up some flakes

### DIFF
--- a/forward_grpc_test.go
+++ b/forward_grpc_test.go
@@ -35,6 +35,7 @@ func newForwardGRPCFixture(t testing.TB, localConfig Config, sink sinks.MetricSi
 	go func() {
 		global.Serve()
 	}()
+	waitForHTTPStart(t, global, 3*time.Second)
 
 	// Create a proxy Veneur
 	proxyCfg := generateProxyConfig()
@@ -42,10 +43,11 @@ func newForwardGRPCFixture(t testing.TB, localConfig Config, sink sinks.MetricSi
 	proxyCfg.GrpcAddress = unusedLocalTCPAddress(t)
 	proxyCfg.ConsulForwardServiceName = ""
 	proxy, err := NewProxyFromConfig(logrus.New(), proxyCfg)
+	assert.NoError(t, err)
 	go func() {
 		proxy.Serve()
 	}()
-	assert.NoError(t, err)
+	waitForHTTPStart(t, &proxy, 3*time.Second)
 
 	localConfig.ForwardAddress = proxyCfg.GrpcAddress
 	localConfig.ForwardUseGrpc = true

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -258,8 +258,8 @@ func (s *Server) sendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) 
 		for _, err := range errs {
 			err.reportMetrics(span)
 		}
-		log.WithError(res).Error("Proxying failed")
 		res = errs
+		log.WithError(res).Error("Proxying failed")
 	} else {
 		// otherwise just print a success message
 		log.Debug("Completed forwarding to downstream Veneurs")

--- a/server.go
+++ b/server.go
@@ -1066,6 +1066,7 @@ func (s *Server) HTTPServe() {
 	// when *not* running under einhorn.
 	graceful.AddSignal(syscall.SIGUSR2, syscall.SIGHUP)
 	graceful.HandleSignals()
+	gracefulSocket := graceful.WrapListener(httpSocket)
 	log.WithField("address", s.HTTPAddr).Info("HTTP server listening")
 
 	// Signal that the HTTP server is starting
@@ -1073,7 +1074,7 @@ func (s *Server) HTTPServe() {
 	defer atomic.AddInt32(s.numListeningHTTP, -1)
 	bind.Ready()
 
-	if err := graceful.Serve(httpSocket, s.Handler()); err != nil {
+	if err := http.Serve(gracefulSocket, s.Handler()); err != nil {
 		log.WithError(err).Error("HTTP server shut down due to error")
 	}
 	log.Info("Stopped HTTP server")

--- a/server_test.go
+++ b/server_test.go
@@ -1322,7 +1322,7 @@ type testHTTPStarter interface {
 
 // waitForHTTPStart blocks until the Server's HTTP server is started, or until
 // the specified duration is elapsed.
-func waitForHTTPStart(t *testing.T, s testHTTPStarter, timeout time.Duration) {
+func waitForHTTPStart(t testing.TB, s testHTTPStarter, timeout time.Duration) {
 	tickCh := time.Tick(10 * time.Millisecond)
 	timeoutCh := time.After(timeout)
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Clean up a couple of flaky tests in the grpc proxying implementation. still wip, will assign when ready

this one fails on jenkins but apparently not on travis. maybe we need to stub out the default trace client? in travis, nothing would be listening on that port, but in jenkins, there is a veneur listening to the default trace client

```
18:08:58 === RUN   TestProxyServeStopHTTP
18:08:58 time="2018-08-07T18:08:51Z" level=info msg="Using consul for service discovery" consulForwardService=forwardServiceName consulGRPCForwardService= consulTraceService=traceServiceName
18:08:58 time="2018-08-07T18:08:51Z" level=info msg="Will use Consul for service discovery" interval=86400s
18:08:58 time="2018-08-07T18:08:51Z" level=info msg="Starting gRPC server" address="127.0.0.1:0"
18:08:58 time="2018-08-07T18:08:51Z" level=info msg="HTTP server listening" address="127.0.0.1:0"
18:08:58 time="2018-08-07T18:08:51Z" level=info msg="Stopped HTTP server"
18:08:58 2018/08/07 18:08:52 LightStep instrumentation error (rpc error: code = Unavailable desc = all SubConns are in TransientFailure). Set the Verbose option to enable more logging.
18:08:58 --- FAIL: TestProxyServeStopHTTP (3.01s)
18:08:58 	assertions.go:247: 
                          
	Error Trace:	proxy_test.go:285
18:08:58 		
	Error:      	Stopping the Proxy over HTTP did not stop both listeners
18:08:58 		
	Test:       	TestProxyServeStopHTTP
```

and this one fails on travis but not yet on jenkins. it's a transient grpc connection problem of some kind.

```
=== RUN   TestE2EForwardingGRPCMetrics
time="2018-08-07T18:12:56Z" level=info msg="Set mutex profile fraction" MutexProfileFraction=0 previousMutexProfileFraction=0
time="2018-08-07T18:12:56Z" level=info msg="Set block profile rate (nanoseconds)" BlockProfileRate=0
time="2018-08-07T18:12:56Z" level=info msg="Preparing workers" number=4
time="2018-08-07T18:12:56Z" level=info msg="AWS S3 bucket not set. Skipping S3 Plugin initialization."
time="2018-08-07T18:12:56Z" level=info msg="S3 archives are disabled"
time="2018-08-07T18:12:56Z" level=debug msg="Initialized server" config="{[min max count] REDACTED   REDACTED 0  REDACTED 1024 0  true false false false   0  false 127.0.0.1:39465 localhost localhost:0  50ms    0  0    0 0  0  0    REDACTED  0 0  4096 0 1 2 4 false [0.5 0.75 0.99] 2097152 REDACTED REDACTED   []  0 0 [udp://127.0.0.1:0] localhost:8125 [udp://localhost:0] false [] []   REDACTED   0 0  4096}"
time="2018-08-07T18:12:56Z" level=info msg="Starting server" version=dirty
time="2018-08-07T18:12:56Z" level=info msg="Starting span workers" n=2
time="2018-08-07T18:12:56Z" level=info msg="Starting span sink" sink=metric_extraction
time="2018-08-07T18:12:56Z" level=info msg="Starting span sink" sink=blackhole
time="2018-08-07T18:12:56Z" level=info msg="Starting metric sink" sink=channel
time="2018-08-07T18:12:56Z" level=info msg="Listening on UDP address" address="127.0.0.1:47005" listeners=1 protocol=statsd
time="2018-08-07T18:12:56Z" level=info msg="Listening on UDP address" address="127.0.0.1:55556" listeners=1 protocol=ssf
time="2018-08-07T18:12:56Z" level=info msg="Listening for SSF traces" address="127.0.0.1:55556" network=udp
time="2018-08-07T18:12:56Z" level=info msg="Using consul for service discovery" consulForwardService= consulGRPCForwardService= consulTraceService=traceServiceName
time="2018-08-07T18:12:56Z" level=info msg="Will use Consul for service discovery" interval=86400s
time="2018-08-07T18:12:56Z" level=info msg="Starting gRPC server" address="127.0.0.1:39465"
time="2018-08-07T18:12:56Z" level=info msg="HTTP server listening" address="localhost:0"
time="2018-08-07T18:12:56Z" level=info msg="Starting gRPC server" address="127.0.0.1:45107"
time="2018-08-07T18:12:56Z" level=info msg="HTTP server listening" address="127.0.0.1:0"
time="2018-08-07T18:12:56Z" level=info msg="Set mutex profile fraction" MutexProfileFraction=0 previousMutexProfileFraction=0
time="2018-08-07T18:12:56Z" level=info msg="Set block profile rate (nanoseconds)" BlockProfileRate=0
time="2018-08-07T18:12:56Z" level=info msg="Preparing workers" number=4
time="2018-08-07T18:12:56Z" level=info msg="Starting Event worker"
time="2018-08-07T18:12:56Z" level=info msg="AWS S3 bucket not set. Skipping S3 Plugin initialization."
time="2018-08-07T18:12:56Z" level=info msg="S3 archives are disabled"
time="2018-08-07T18:12:56Z" level=debug msg="Initialized server" config="{[min max count] REDACTED   REDACTED 0  REDACTED 1024 0  true false false false   0 127.0.0.1:45107 true localhost:0 localhost localhost:0  50ms    0  0    0 0  0  0    REDACTED  0 0  4096 0 1 2 4 false [0.5 0.75 0.99] 2097152 REDACTED REDACTED   []  0 0 [udp://127.0.0.1:0] localhost:8125 [udp://localhost:0] false [] []   REDACTED   0 0  4096}"
time="2018-08-07T18:12:56Z" level=info msg="Starting server" version=dirty
time="2018-08-07T18:12:56Z" level=info msg="Starting span workers" n=2
time="2018-08-07T18:12:56Z" level=info msg="Starting span sink" sink=metric_extraction
time="2018-08-07T18:12:56Z" level=info msg="Starting span sink" sink=blackhole
time="2018-08-07T18:12:56Z" level=info msg="Starting metric sink" sink=blackhole
time="2018-08-07T18:12:56Z" level=info msg="Starting Event worker"
time="2018-08-07T18:12:56Z" level=info msg="Listening on UDP address" address="127.0.0.1:38433" listeners=1 protocol=statsd
time="2018-08-07T18:12:56Z" level=info msg="Listening on UDP address" address="127.0.0.1:59140" listeners=1 protocol=ssf
time="2018-08-07T18:12:56Z" level=info msg="Listening for SSF traces" address="127.0.0.1:59140" network=udp
time="2018-08-07T18:12:56Z" level=info msg="Completed forward to an upstream Veneur" destination="127.0.0.1:45107" grpcstate=READY metrics=5 protocol=grpc
time="2018-08-07T18:12:56Z" level=error msg="Proxying failed" duration="666.38µs" error="failed to forward to the host '127.0.0.1:39465' (cause=forward, metrics=5): failed to send 5 metrics over gRPC: rpc error: code = Unavailable desc = all SubConns are in TransientFailure" protocol=grpc
time="2018-08-07T18:12:59Z" level=info msg="Shutting down server gracefully"
time="2018-08-07T18:12:59Z" level=info msg="Stopped gRPC server" address="127.0.0.1:45107"
time="2018-08-07T18:12:59Z" level=info msg="Shutting down server gracefully"
time="2018-08-07T18:12:59Z" level=info msg="Shutting down server gracefully"
--- FAIL: TestE2EForwardingGRPCMetrics (3.04s)
    forward_grpc_test.go:201: Timed out waiting for a metric after 3 seconds
```

#### Motivation
<!-- Why are you making this change? -->
flakes are bad yo

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
rerun automated tests ad infinitum

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
none required