### PR TITLE
Add trace id to grpc request headers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -848,6 +848,7 @@
     "golang.org/x/sys/unix",
     "google.golang.org/grpc",
     "google.golang.org/grpc/connectivity",
+    "google.golang.org/grpc/metadata",
     "google.golang.org/grpc/status",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",

--- a/sinks/grpsink/grpsink.go
+++ b/sinks/grpsink/grpsink.go
@@ -2,6 +2,7 @@ package grpsink
 
 import (
 	"context"
+	"strconv"
 	"sync/atomic"
 
 	ocontext "golang.org/x/net/context"
@@ -15,6 +16,7 @@ import (
 	"github.com/stripe/veneur/trace/metrics"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -101,7 +103,8 @@ func (gs *GRPCSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		return err
 	}
 
-	_, err := gs.ssc.SendSpan(ocontext.Background(), ssfSpan)
+	ctx := metadata.AppendToOutgoingContext(ocontext.Background(), "x-veneur-trace-id", strconv.FormatInt(ssfSpan.TraceId, 16))
+	_, err := gs.ssc.SendSpan(ctx, ssfSpan)
 
 	if err != nil {
 		atomic.AddUint32(&gs.dropCount, 1)


### PR DESCRIPTION

#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
When sending spans over gRPC, include the trace ID in a header. Bikeshedding welcome on the header name (`x-veneur-trace-id`). Maybe should be flagged behind a config option?

cc @stripe/observability 

#### Motivation
<!-- Why are you making this change? -->
Useful for consistent hash load balancers, which can inspect the header but can't decode a protobuf request body.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
fiddled in qa and wiresharked it

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
as normal