### PR TITLE
Remove Go 1.9 from Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.9
   - "1.10"
   - tip
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Remove Go 1.9 from Travis builds.

The new Splunk sink (#531) doesn't build against Go 1.9. Go 1.11 is expected to be released any day now, though it isn't out yet, which means Go 1.9 still receives official support from the Go project for the time being. This technically means we're dropping support for an officially-supported version of Go, and only supporting the latest stable release, but

a) This only removes Travis CI builds; people can still build Veneur without the Splunk plugin on Go 1.9

b) In a matter of days, Go 1.9 support will be dropped, because Go 1.11 will be released

...so if anyone has issues with this, I can talk to them. :)

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
