### PR TITLE
Add Go 1.11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - "1.10"
+  - "1.11"
   - tip
 
 install:


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Now that Go 1.11 is released (as of Friday), we should add it to our Travis CI builds.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 