### PR TITLE
Add support for Envoy OpenTracing headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Veneur has a new sink that can be configured to send spans as events into a [Splunk HEC](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) endpoint. Thanks, [antifuchs](https://github.com/antifuchs) and [aditya](https://github.com/chimeracoder)!
 * Go 1.11 is now supported and used for all public Docker images. Thanks, [aditya](https://github.com/chimeracoder)!
 
+## Bugfixes
+* The trace client can now correctly parse trace headers emitted by Envoy. Thanks, [aditya](https://github.com/chimeracoder)!
+
+
 ## Removals
 * Go 1.9 is no longer supported.
 

--- a/trace/opentracing.go
+++ b/trace/opentracing.go
@@ -1,4 +1,4 @@
-package trace
+package trac
 
 import (
 	"context"
@@ -27,10 +27,12 @@ type HeaderGroup struct {
 // Veneur supports multiple tracing header formats. We try each set of headers until we find one that exists.
 // Note: textMapReaderGet is case insensitive, so the capitalization of these headers is not important.
 var HeaderFormats = []HeaderGroup{
-	// Envoy format. We check Envoy first because Envoy sits between services and will most likely be the nearest parent.
+	// Envoy format. We check Envoy first because, if Envoy is used, Envoy sits between services and will most likely be the nearest parent.
+	// Envoy (and OpenTracing) allow multiple header formats; this is the naming scheme used by Envoy configured with Lightstep, though
+	// it does not require usage of Lightstep.
 	HeaderGroup{
-		TraceID: "x-request-id",
-		SpanID:  "x-client-trace-id",
+		TraceID: "ot-tracer-traceid",
+		SpanID:  "ot-tracer-spanid",
 	},
 	// OpenTracing format.
 	HeaderGroup{

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -236,8 +236,8 @@ func TestTracerInjectExtractHeader(t *testing.T) {
 func TestTraceExtractHeaderEnvoy(t *testing.T) {
 	tracer := Tracer{}
 	tm := textMapReaderWriter(map[string]string{
-		"x-request-id":      "12345",
-		"x-client-trace-id": "67890",
+		"ot-tracer-traceid": "12345",
+		"ot-tracer-spanid":  "67890",
 	})
 
 	c, _ := tracer.Extract(opentracing.TextMap, tm)

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -236,8 +236,8 @@ func TestTracerInjectExtractHeader(t *testing.T) {
 func TestTraceExtractHeaderEnvoy(t *testing.T) {
 	tracer := Tracer{}
 	tm := textMapReaderWriter(map[string]string{
-		"ot-tracer-traceid": "12345",
-		"ot-tracer-spanid":  "67890",
+		"ot-tracer-traceid": "3039",
+		"ot-tracer-spanid":  "10932",
 	})
 
 	c, _ := tracer.Extract(opentracing.TextMap, tm)


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add support for Envoy tracing headers. Please take a look at the comment to make sure I correctly described the situation (since there was some confusion about the possible header types).

#### Motivation
<!-- Why are you making this change? -->
https://jira.corp.stripe.com/browse/OBS-7868

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Did not test this with Veneur, since no Go services currently route traffic through Envoy, but these are the headers we already use in the Ruby clients.


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @sjung-stripe 
cc @stripe/observability 