### PR TITLE
Make proxy.metrics_by_destination a counter

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -649,7 +649,7 @@ func (p *Proxy) doPost(ctx context.Context, wg *sync.WaitGroup, destination stri
 		}).Warn("Failed to POST metrics to destination")
 	}
 	samples.Add(ssf.RandomlySample(0.1,
-		ssf.Count("metrics_by_destination", float32(batchSize), map[string]string{"destination": destination}),
+		ssf.Count("metrics_by_destination", float32(batchSize), map[string]string{"destination": destination, "protocol": "http"}),
 	)...)
 }
 

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -296,8 +296,8 @@ func (s *Server) forward(ctx context.Context, dest string, ms []*metricpb.Metric
 	}
 
 	_ = metrics.ReportBatch(s.opts.traceClient, ssf.RandomlySample(0.1,
-		ssf.Gauge("metrics_by_destination", float32(len(ms)),
-			map[string]string{"destination": dest}),
+		ssf.Count("metrics_by_destination", float32(len(ms)),
+			map[string]string{"destination": dest, "protocol": "grpc"}),
 	))
 
 	return nil


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Fix some of the reporting on `veneur_proxy.metrics_by_destination`. It gets reported on the grpc and http proxying paths, but with different metric types.

r? @aditya-stripe 
cc @stripe/observability 

#### Motivation
<!-- Why are you making this change? -->
split metric type can lead to some weird graphing

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
n/a

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
n/a