### PR TITLE
Add sink for sending spans to Splunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * Metrics can be forwarded over gRPC using veneur-proxy (and Consul).  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
 * Added tracer.InjectHeader convenience function for... convenience! Thanks, [mikeh](https://github.com/mikeh-stripe)!
+* Veneur has a new sink that can be configured to send spans as events into a [Splunk HEC](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) endpoint. Thanks, [antifuchs](https://github.com/antifuchs) and [aditya](https://github.com/chimeracoder)!
 
 ## Removals
 * Go 1.9 is no longer supported.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,12 +445,12 @@
   revision = "e181e095bae94582363434144c61a9653aff6e50"
 
 [[projects]]
-  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
+  branch = "master"
+  digest = "1:8737b20e873c7cad069dfafd6382659b4cdf9e80359cdc159b8ec464893c932e"
   name = "github.com/satori/go.uuid"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,6 +128,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:31c2969530015c039d7f33400368f54d37d4f4dbdf95baabd0c89857a3cacb5b"
+  name = "github.com/fuyufjh/splunk-hec-go"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3e5842a6937536b4f7221bc797f35500b1fa0ff7"
+
+[[projects]]
+  branch = "master"
   digest = "1:d0bf01f4719fd005c2c19f805f539c52c3c50ce44a9639ef4b53b93240574893"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
@@ -435,6 +443,14 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "e181e095bae94582363434144c61a9653aff6e50"
+
+[[projects]]
+  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -816,6 +832,7 @@
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/s3/s3iface",
     "github.com/axiomhq/hyperloglog",
+    "github.com/fuyufjh/splunk-hec-go",
     "github.com/getsentry/raven-go",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -118,6 +118,10 @@
   branch = "master"
   name = "github.com/fuyufjh/splunk-hec-go"
 
+[[override]]
+  branch = "master"
+  name = "github.com/satori/go.uuid"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,8 +114,11 @@
   branch = "master"
   name = "github.com/segmentio/fasthash"
 
+[[constraint]]
+  branch = "master"
+  name = "github.com/fuyufjh/splunk-hec-go"
+
 [prune]
   go-tests = true
   unused-packages = true
   non-go = true
-

--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
+	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string `yaml:"ssf_listen_addresses"`

--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
+	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`

--- a/config.go
+++ b/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	} `yaml:"signalfx_per_tag_api_keys"`
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
+	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
+	SplunkHecToken                string   `yaml:"splunk_hec_token"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string   `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -349,6 +349,14 @@ kafka_retry_max: 0
 
 falconer_address: "falconer.service.consul"
 
+# == Splunk ==
+#
+# Veneur can feed spans to splunk through the HEC interface
+# (http://dev.splunk.com/view/event-collector/SP-CAAAE6M)
+
+splunk_hec_address: "https://localhost:8088"
+splunk_hec_token: "00000000-0000-0000-0000-000000000000"
+
 # == PLUGINS ==
 
 # == S3 Output ==

--- a/example.yaml
+++ b/example.yaml
@@ -351,11 +351,20 @@ falconer_address: "falconer.service.consul"
 
 # == Splunk ==
 #
-# Veneur can feed spans to splunk through the HEC interface
-# (http://dev.splunk.com/view/event-collector/SP-CAAAE6M)
+# Veneur can feed spans to splunk through the HTTP Event Consumer
+# (HEC) interface
+# See also http://dev.splunk.com/view/event-collector/SP-CAAAE6M
 
+# The URL to use for a connection to the splunk
 splunk_hec_address: "https://localhost:8088"
+
+# The authentication token veneur will use to authenticate to the HEC
 splunk_hec_token: "00000000-0000-0000-0000-000000000000"
+
+# (optional) server name set on the TLS configuration. This is useful
+# if the host you're reaching identifies with a different name than on
+# the URL.
+splunk_hec_tls_validate_hostname: "some-other-hostname"
 
 # == PLUGINS ==
 

--- a/example.yaml
+++ b/example.yaml
@@ -366,6 +366,11 @@ splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 # the URL.
 splunk_hec_tls_validate_hostname: "some-other-hostname"
 
+# (optional) The maximum amount of time to wait before timing out
+# sending a span to the Splunk HEC. If omitted / set to 0, sending
+# spans happens without a timeout.
+splunk_hec_send_timeout: "10ms"
+
 # == PLUGINS ==
 
 # == S3 Output ==

--- a/server.go
+++ b/server.go
@@ -416,7 +416,14 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log)
+			var timeout time.Duration
+			if conf.SplunkHecSendTimeout != "" {
+				timeout, err = time.ParseDuration(conf.SplunkHecSendTimeout)
+				if err != nil {
+					return ret, err
+				}
+			}
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, timeout)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stripe/veneur/sinks/kafka"
 	"github.com/stripe/veneur/sinks/lightstep"
 	"github.com/stripe/veneur/sinks/signalfx"
+	"github.com/stripe/veneur/sinks/splunk"
 	"github.com/stripe/veneur/sinks/ssfmetrics"
 	"github.com/stripe/veneur/ssf"
 	"github.com/stripe/veneur/trace"
@@ -410,8 +411,15 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			logger.Info("Configured Lightstep trace sink")
 		}
 
-		if conf.SplunkAccessToken != "" {
-			sss := splunk.SplunkSpanSink{}
+		if (conf.SplunkHecToken != "" && conf.SplunkHecAddress == "") ||
+			(conf.SplunkHecToken == "" && conf.SplunkHecAddress != "") {
+			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
+		}
+		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken)
+			if err != nil {
+				return ret, err
+			}
 
 			ret.spanSinks = append(ret.spanSinks, sss)
 		}

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, conf.Hostname, log)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -410,6 +410,12 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			logger.Info("Configured Lightstep trace sink")
 		}
 
+		if conf.SplunkAccessToken != "" {
+			sss := splunk.SplunkSpanSink{}
+
+			ret.spanSinks = append(ret.spanSinks, sss)
+		}
+
 		if conf.FalconerAddress != "" {
 			falsink, err := falconer.NewSpanSink(context.Background(), conf.FalconerAddress, log, grpc.WithInsecure())
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, conf.Hostname)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, conf.Hostname, log)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, ret.Hostname)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, ret.Hostname)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.SplunkHecTLSValidateHostname, conf.Hostname)
 			if err != nil {
 				return ret, err
 			}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -137,8 +137,11 @@ func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) 
 	if err != nil {
 		atomic.AddUint32(&sss.dropCount, 1)
 
-		// TODO: get rid of this, it'll get suuuper chunderous:
-		sss.log.WithError(err).Error("Couldn't flush span to HEC")
+		if ctx.Err() == nil {
+			// We're not interested in deadline-exceeded, but also
+			// TODO: get rid of this, it'll get suuuper chunderous:
+			sss.log.WithError(err).Error("Couldn't flush span to HEC")
+		}
 	} else {
 		atomic.AddUint32(&sss.sentCount, 1)
 	}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -45,7 +45,7 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 		client.SetHTTPClient(httpC)
 	}
 
-	return &splunkSpanSink{Client: client, hostname: localHostname}, nil
+	return &splunkSpanSink{Client: client, hostname: localHostname, log: log}, nil
 }
 
 func (sss *splunkSpanSink) Start(cl *trace.Client) error {

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -17,15 +17,21 @@ type splunkSpanSink struct {
 	*hec.Client
 }
 
-func NewSplunkSpanSink(server string, token string) (sinks.SpanSink, error) {
+// NewSplunkSpanSink constructs a new splunk span sink from the server
+// name and token provided. A third argument, validateServerName is
+// used (if non-empty) to instruct go to validate a different hostname
+// than the one on the server URL.
+func NewSplunkSpanSink(server string, token string, validateServerName string) (sinks.SpanSink, error) {
 	client := hec.NewClient(server, token).(*hec.Client)
 
-	tlsCfg := &tls.Config{}
-	tlsCfg.InsecureSkipVerify = true // TODO: make the CA cert and host names configurable
+	if validateServerName != "" {
+		tlsCfg := &tls.Config{}
+		tlsCfg.ServerName = validateServerName
 
-	trnsp := &http.Transport{TLSClientConfig: tlsCfg}
-	httpC := &http.Client{Transport: trnsp}
-	client.SetHTTPClient(httpC)
+		trnsp := &http.Transport{TLSClientConfig: tlsCfg}
+		httpC := &http.Client{Transport: trnsp}
+		client.SetHTTPClient(httpC)
+	}
 
 	return &splunkSpanSink{Client: client}, nil
 }

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -92,10 +92,11 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	return sss.writeSpan(ctx, ssfSpan)
 }
 
-// Splunk can't handle int64s, and we don't
-// want to round our traceID to the thousands place.
-// This is mildly redundant, but oh well
-type serializedSSF struct {
+// SerializedSSF holds a set of fields in a format that Splunk can
+// handle (it can't handle int64s, and we don't want to round our
+// traceID to the thousands place).  This is mildly redundant, but oh
+// well.
+type SerializedSSF struct {
 	TraceId        string            `json:"trace_id"`
 	Id             string            `json:"id"`
 	ParentId       string            `json:"parent_id"`
@@ -109,7 +110,7 @@ type serializedSSF struct {
 }
 
 func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) error {
-	serialized := serializedSSF{
+	serialized := SerializedSSF{
 		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 10),
 		Id:             strconv.FormatInt(ssfSpan.Id, 10),
 		ParentId:       strconv.FormatInt(ssfSpan.ParentId, 10),

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -1,14 +1,54 @@
 package splunk
 
-type SplunkSpanSink struct {
+import (
+	"context"
+	"time"
+
+	hec "github.com/fuyufjh/splunk-hec-go"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+type splunkSpanSink struct {
+	*hec.Client
 }
 
-// Name rutrns this sink's name
-func (SplunkSpanSink) Name() string {
+func NewSplunkSpanSink(server string, token string) (sinks.SpanSink, error) {
+	client := hec.NewClient(server, token)
+	return &splunkSpanSink{Client: client.(*hec.Client)}, nil
+}
+
+func (*splunkSpanSink) Start(*trace.Client) error {
+	return nil
+}
+
+func (*splunkSpanSink) Flush() {
+	// nothing to do.
+}
+
+// Name returns this sink's name
+func (*splunkSpanSink) Name() string {
 	return "splunk"
 }
 
-// Ingesttakes in a span and passes it to Splunk using the
+// Ingest takes in a span and passes it to Splunk using the
 // HTTP Event Collector
-func (sss *SplunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+	// Fake up a context with a reasonable timeout:
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+
+	return sss.writeSpan(ctx, ssfSpan)
+}
+
+func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) error {
+	return sss.WriteEventWithContext(ctx, &hec.Event{
+		// TODO: We're just serializing the regular SSF span
+		// to JSON; we might want to do some translation to
+		// fields so they look better in splunk (and also
+		// maybe filter out some fields).
+		Event: ssfSpan,
+	})
 }

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -110,20 +110,20 @@ type SerializedSSF struct {
 }
 
 func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) error {
+	start := time.Unix(0, ssfSpan.StartTimestamp)
+	end := time.Unix(0, ssfSpan.EndTimestamp)
 	serialized := SerializedSSF{
 		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 10),
 		Id:             strconv.FormatInt(ssfSpan.Id, 10),
 		ParentId:       strconv.FormatInt(ssfSpan.ParentId, 10),
-		StartTimestamp: time.Unix(0, ssfSpan.StartTimestamp),
-		EndTimestamp:   time.Unix(0, ssfSpan.EndTimestamp),
+		StartTimestamp: start,
+		EndTimestamp:   end,
 		Error:          ssfSpan.Error,
 		Service:        ssfSpan.Service,
 		Tags:           ssfSpan.Tags,
 		Indicator:      ssfSpan.Indicator,
 		Name:           ssfSpan.Name,
 	}
-
-	start := time.Unix(int64((time.Duration(ssfSpan.StartTimestamp) / time.Second)), 0)
 
 	event := &hec.Event{
 		Event: serialized,

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -67,8 +67,8 @@ type serializedSSF struct {
 	TraceId        string            `json:"trace_id"`
 	Id             string            `json:"id"`
 	ParentId       string            `json:"parent_id"`
-	StartTimestamp string            `json:"start_timestamp"`
-	EndTimestamp   string            `json:"end_timestamp"`
+	StartTimestamp time.Time         `json:"start_timestamp"`
+	EndTimestamp   time.Time         `json:"end_timestamp"`
 	Error          bool              `json:"error"`
 	Service        string            `json:"service"`
 	Tags           map[string]string `json:"tags"`
@@ -77,13 +77,12 @@ type serializedSSF struct {
 }
 
 func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) error {
-
 	serialized := serializedSSF{
 		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 10),
 		Id:             strconv.FormatInt(ssfSpan.Id, 10),
 		ParentId:       strconv.FormatInt(ssfSpan.ParentId, 10),
-		StartTimestamp: strconv.FormatInt(ssfSpan.StartTimestamp, 10),
-		EndTimestamp:   strconv.FormatInt(ssfSpan.EndTimestamp, 10),
+		StartTimestamp: time.Unix(0, ssfSpan.StartTimestamp),
+		EndTimestamp:   time.Unix(0, ssfSpan.EndTimestamp),
 		Error:          ssfSpan.Error,
 		Service:        ssfSpan.Service,
 		Tags:           ssfSpan.Tags,

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -24,7 +24,7 @@ func (*splunkSpanSink) Start(*trace.Client) error {
 }
 
 func (*splunkSpanSink) Flush() {
-	// nothing to do.
+	// nothing to do. Eventually, we should submit batches instead.
 }
 
 // Name returns this sink's name

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -95,6 +95,7 @@ func (sss *splunkSpanSink) writeSpan(ctx context.Context, ssfSpan *ssf.SSFSpan) 
 	event := &hec.Event{
 		Event: serialized,
 	}
+	event.SetTime(time.Unix(0, ssfSpan.StartTimestamp))
 
 	event.SetTime(start)
 

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -1,0 +1,14 @@
+package splunk
+
+type SplunkSpanSink struct {
+}
+
+// Name rutrns this sink's name
+func (SplunkSpanSink) Name() string {
+	return "splunk"
+}
+
+// Ingesttakes in a span and passes it to Splunk using the
+// HTTP Event Collector
+func (sss *SplunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+}

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -1,0 +1,98 @@
+package splunk_test
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	hec "github.com/fuyufjh/splunk-hec-go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/sinks/splunk"
+	"github.com/stripe/veneur/ssf"
+)
+
+func jsonEndpoint(t *testing.T, ch chan<- hec.Event) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failed := false
+		input := hec.Event{}
+		j := json.NewDecoder(r.Body)
+		j.DisallowUnknownFields()
+		err := j.Decode(&input)
+		if err != nil {
+			t.Errorf("Decoding JSON: %v", err)
+			failed = true
+		}
+		log.Print(*input.Time)
+
+		if failed {
+			w.WriteHeader(400)
+			w.Write([]byte(`{"text": "Error processing event", "code": 90}`))
+		} else {
+			w.Write([]byte(`{"text":"Success","code":0}`))
+			ch <- input
+		}
+	})
+}
+
+func TestSpanIngest(t *testing.T) {
+	logger := logrus.StandardLogger()
+
+	ch := make(chan hec.Event, 1)
+	ts := httptest.NewServer(jsonEndpoint(t, ch))
+	defer ts.Close()
+	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
+		"test-host", "", logger)
+	require.NoError(t, err)
+
+	start := time.Unix(100000, 1000000)
+	end := start.Add(5 * time.Second)
+	span := &ssf.SSFSpan{
+		ParentId:       4,
+		Id:             5,
+		TraceId:        6,
+		StartTimestamp: start.UnixNano(),
+		EndTimestamp:   end.UnixNano(),
+		Service:        "test-srv",
+		Name:           "test-span",
+		Indicator:      true,
+		Error:          true,
+		Tags: map[string]string{
+			"farts": "mandatory",
+		},
+		Metrics: []*ssf.SSFSample{
+			ssf.Count("some.counter", 1, map[string]string{"purpose": "testing"}),
+			ssf.Gauge("some.gauge", 20, map[string]string{"purpose": "testing"}),
+		},
+	}
+	err = sink.Ingest(span)
+	require.NoError(t, err)
+	event := <-ch
+
+	fakeEvent := hec.Event{}
+	fakeEvent.SetTime(start)
+
+	assert.Equal(t, *fakeEvent.Time, *event.Time)
+	assert.Equal(t, "test-srv", *event.SourceType)
+	assert.Equal(t, "test-host", *event.Host)
+
+	spanB, err := json.Marshal(event.Event)
+	require.NoError(t, err)
+	output := splunk.SerializedSSF{}
+	err = json.Unmarshal(spanB, &output)
+
+	assert.Equal(t, time.Unix(0, span.StartTimestamp), output.StartTimestamp)
+	assert.Equal(t, time.Unix(0, span.EndTimestamp), output.EndTimestamp)
+	assert.Equal(t, strconv.FormatInt(span.Id, 10), output.Id)
+	assert.Equal(t, strconv.FormatInt(span.ParentId, 10), output.ParentId)
+	assert.Equal(t, strconv.FormatInt(span.TraceId, 10), output.TraceId)
+	assert.Equal(t, "test-span", output.Name)
+	assert.Equal(t, map[string]string{"farts": "mandatory"}, output.Tags)
+	assert.Equal(t, true, output.Indicator)
+	assert.Equal(t, true, output.Error)
+}

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -2,7 +2,6 @@ package splunk_test
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -28,7 +27,6 @@ func jsonEndpoint(t *testing.T, ch chan<- hec.Event) http.Handler {
 			t.Errorf("Decoding JSON: %v", err)
 			failed = true
 		}
-		log.Print(*input.Time)
 
 		if failed {
 			w.WriteHeader(400)
@@ -86,8 +84,8 @@ func TestSpanIngest(t *testing.T) {
 	output := splunk.SerializedSSF{}
 	err = json.Unmarshal(spanB, &output)
 
-	assert.Equal(t, time.Unix(0, span.StartTimestamp), output.StartTimestamp)
-	assert.Equal(t, time.Unix(0, span.EndTimestamp), output.EndTimestamp)
+	assert.Equal(t, span.StartTimestamp, output.StartTimestamp.UnixNano())
+	assert.Equal(t, span.EndTimestamp, output.EndTimestamp.UnixNano())
 	assert.Equal(t, strconv.FormatInt(span.Id, 10), output.Id)
 	assert.Equal(t, strconv.FormatInt(span.ParentId, 10), output.ParentId)
 	assert.Equal(t, strconv.FormatInt(span.TraceId, 10), output.TraceId)

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -84,8 +84,9 @@ func TestSpanIngest(t *testing.T) {
 	output := splunk.SerializedSSF{}
 	err = json.Unmarshal(spanB, &output)
 
-	assert.Equal(t, span.StartTimestamp, output.StartTimestamp.UnixNano())
-	assert.Equal(t, span.EndTimestamp, output.EndTimestamp.UnixNano())
+	assert.Equal(t, float64(span.StartTimestamp)/float64(time.Second), output.StartTimestamp)
+	assert.Equal(t, float64(span.EndTimestamp)/float64(time.Second), output.EndTimestamp)
+
 	assert.Equal(t, strconv.FormatInt(span.Id, 10), output.Id)
 	assert.Equal(t, strconv.FormatInt(span.ParentId, 10), output.ParentId)
 	assert.Equal(t, strconv.FormatInt(span.TraceId, 10), output.TraceId)

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -45,7 +45,7 @@ func TestSpanIngest(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger)
+		"test-host", "", logger, time.Duration(0))
 	require.NoError(t, err)
 
 	start := time.Unix(100000, 1000000)

--- a/vendor/github.com/fuyufjh/splunk-hec-go/LICENSE
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/fuyufjh/splunk-hec-go/client.go
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/client.go
@@ -1,0 +1,286 @@
+package hec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/satori/go.uuid"
+)
+
+const (
+	retryWaitTime = 1 * time.Second
+
+	defaultMaxContentLength = 1000000
+)
+
+type Client struct {
+	HEC
+
+	// HTTP Client for communication with (optional)
+	httpClient *http.Client
+
+	// Splunk Server URL for API requests (required)
+	serverURL string
+
+	// HEC Token (required)
+	token string
+
+	// Keep-Alive (optional, default: true)
+	keepAlive bool
+
+	// Channel (required for Raw mode)
+	channel string
+
+	// Max retrying times (optional, default: 2)
+	retries int
+
+	// Max content length (optional, default: 1000000)
+	maxLength int
+}
+
+func NewClient(serverURL string, token string) HEC {
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+	return &Client{
+		httpClient: http.DefaultClient,
+		serverURL:  serverURL,
+		token:      token,
+		keepAlive:  true,
+		channel:    id.String(),
+		retries:    2,
+		maxLength:  defaultMaxContentLength,
+	}
+}
+
+func (hec *Client) SetHTTPClient(client *http.Client) {
+	hec.httpClient = client
+}
+
+func (hec *Client) SetKeepAlive(enable bool) {
+	hec.keepAlive = enable
+}
+
+func (hec *Client) SetChannel(channel string) {
+	hec.channel = channel
+}
+
+func (hec *Client) SetMaxRetry(retries int) {
+	hec.retries = retries
+}
+
+func (hec *Client) SetMaxContentLength(size int) {
+	hec.maxLength = size
+}
+
+func (hec *Client) WriteEventWithContext(ctx context.Context, event *Event) error {
+	if event.empty() {
+		return nil // skip empty events
+	}
+
+	endpoint := "/services/collector?channel=" + hec.channel
+	data, _ := json.Marshal(event)
+
+	if len(data) > hec.maxLength {
+		return ErrEventTooLong
+	}
+	return hec.write(ctx, endpoint, data)
+}
+
+func (hec *Client) WriteEvent(event *Event) error {
+	return hec.WriteEventWithContext(context.Background(), event)
+}
+
+func (hec *Client) WriteBatchWithContext(ctx context.Context, events []*Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	endpoint := "/services/collector?channel=" + hec.channel
+	var buffer bytes.Buffer
+	var tooLongs []int
+
+	for index, event := range events {
+		if event.empty() {
+			continue // skip empty events
+		}
+
+		data, _ := json.Marshal(event)
+		if len(data) > hec.maxLength {
+			tooLongs = append(tooLongs, index)
+			continue
+		}
+		// Send out bytes in buffer immediately if the limit exceeded after adding this event
+		if buffer.Len()+len(data) > hec.maxLength {
+			if err := hec.write(ctx, endpoint, buffer.Bytes()); err != nil {
+				return err
+			}
+			buffer.Reset()
+		}
+		buffer.Write(data)
+	}
+
+	if buffer.Len() > 0 {
+		if err := hec.write(ctx, endpoint, buffer.Bytes()); err != nil {
+			return err
+		}
+	}
+	if len(tooLongs) > 0 {
+		return ErrEventTooLong
+	}
+	return nil
+}
+
+func (hec *Client) WriteBatch(events []*Event) error {
+	return hec.WriteBatchWithContext(context.Background(), events)
+}
+
+type EventMetadata struct {
+	Host       *string
+	Index      *string
+	Source     *string
+	SourceType *string
+	Time       *time.Time
+}
+
+func (hec *Client) WriteRawWithContext(ctx context.Context, reader io.ReadSeeker, metadata *EventMetadata) error {
+	endpoint := rawHecEndpoint(hec.channel, metadata)
+
+	return breakStream(reader, hec.maxLength, func(chunk []byte) error {
+		if err := hec.write(ctx, endpoint, chunk); err != nil {
+			// Ignore NoData error (e.g. "\n\n" will cause NoData error)
+			if res, ok := err.(*Response); !ok || res.Code != StatusNoData {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (hec *Client) WriteRaw(reader io.ReadSeeker, metadata *EventMetadata) error {
+	return hec.WriteRawWithContext(context.Background(), reader, metadata)
+}
+
+// breakStream breaks text from reader into chunks, with every chunk less than max.
+// Unless a single line is longer than max, it always cut at end of lines ("\n")
+func breakStream(reader io.ReadSeeker, max int, callback func(chunk []byte) error) error {
+
+	var buf []byte = make([]byte, max+1)
+	var writeAt int
+	for {
+		n, err := reader.Read(buf[writeAt:max])
+		if n == 0 && err == io.EOF {
+			break
+		}
+
+		// If last line does not end with LF, add one for it
+		if err == io.EOF && buf[writeAt+n-1] != '\n' {
+			n++
+			buf[writeAt+n-1] = '\n'
+		}
+
+		data := buf[0 : writeAt+n]
+
+		// Cut after the last LF character
+		cut := bytes.LastIndexByte(data, '\n') + 1
+		if cut == 0 {
+			// This line is too long, but just let it break here
+			cut = len(data)
+		}
+		if err := callback(buf[:cut]); err != nil {
+			return err
+		}
+
+		writeAt = copy(buf, data[cut:])
+
+		if err != nil && err != io.EOF {
+			return err
+		}
+	}
+
+	if writeAt != 0 {
+		return callback(buf[:writeAt])
+	}
+
+	return nil
+}
+
+func responseFrom(body []byte) *Response {
+	var res Response
+	json.Unmarshal(body, &res)
+	return &res
+}
+
+func (res *Response) Error() string {
+	return res.Text
+}
+
+func (res *Response) String() string {
+	b, _ := json.Marshal(res)
+	return string(b)
+}
+
+func (hec *Client) write(ctx context.Context, endpoint string, data []byte) error {
+	retries := 0
+RETRY:
+	req, err := http.NewRequest(http.MethodPost, hec.serverURL+endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	if hec.keepAlive {
+		req.Header.Set("Connection", "keep-alive")
+	}
+	req.Header.Set("Authorization", "Splunk "+hec.token)
+	res, err := hec.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		response := responseFrom(body)
+		if retriable(response.Code) && retries < hec.retries {
+			retries++
+			time.Sleep(retryWaitTime)
+			goto RETRY
+		}
+		return response
+	}
+	return nil
+}
+
+func rawHecEndpoint(channel string, metadata *EventMetadata) string {
+	var buffer bytes.Buffer
+	buffer.WriteString("/services/collector/raw?channel=" + channel)
+	if metadata == nil {
+		return buffer.String()
+	}
+	if metadata.Host != nil {
+		buffer.WriteString("&host=" + *metadata.Host)
+	}
+	if metadata.Index != nil {
+		buffer.WriteString("&index=" + *metadata.Index)
+	}
+	if metadata.Source != nil {
+		buffer.WriteString("&source=" + *metadata.Source)
+	}
+	if metadata.SourceType != nil {
+		buffer.WriteString("&sourcetype=" + *metadata.SourceType)
+	}
+	if metadata.Time != nil {
+		buffer.WriteString("&time=" + epochTime(metadata.Time))
+	}
+	return buffer.String()
+}

--- a/vendor/github.com/fuyufjh/splunk-hec-go/cluster.go
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/cluster.go
@@ -1,0 +1,138 @@
+package hec
+
+import (
+	"io"
+	"math/rand"
+	"net/http"
+	"sync"
+
+	"github.com/satori/go.uuid"
+)
+
+type Cluster struct {
+	HEC
+
+	// Inner clients
+	clients []*Client
+
+	mtx sync.Mutex
+
+	maxRetries int
+}
+
+func NewCluster(serverURLs []string, token string) HEC {
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+	channel := id.String()
+	clients := make([]*Client, len(serverURLs))
+	for i, serverURL := range serverURLs {
+		clients[i] = &Client{
+			httpClient: http.DefaultClient,
+			serverURL:  serverURL,
+			token:      token,
+			keepAlive:  true,
+			channel:    channel,
+			retries:    0, // try only once for each client
+			maxLength:  defaultMaxContentLength,
+		}
+	}
+	return &Cluster{
+		clients:    clients,
+		maxRetries: -1, // default: try all clients
+	}
+}
+
+func (c *Cluster) SetHTTPClient(httpClient *http.Client) {
+	c.mtx.Lock()
+	for _, client := range c.clients {
+		client.SetHTTPClient(httpClient)
+	}
+	c.mtx.Unlock()
+}
+
+func (c *Cluster) SetKeepAlive(enable bool) {
+	c.mtx.Lock()
+	for _, client := range c.clients {
+		client.SetKeepAlive(enable)
+	}
+	c.mtx.Unlock()
+}
+
+func (c *Cluster) SetChannel(channel string) {
+	c.mtx.Lock()
+	for _, client := range c.clients {
+		client.SetChannel(channel)
+	}
+	c.mtx.Unlock()
+}
+
+func (c *Cluster) SetMaxRetry(retries int) {
+	c.maxRetries = retries
+}
+
+func (c *Cluster) SetMaxContentLength(size int) {
+	c.mtx.Lock()
+	for _, client := range c.clients {
+		client.SetMaxContentLength(size)
+	}
+	c.mtx.Unlock()
+}
+
+func (c *Cluster) WriteEvent(event *Event) error {
+	return c.retry(func(client *Client) error {
+		return client.WriteEvent(event)
+	})
+}
+
+func (c *Cluster) WriteBatch(events []*Event) error {
+	return c.retry(func(client *Client) error {
+		return client.WriteBatch(events)
+	})
+}
+
+func (c *Cluster) WriteRaw(reader io.ReadSeeker, metadata *EventMetadata) error {
+	startAt, _ := reader.Seek(0, io.SeekCurrent)
+	return c.retry(func(client *Client) error {
+		reader.Seek(startAt, io.SeekStart)
+		return client.WriteRaw(reader, metadata)
+	})
+}
+
+func (c *Cluster) retry(writeFunc func(*Client) error) error {
+	exclude := make([]*Client, 0)
+	var err error
+	for t := 0; t < len(c.clients) && t != c.maxRetries; t++ {
+		client := pick(c.clients, exclude)
+		if err = writeFunc(client); err != nil {
+			if err == ErrEventTooLong {
+				return err
+			} else if res, ok := err.(*Response); !ok || retriable(res.Code) {
+				// If failed to write into this client, exclude it and try others
+				exclude = append(exclude, client)
+				continue
+			}
+		} else {
+			return nil
+		}
+	}
+	return err
+}
+
+func pick(clients []*Client, exclude []*Client) *Client {
+	var choice *Client
+	for choice == nil {
+		choice = clients[rand.Int()%len(clients)]
+		if exclude == nil {
+			break
+		}
+		for _, bad := range exclude {
+			if bad == choice {
+				choice = nil
+				break
+			}
+		}
+	}
+	return choice
+}

--- a/vendor/github.com/fuyufjh/splunk-hec-go/errors.go
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/errors.go
@@ -1,0 +1,36 @@
+package hec
+
+import (
+	"errors"
+)
+
+// Response is response message from HEC. For example, `{"text":"Success","code":0}`.
+type Response struct {
+	Text string `json:"text"`
+	Code int    `json:"code"`
+}
+
+// Response status codes
+const (
+	StatusSuccess              = 0
+	StatusTokenDisabled        = 1
+	StatusTokenRequired        = 2
+	StatusInvalidAuthorization = 3
+	StatusInvalidToken         = 4
+	StatusNoData               = 5
+	StatusInvalidDataFormat    = 6
+	StatusIncorrectIndex       = 7
+	StatusInternalServerError  = 8
+	StatusServerBusy           = 9
+	StatusChannelMissing       = 10
+	StatusInvalidChannel       = 11
+	StatusEventFieldRequired   = 12
+	StatusEventFieldBlank      = 13
+	StatusAckDisabled          = 14
+)
+
+func retriable(code int) bool {
+	return code == StatusServerBusy || code == StatusInternalServerError
+}
+
+var ErrEventTooLong = errors.New("Event length is too long")

--- a/vendor/github.com/fuyufjh/splunk-hec-go/event.go
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/event.go
@@ -1,0 +1,67 @@
+package hec
+
+import (
+	"fmt"
+	"time"
+)
+
+type Event struct {
+	Host       *string     `json:"host,omitempty"`
+	Index      *string     `json:"index,omitempty"`
+	Source     *string     `json:"source,omitempty"`
+	SourceType *string     `json:"sourcetype,omitempty"`
+	Time       *string     `json:"time,omitempty"`
+	Event      interface{} `json:"event"`
+}
+
+func NewEvent(data interface{}) *Event {
+	// Empty event is not allowed, but let HEC complain the error
+	switch data.(type) {
+	case *string:
+		return &Event{Event: *data.(*string)}
+	case string:
+		return &Event{Event: data.(string)}
+	default:
+		return &Event{Event: data}
+	}
+}
+
+func (e *Event) SetHost(host string) {
+	e.Host = &host
+}
+
+func (e *Event) SetIndex(index string) {
+	e.Index = &index
+}
+
+func (e *Event) SetSourceType(sourcetype string) {
+	e.SourceType = &sourcetype
+}
+
+func (e *Event) SetSource(source string) {
+	e.Source = &source
+}
+
+func (e *Event) SetTime(time time.Time) {
+	e.Time = String(epochTime(&time))
+}
+
+func (e *Event) empty() bool {
+	switch e.Event.(type) {
+	case *string:
+		return e.Event.(*string) == nil || *e.Event.(*string) == ""
+	case string:
+		return e.Event.(string) == ""
+	default:
+		return e.Event == nil
+	}
+}
+
+func epochTime(t *time.Time) string {
+	millis := t.UnixNano() / 1000000
+	return fmt.Sprintf("%d.%03d", millis/1000, millis%1000)
+}
+
+func String(str string) *string {
+	return &str
+}

--- a/vendor/github.com/fuyufjh/splunk-hec-go/hec.go
+++ b/vendor/github.com/fuyufjh/splunk-hec-go/hec.go
@@ -1,0 +1,23 @@
+package hec
+
+import (
+	"io"
+	"net/http"
+)
+
+type HEC interface {
+	SetHTTPClient(client *http.Client)
+	SetKeepAlive(enable bool)
+	SetChannel(channel string)
+	SetMaxRetry(retries int)
+	SetMaxContentLength(size int)
+
+	// WriteEvent writes single event via HEC json mode
+	WriteEvent(event *Event) error
+
+	// WriteBatch writes multiple events via HCE batch mode
+	WriteBatch(events []*Event) error
+
+	// WriteRaw writes raw data stream via HEC raw mode
+	WriteRaw(reader io.ReadSeeker, metadata *EventMetadata) error
+}

--- a/vendor/github.com/satori/go.uuid/LICENSE
+++ b/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/satori/go.uuid/codec.go
+++ b/vendor/github.com/satori/go.uuid/codec.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b8109dad11d180b400c04fd430c8"
+// ABNF for supported UUID text representation follows:
+//   uuid := canonical | hashlike | braced | urn
+//   plain := canonical | hashlike
+//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//   hashlike := 12hexoct
+//   braced := '{' plain '}'
+//   urn := URN ':' UUID-NID ':' plain
+//   URN := 'urn'
+//   UUID-NID := 'uuid'
+//   12hexoct := 6hexoct 6hexoct
+//   6hexoct := 4hexoct 2hexoct
+//   4hexoct := 2hexoct 2hexoct
+//   2hexoct := hexoct hexoct
+//   hexoct := hexdig hexdig
+//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	switch len(text) {
+	case 32:
+		return u.decodeHashLike(text)
+	case 36:
+		return u.decodeCanonical(text)
+	case 38:
+		return u.decodeBraced(text)
+	case 41:
+		fallthrough
+	case 45:
+		return u.decodeURN(text)
+	default:
+		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
+func (u *UUID) decodeCanonical(t []byte) (err error) {
+	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	src := t[:]
+	dst := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			src = src[1:] // skip dash
+		}
+		_, err = hex.Decode(dst[:byteGroup/2], src[:byteGroup])
+		if err != nil {
+			return
+		}
+		src = src[byteGroup:]
+		dst = dst[byteGroup/2:]
+	}
+
+	return
+}
+
+// decodeHashLike decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeHashLike(t []byte) (err error) {
+	src := t[:]
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	}
+	return
+}
+
+// decodeBraced decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}" or in format
+// "{6ba7b8109dad11d180b400c04fd430c8}".
+func (u *UUID) decodeBraced(t []byte) (err error) {
+	l := len(t)
+
+	if t[0] != '{' || t[l-1] != '}' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	return u.decodePlain(t[1 : l-1])
+}
+
+// decodeURN decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in format
+// "urn:uuid:6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeURN(t []byte) (err error) {
+	total := len(t)
+
+	urn_uuid_prefix := t[:9]
+
+	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+	}
+
+	return u.decodePlain(t[9:total])
+}
+
+// decodePlain decodes UUID string in canonical format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodePlain(t []byte) (err error) {
+	switch len(t) {
+	case 32:
+		return u.decodeHashLike(t)
+	case 36:
+		return u.decodeCanonical(t)
+	default:
+		return fmt.Errorf("uuid: incorrrect UUID length: %s", t)
+	}
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != Size {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}

--- a/vendor/github.com/satori/go.uuid/generator.go
+++ b/vendor/github.com/satori/go.uuid/generator.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"hash"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+var (
+	global = newDefaultGenerator()
+
+	epochFunc = unixTimeFunc
+	posixUID  = uint32(os.Getuid())
+	posixGID  = uint32(os.Getgid())
+)
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	return global.NewV1()
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	return global.NewV2(domain)
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	return global.NewV3(ns, name)
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() UUID {
+	return global.NewV4()
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	return global.NewV5(ns, name)
+}
+
+// Generator provides interface for generating UUIDs.
+type Generator interface {
+	NewV1() UUID
+	NewV2(domain byte) UUID
+	NewV3(ns UUID, name string) UUID
+	NewV4() UUID
+	NewV5(ns UUID, name string) UUID
+}
+
+// Default generator implementation.
+type generator struct {
+	storageOnce  sync.Once
+	storageMutex sync.Mutex
+
+	lastTime      uint64
+	clockSequence uint16
+	hardwareAddr  [6]byte
+}
+
+func newDefaultGenerator() Generator {
+	return &generator{}
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func (g *generator) NewV1() UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V1)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func (g *generator) NewV2(domain byte) UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[0:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[0:], posixGID)
+	}
+
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+	u[9] = domain
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V2)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func (g *generator) NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(V3)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func (g *generator) NewV4() UUID {
+	u := UUID{}
+	g.safeRandom(u[:])
+	u.SetVersion(V4)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func (g *generator) NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(V5)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+func (g *generator) initStorage() {
+	g.initClockSequence()
+	g.initHardwareAddr()
+}
+
+func (g *generator) initClockSequence() {
+	buf := make([]byte, 2)
+	g.safeRandom(buf)
+	g.clockSequence = binary.BigEndian.Uint16(buf)
+}
+
+func (g *generator) initHardwareAddr() {
+	interfaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range interfaces {
+			if len(iface.HardwareAddr) >= 6 {
+				copy(g.hardwareAddr[:], iface.HardwareAddr)
+				return
+			}
+		}
+	}
+
+	// Initialize hardwareAddr randomly in case
+	// of real network interfaces absence
+	g.safeRandom(g.hardwareAddr[:])
+
+	// Set multicast bit as recommended in RFC 4122
+	g.hardwareAddr[0] |= 0x01
+}
+
+func (g *generator) safeRandom(dest []byte) {
+	if _, err := rand.Read(dest); err != nil {
+		panic(err)
+	}
+}
+
+// Returns UUID v1/v2 storage state.
+// Returns epoch timestamp, clock sequence, and hardware address.
+func (g *generator) getStorage() (uint64, uint16, []byte) {
+	g.storageOnce.Do(g.initStorage)
+
+	g.storageMutex.Lock()
+	defer g.storageMutex.Unlock()
+
+	timeNow := epochFunc()
+	// Clock changed backwards since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= g.lastTime {
+		g.clockSequence++
+	}
+	g.lastTime = timeNow
+
+	return timeNow, g.clockSequence, g.hardwareAddr[:]
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+// This is default epoch calculation function.
+func unixTimeFunc() uint64 {
+	return epochStart + uint64(time.Now().UnixNano()/100)
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}

--- a/vendor/github.com/satori/go.uuid/generator.go
+++ b/vendor/github.com/satori/go.uuid/generator.go
@@ -26,7 +26,9 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/binary"
+	"fmt"
 	"hash"
+	"io"
 	"net"
 	"os"
 	"sync"
@@ -37,21 +39,23 @@ import (
 // UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
 const epochStart = 122192928000000000
 
-var (
-	global = newDefaultGenerator()
+type epochFunc func() time.Time
+type hwAddrFunc func() (net.HardwareAddr, error)
 
-	epochFunc = unixTimeFunc
-	posixUID  = uint32(os.Getuid())
-	posixGID  = uint32(os.Getgid())
+var (
+	global = newRFC4122Generator()
+
+	posixUID = uint32(os.Getuid())
+	posixGID = uint32(os.Getgid())
 )
 
 // NewV1 returns UUID based on current timestamp and MAC address.
-func NewV1() UUID {
+func NewV1() (UUID, error) {
 	return global.NewV1()
 }
 
 // NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func NewV2(domain byte) UUID {
+func NewV2(domain byte) (UUID, error) {
 	return global.NewV2(domain)
 }
 
@@ -61,7 +65,7 @@ func NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns random generated UUID.
-func NewV4() UUID {
+func NewV4() (UUID, error) {
 	return global.NewV4()
 }
 
@@ -72,74 +76,85 @@ func NewV5(ns UUID, name string) UUID {
 
 // Generator provides interface for generating UUIDs.
 type Generator interface {
-	NewV1() UUID
-	NewV2(domain byte) UUID
+	NewV1() (UUID, error)
+	NewV2(domain byte) (UUID, error)
 	NewV3(ns UUID, name string) UUID
-	NewV4() UUID
+	NewV4() (UUID, error)
 	NewV5(ns UUID, name string) UUID
 }
 
 // Default generator implementation.
-type generator struct {
-	storageOnce  sync.Once
-	storageMutex sync.Mutex
+type rfc4122Generator struct {
+	clockSequenceOnce sync.Once
+	hardwareAddrOnce  sync.Once
+	storageMutex      sync.Mutex
 
+	rand io.Reader
+
+	epochFunc     epochFunc
+	hwAddrFunc    hwAddrFunc
 	lastTime      uint64
 	clockSequence uint16
 	hardwareAddr  [6]byte
 }
 
-func newDefaultGenerator() Generator {
-	return &generator{}
+func newRFC4122Generator() Generator {
+	return &rfc4122Generator{
+		epochFunc:  time.Now,
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
 }
 
 // NewV1 returns UUID based on current timestamp and MAC address.
-func (g *generator) NewV1() UUID {
+func (g *rfc4122Generator) NewV1() (UUID, error) {
 	u := UUID{}
 
-	timeNow, clockSeq, hardwareAddr := g.getStorage()
-
+	timeNow, clockSeq, err := g.getClockSequence()
+	if err != nil {
+		return Nil, err
+	}
 	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
 	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
 	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
 	binary.BigEndian.PutUint16(u[8:], clockSeq)
 
+	hardwareAddr, err := g.getHardwareAddr()
+	if err != nil {
+		return Nil, err
+	}
 	copy(u[10:], hardwareAddr)
 
 	u.SetVersion(V1)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func (g *generator) NewV2(domain byte) UUID {
-	u := UUID{}
-
-	timeNow, clockSeq, hardwareAddr := g.getStorage()
+func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
+	u, err := g.NewV1()
+	if err != nil {
+		return Nil, err
+	}
 
 	switch domain {
 	case DomainPerson:
-		binary.BigEndian.PutUint32(u[0:], posixUID)
+		binary.BigEndian.PutUint32(u[:], posixUID)
 	case DomainGroup:
-		binary.BigEndian.PutUint32(u[0:], posixGID)
+		binary.BigEndian.PutUint32(u[:], posixGID)
 	}
 
-	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
-	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
-	binary.BigEndian.PutUint16(u[8:], clockSeq)
 	u[9] = domain
-
-	copy(u[10:], hardwareAddr)
 
 	u.SetVersion(V2)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV3 returns UUID based on MD5 hash of namespace UUID and name.
-func (g *generator) NewV3(ns UUID, name string) UUID {
+func (g *rfc4122Generator) NewV3(ns UUID, name string) UUID {
 	u := newFromHash(md5.New(), ns, name)
 	u.SetVersion(V3)
 	u.SetVariant(VariantRFC4122)
@@ -148,17 +163,19 @@ func (g *generator) NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns random generated UUID.
-func (g *generator) NewV4() UUID {
+func (g *rfc4122Generator) NewV4() (UUID, error) {
 	u := UUID{}
-	g.safeRandom(u[:])
+	if _, err := g.rand.Read(u[:]); err != nil {
+		return Nil, err
+	}
 	u.SetVersion(V4)
 	u.SetVariant(VariantRFC4122)
 
-	return u
+	return u, nil
 }
 
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
-func (g *generator) NewV5(ns UUID, name string) UUID {
+func (g *rfc4122Generator) NewV5(ns UUID, name string) UUID {
 	u := newFromHash(sha1.New(), ns, name)
 	u.SetVersion(V5)
 	u.SetVariant(VariantRFC4122)
@@ -166,66 +183,61 @@ func (g *generator) NewV5(ns UUID, name string) UUID {
 	return u
 }
 
-func (g *generator) initStorage() {
-	g.initClockSequence()
-	g.initHardwareAddr()
-}
-
-func (g *generator) initClockSequence() {
-	buf := make([]byte, 2)
-	g.safeRandom(buf)
-	g.clockSequence = binary.BigEndian.Uint16(buf)
-}
-
-func (g *generator) initHardwareAddr() {
-	interfaces, err := net.Interfaces()
-	if err == nil {
-		for _, iface := range interfaces {
-			if len(iface.HardwareAddr) >= 6 {
-				copy(g.hardwareAddr[:], iface.HardwareAddr)
-				return
-			}
+// Returns epoch and clock sequence.
+func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
+	var err error
+	g.clockSequenceOnce.Do(func() {
+		buf := make([]byte, 2)
+		if _, err = g.rand.Read(buf); err != nil {
+			return
 		}
+		g.clockSequence = binary.BigEndian.Uint16(buf)
+	})
+	if err != nil {
+		return 0, 0, err
 	}
-
-	// Initialize hardwareAddr randomly in case
-	// of real network interfaces absence
-	g.safeRandom(g.hardwareAddr[:])
-
-	// Set multicast bit as recommended in RFC 4122
-	g.hardwareAddr[0] |= 0x01
-}
-
-func (g *generator) safeRandom(dest []byte) {
-	if _, err := rand.Read(dest); err != nil {
-		panic(err)
-	}
-}
-
-// Returns UUID v1/v2 storage state.
-// Returns epoch timestamp, clock sequence, and hardware address.
-func (g *generator) getStorage() (uint64, uint16, []byte) {
-	g.storageOnce.Do(g.initStorage)
 
 	g.storageMutex.Lock()
 	defer g.storageMutex.Unlock()
 
-	timeNow := epochFunc()
-	// Clock changed backwards since last UUID generation.
+	timeNow := g.getEpoch()
+	// Clock didn't change since last UUID generation.
 	// Should increase clock sequence.
 	if timeNow <= g.lastTime {
 		g.clockSequence++
 	}
 	g.lastTime = timeNow
 
-	return timeNow, g.clockSequence, g.hardwareAddr[:]
+	return timeNow, g.clockSequence, nil
+}
+
+// Returns hardware address.
+func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
+	var err error
+	g.hardwareAddrOnce.Do(func() {
+		if hwAddr, err := g.hwAddrFunc(); err == nil {
+			copy(g.hardwareAddr[:], hwAddr)
+			return
+		}
+
+		// Initialize hardwareAddr randomly in case
+		// of real network interfaces absence.
+		if _, err = g.rand.Read(g.hardwareAddr[:]); err != nil {
+			return
+		}
+		// Set multicast bit as recommended by RFC 4122
+		g.hardwareAddr[0] |= 0x01
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+	return g.hardwareAddr[:], nil
 }
 
 // Returns difference in 100-nanosecond intervals between
 // UUID epoch (October 15, 1582) and current time.
-// This is default epoch calculation function.
-func unixTimeFunc() uint64 {
-	return epochStart + uint64(time.Now().UnixNano()/100)
+func (g *rfc4122Generator) getEpoch() uint64 {
+	return epochStart + uint64(g.epochFunc().UnixNano()/100)
 }
 
 // Returns UUID based on hashing of namespace UUID and name.
@@ -236,4 +248,18 @@ func newFromHash(h hash.Hash, ns UUID, name string) UUID {
 	copy(u[:], h.Sum(nil))
 
 	return u
+}
+
+// Returns hardware address.
+func defaultHWAddrFunc() (net.HardwareAddr, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []byte{}, err
+	}
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) >= 6 {
+			return iface.HardwareAddr, nil
+		}
+	}
+	return []byte{}, fmt.Errorf("uuid: no HW address found")
 }

--- a/vendor/github.com/satori/go.uuid/sql.go
+++ b/vendor/github.com/satori/go.uuid/sql.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == Size {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}

--- a/vendor/github.com/satori/go.uuid/uuid.go
+++ b/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,161 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+)
+
+// Size of a UUID in bytes.
+const Size = 16
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [Size]byte
+
+// UUID versions
+const (
+	_ byte = iota
+	V1
+	V2
+	V3
+	V4
+	V5
+)
+
+// UUID layout variants.
+const (
+	VariantNCS byte = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+// Nil is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS  = Must(FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceURL  = Must(FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceOID  = Must(FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
+)
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() byte {
+	return u[6] >> 4
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() byte {
+	switch {
+	case (u[8] >> 7) == 0x00:
+		return VariantNCS
+	case (u[8] >> 6) == 0x02:
+		return VariantRFC4122
+	case (u[8] >> 5) == 0x06:
+		return VariantMicrosoft
+	case (u[8] >> 5) == 0x07:
+		fallthrough
+	default:
+		return VariantFuture
+	}
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits.
+func (u *UUID) SetVariant(v byte) {
+	switch v {
+	case VariantNCS:
+		u[8] = (u[8]&(0xff>>1) | (0x00 << 7))
+	case VariantRFC4122:
+		u[8] = (u[8]&(0xff>>2) | (0x02 << 6))
+	case VariantMicrosoft:
+		u[8] = (u[8]&(0xff>>3) | (0x06 << 5))
+	case VariantFuture:
+		fallthrough
+	default:
+		u[8] = (u[8]&(0xff>>3) | (0x07 << 5))
+	}
+}
+
+// Must is a helper that wraps a call to a function returning (UUID, error)
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"));
+func Must(u UUID, err error) UUID {
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
#### Summary

This PR adds a sink that sends all SSF spans into a configurable splunk HEC endpoint as json-formatted events.

The sink is ~pretty much there to experiment with, and as such comes with a few restrictions / TODO items:

* It logs whenever it encounters a non-context-deadline related error; that happens for every span. We might want to gate this so it doesn't happen too often, but for now we might want to see all errors. (I saw no excessive chunder in tests yet.)
* The HEC sink comes with a config option for a per-span timeout, and that can cause a bunch of spans to get dropped if the HEC isn't fast enough. I think that's fine for now (automatic sampling!) but we might want to investigate ingesting them all soon.

#### Motivation
I want to see how much storage it'll use!


#### Test plan

I wrote a test to check if the HEC event format is right, and we're running it in QA right now!


#### Rollout/monitoring/revert plan

Pretty much just merge & update the config to include `splunk_hec_*` keys.