### PR TITLE
Add configurable timeout to veneur emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 * Metrics can be forwarded over gRPC using veneur-proxy (and Consul).  Thanks, [noahgoldman](https://github.com/noahgoldman) and [Quantcast](https://github.com/quantcast)!
+* `veneur-emit` now takes a new option `-timeout` for setting a configurable timeout when performing any emission. The timeout defaults to `5s`. This prevents uses of Veneur emit from blocking indefinitely.
 
 ## Removals
 * Go 1.9 is no longer supported.

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -169,8 +169,7 @@ func main() {
 
 	completion := make(chan int)
 	go func() {
-		doEmission(passedFlags)
-		completion <- 0
+		completion <- doEmission(passedFlags)
 	}()
 
 	select {

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	validateFlagCombinations(passedFlags)
 
-	completion := make(chan int, 1)
+	completion := make(chan int)
 	go func() {
 		doEmission(passedFlags)
 		completion <- 0
@@ -179,7 +179,6 @@ func main() {
 	case <-time.After(*timeout):
 		logrus.WithField("timeout", timeout.String()).
 			Fatal("Timeout exceeded for emission")
-		os.Exit(1)
 	}
 
 }


### PR DESCRIPTION
#### Summary
Adds a `timeout` flag and default of 5s for the emission operation.

#### Motivation
Veneur emit can time out if there is trouble resolving DNS or if the type of connection (tcp, etc) is not fire and forget like UDP. Adding this timeout prevents it blocking forever!

#### Test plan
Verified locally using Network Link Conditioner set to 100% loss and a clear DNS cache.

r? @sdboyer-stripe 