### PR TITLE
Batch HEC events together, send them only at flush time

### DIFF
--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
+	SplunkHecMaxCapacity          int      `yaml:"splunk_hec_max_capacity"`
 	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`

--- a/example.yaml
+++ b/example.yaml
@@ -361,6 +361,13 @@ splunk_hec_address: "https://localhost:8088"
 # The authentication token veneur will use to authenticate to the HEC
 splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 
+# (optional) The maximum number of spans to keep between flushes of
+# the splunk HEC sink. If it ingests more than this number of spans,
+# ingestion of each span into the sink will report an error. If no
+# capacity is given, the number of spans buffered can grow without
+# bounds.
+splunk_hec_max_capacity: 160000
+
 # (optional) server name set on the TLS configuration. This is useful
 # if the host you're reaching identifies with a different name than on
 # the URL.

--- a/example.yaml
+++ b/example.yaml
@@ -367,8 +367,8 @@ splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 splunk_hec_tls_validate_hostname: "some-other-hostname"
 
 # (optional) The maximum amount of time to wait before timing out
-# sending a span to the Splunk HEC. If omitted / set to 0, sending
-# spans happens without a timeout.
+# sending a batch of spans to the Splunk HEC. If omitted / set to 0,
+# sending batches happens without a timeout.
 splunk_hec_send_timeout: "10ms"
 
 # == PLUGINS ==

--- a/server.go
+++ b/server.go
@@ -423,7 +423,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, timeout)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, timeout, conf.SplunkHecMaxCapacity)
 			if err != nil {
 				return ret, err
 			}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -77,6 +77,9 @@ func (sss *splunkSpanSink) batchAndSend() {
 	for {
 		select {
 		case ev := <-sss.ingest:
+			// Note that Ingest checks whether the span
+			// limit is exceeded, so here we can
+			// unconditionally add the span to the batch.
 			batch = append(batch, ev)
 		case sss.flush <- batch:
 			// We could flush the batch - get us a new one.


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This change adjusts the splunk HEC sink's ingestion behavior so that it batches up spans to send and then flushes them all at once.


##### Matters for consideration

* This causes potentially infinite memory usage growth, since we're not limiting the number of spans ingested (I think that mirrors the datadog sink's behavior, which just adds them to a linked list)

#### Motivation

It's been a concern.


#### Test plan

Ran this on a box, and it still submitted spans.

#### Rollout/monitoring/revert plan

Merge; no changelog necessary.