### PR TITLE
Add an indicator boolean to veneur/trace spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added tracer.InjectHeader convenience function for... convenience! Thanks, [mikeh](https://github.com/mikeh-stripe)!
 * Veneur has a new sink that can be configured to send spans as events into a [Splunk HEC](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) endpoint. Thanks, [antifuchs](https://github.com/antifuchs) and [aditya](https://github.com/chimeracoder)!
 * Go 1.11 is now supported and used for all public Docker images. Thanks, [aditya](https://github.com/chimeracoder)!
+* The `veneur/trace` package now supports setting the indicator bit on a span manually. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Bugfixes
 * The trace client can now correctly parse trace headers emitted by Envoy. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -92,6 +92,11 @@ type Trace struct {
 	// alongside a span.
 	Samples []*ssf.SSFSample
 
+	// An indicator span is one that represents an action that is included in a
+	// service's Service Level Indicators (https://en.wikipedia.org/wiki/Service_level_indicator)
+	// For more information, see the SSF definition at https://github.com/stripe/veneur/tree/master/ssf
+	Indicator bool
+
 	error bool
 }
 
@@ -155,6 +160,7 @@ func (t *Trace) SSFSpan() *ssf.SSFSpan {
 		Tags:           t.Tags,
 		Service:        Service,
 		Metrics:        t.Samples,
+		Indicator:      t.Indicator,
 	}
 
 	return span


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add a field to track whether the span is an indicator span. The SSF supports this field already, but the `veneur/trace` package predates that, so it didn't support it.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @sjung-stripe 
cc @stripe/observability 