### PR TITLE
Splunk: Allow configuring ingest timeouts and early-flush thresholds

### DIFF
--- a/config.go
+++ b/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
+	SplunkHecEarlyFlushThreshold  int      `yaml:"splunk_hec_early_flush_threshold"`
+	SplunkHecIngestTimeout        string   `yaml:"splunk_hec_ingest_timeout"`
 	SplunkHecMaxCapacity          int      `yaml:"splunk_hec_max_capacity"`
 	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`

--- a/config.go
+++ b/config.go
@@ -68,10 +68,10 @@ type Config struct {
 	SignalfxVaryKeyBy             string   `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
-	SplunkHecEarlyFlushThreshold  int      `yaml:"splunk_hec_early_flush_threshold"`
 	SplunkHecIngestTimeout        string   `yaml:"splunk_hec_ingest_timeout"`
 	SplunkHecMaxCapacity          int      `yaml:"splunk_hec_max_capacity"`
 	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
+	SplunkHecSubmissionWorkers    int      `yaml:"splunk_hec_submission_workers"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`

--- a/example.yaml
+++ b/example.yaml
@@ -366,12 +366,12 @@ splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 # ingestion of each span into the sink will report an error. If no
 # capacity is given, the number of spans buffered can grow without
 # bounds.
-splunk_hec_max_capacity: 160000
+splunk_hec_max_capacity: 1000
 
-# (optional) The number of spans at which to attempt to flush a batch
-# of accumulated spans early (that is, between the configured flush
-# interval). If this is unset, no early flushes are attempted.
-splunk_hec_early_flush_threshold: 80000
+# (optional) The maximum number of parallell submissions to do to the
+# splunk HEC endpoint. If this setting is omitted or zero, submissions
+# to HEC only happen at the configured flush interval.
+splunk_hec_submission_workers: 3
 
 # (optional) server name set on the TLS configuration. This is useful
 # if the host you're reaching identifies with a different name than on

--- a/example.yaml
+++ b/example.yaml
@@ -368,6 +368,11 @@ splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 # bounds.
 splunk_hec_max_capacity: 160000
 
+# (optional) The number of spans at which to attempt to flush a batch
+# of accumulated spans early (that is, between the configured flush
+# interval). If this is unset, no early flushes are attempted.
+splunk_hec_early_flush_threshold: 80000
+
 # (optional) server name set on the TLS configuration. This is useful
 # if the host you're reaching identifies with a different name than on
 # the URL.
@@ -377,6 +382,11 @@ splunk_hec_tls_validate_hostname: "some-other-hostname"
 # sending a batch of spans to the Splunk HEC. If omitted / set to 0,
 # sending batches happens without a timeout.
 splunk_hec_send_timeout: "10ms"
+
+# (optional) The maximum amount of time to wait before timing out
+# ingesting a single span to the Splunk HEC sink. If omitted / set to
+# 0, ingestion will wait indefintely until the span can be ingested.
+splunk_hec_ingest_timeout: "10ms"
 
 # == PLUGINS ==
 

--- a/server.go
+++ b/server.go
@@ -416,14 +416,20 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			var timeout time.Duration
+			var sendTimeout, ingestTimeout time.Duration
 			if conf.SplunkHecSendTimeout != "" {
-				timeout, err = time.ParseDuration(conf.SplunkHecSendTimeout)
+				sendTimeout, err = time.ParseDuration(conf.SplunkHecSendTimeout)
 				if err != nil {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, timeout, conf.SplunkHecMaxCapacity)
+			if conf.SplunkHecIngestTimeout != "" {
+				sendTimeout, err = time.ParseDuration(conf.SplunkHecIngestTimeout)
+				if err != nil {
+					return ret, err
+				}
+			}
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecMaxCapacity, conf.SplunkHecEarlyFlushThreshold)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -429,7 +429,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecMaxCapacity, conf.SplunkHecEarlyFlushThreshold)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecMaxCapacity, conf.SplunkHecSubmissionWorkers)
 			if err != nil {
 				return ret, err
 			}

--- a/sinks/splunk/buffer_read_seeker.go
+++ b/sinks/splunk/buffer_read_seeker.go
@@ -1,0 +1,30 @@
+package splunk
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// struct bufferReadSeeker is a wrapper around bytes.Buffer that
+// implements Read and Seek, so it can be used as a ReadSeeker for the
+// HEC client (until that client gets a Reader-only interface).
+type bufferReadSeeker struct {
+	b *bytes.Buffer
+}
+
+func NewBufferReadSeeker(b *bytes.Buffer) io.ReadSeeker {
+	return &bufferReadSeeker{b: b}
+}
+
+// Read proxies through to the contained bytes.Buffer Read method.
+func (frs *bufferReadSeeker) Read(p []byte) (n int, err error) {
+	return frs.b.Read(p)
+}
+
+var ErrSeekNotSupported = fmt.Errorf("method Seek is not supported on bufferSeekReaders")
+
+// Seek returns ErrSeekNotSupported.
+func (frs *bufferReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, ErrSeekNotSupported
+}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -37,6 +37,8 @@ type splunkSpanSink struct {
 	log         *logrus.Logger
 }
 
+const DefaultMaxContentLength = 1000000
+
 // ErrTooManySpans is an error returned when the number of spans
 // ingested in a flush interval exceeds the maximum number configured
 // for this sink. See the splunk_hec_max_capacity config setting.
@@ -49,6 +51,8 @@ var ErrTooManySpans = fmt.Errorf("ingested spans exceed the configured limit.")
 // one on the server URL.
 func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, maxSpanCapacity int, earlyFlushThreshold int) (sinks.SpanSink, error) {
 	client := hec.NewClient(server, token).(*hec.Client)
+	client.SetMaxRetry(0)
+	client.SetMaxContentLength(DefaultMaxContentLength)
 
 	if validateServerName != "" {
 		tlsCfg := &tls.Config{}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -20,13 +20,18 @@ import (
 
 type splunkSpanSink struct {
 	*hec.Client
-	hostname        string
-	sendTimeout     time.Duration
-	maxSpanCapacity int
-	ingestedSpans   uint32
+	hostname             string
+	sendTimeout          time.Duration
+	ingestTimeout        time.Duration
+	maxSpanCapacity      int
+	earlyFlushThreshold  int
+	hecSubmissionWorkers int
+	ingestedSpans        uint32
+	droppedSpans         uint32
 
-	ingest chan *hec.Event
-	flush  chan []*hec.Event
+	ingest       chan *hec.Event
+	flushForTime chan []*hec.Event
+	flushForSize chan []*hec.Event
 
 	traceClient *trace.Client
 	log         *logrus.Logger
@@ -35,14 +40,14 @@ type splunkSpanSink struct {
 // ErrTooManySpans is an error returned when the number of spans
 // ingested in a flush interval exceeds the maximum number configured
 // for this sink. See the splunk_hec_max_capacity config setting.
-var ErrTooManySpans = fmt.Errorf("Ingested spans exceed the configured limit.")
+var ErrTooManySpans = fmt.Errorf("ingested spans exceed the configured limit.")
 
 // NewSplunkSpanSink constructs a new splunk span sink from the server
 // name and token provided, using the local hostname configured for
 // veneur. An optional argument, validateServerName is used (if
 // non-empty) to instruct go to validate a different hostname than the
 // one on the server URL.
-func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, sendTimeout time.Duration, maxSpanCapacity int) (sinks.SpanSink, error) {
+func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, maxSpanCapacity int, earlyFlushThreshold int) (sinks.SpanSink, error) {
 	client := hec.NewClient(server, token).(*hec.Client)
 
 	if validateServerName != "" {
@@ -57,49 +62,45 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 	return &splunkSpanSink{
 		Client:          client,
 		ingest:          make(chan *hec.Event),
-		flush:           make(chan []*hec.Event),
+		flushForTime:    make(chan []*hec.Event),
+		flushForSize:    make(chan []*hec.Event),
 		hostname:        localHostname,
 		log:             log,
 		sendTimeout:     sendTimeout,
+		ingestTimeout:   ingestTimeout,
 		maxSpanCapacity: maxSpanCapacity,
 	}, nil
+}
+
+// Name returns this sink's name
+func (*splunkSpanSink) Name() string {
+	return "splunk"
 }
 
 func (sss *splunkSpanSink) Start(cl *trace.Client) error {
 	sss.traceClient = cl
 	go sss.batchAndSend()
 
+	if sss.earlyFlushThreshold > 0 {
+		go sss.submitter()
+	}
+
 	return nil
 }
 
-func (sss *splunkSpanSink) batchAndSend() {
-	batch := make([]*hec.Event, 0, sss.maxSpanCapacity)
+func (sss *splunkSpanSink) submitter() {
+	ctx := context.Background()
 	for {
-		select {
-		case ev := <-sss.ingest:
-			// Note that Ingest checks whether the span
-			// limit is exceeded, so here we can
-			// unconditionally add the span to the batch.
-			batch = append(batch, ev)
-		case sss.flush <- batch:
-			// We could flush the batch - get us a new one.
-			batch = make([]*hec.Event, 0, sss.maxSpanCapacity)
-		}
-
+		batch := <-sss.flushForSize
+		sss.submitBatch(ctx, batch)
 	}
 }
 
-// Flush takes the batched-up events and sends them to the HEC
-// endpoint for ingestion. If set, it uses the send timeout configured
-// for the span batch.
-func (sss *splunkSpanSink) Flush() {
-	flushed := 0
-	dropped := 0
-	batch := <-sss.flush
-	atomic.StoreUint32(&sss.ingestedSpans, 0)
+func (sss *splunkSpanSink) submitBatch(ctx context.Context, batch []*hec.Event) {
+	samples := &ssf.Samples{}
+	defer metrics.Report(sss.traceClient, samples)
 
-	// TODO: Ideally, Flush() would get a context of its own:
-	ctx := context.Background()
+	start := time.Now()
 	if sss.sendTimeout != 0 {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, sss.sendTimeout)
@@ -107,25 +108,69 @@ func (sss *splunkSpanSink) Flush() {
 	}
 	err := sss.Client.WriteBatchWithContext(ctx, batch)
 	if err != nil {
-		dropped += len(batch)
+		samples.Add(ssf.Count("splunk.span_submission_failed_total", float32(len(batch)), map[string]string{}))
 		if ctx.Err() == nil {
 			sss.log.WithError(err).
 				WithField("n_spans", len(batch)).
 				Error("Couldn't flush batch to HEC")
 		}
 	} else {
-		flushed += len(batch)
+		samples.Add(ssf.Count("splunk.span_submitted_total", float32(len(batch)), map[string]string{}))
 	}
+	samples.Add(ssf.Timing("splunk.span_submission_duration_ns", start.Sub(time.Now()), time.Nanosecond, map[string]string{}))
+}
+
+func (sss *splunkSpanSink) batchAndSend() {
+	batch := make([]*hec.Event, 0, sss.maxSpanCapacity)
+	for {
+		select {
+		case ev := <-sss.ingest:
+			batch = append(batch, ev)
+
+			// attempt to flush the batch if it's growing too large:
+			if sss.earlyFlushThreshold != 0 && len(batch) > sss.earlyFlushThreshold {
+				select {
+				case sss.flushForSize <- batch:
+					batch = make([]*hec.Event, 0, sss.maxSpanCapacity)
+				default:
+				}
+			}
+		case sss.flushForTime <- batch:
+			batch = make([]*hec.Event, 0, sss.maxSpanCapacity)
+		}
+
+		// If we're at capacity, block the ingestion channel
+		// and attempt to flush the batch:
+		if sss.maxSpanCapacity != 0 && len(batch) == sss.maxSpanCapacity {
+			select {
+			case sss.flushForTime <- batch:
+				batch = make([]*hec.Event, 0, sss.maxSpanCapacity)
+			case sss.flushForSize <- batch:
+				batch = make([]*hec.Event, 0, sss.maxSpanCapacity)
+			}
+		}
+	}
+}
+
+// Flush takes the batched-up events and sends them to the HEC
+// endpoint for ingestion. If set, it uses the send timeout configured
+// for the span batch.
+func (sss *splunkSpanSink) Flush() {
+	batch := <-sss.flushForTime
+
+	// TODO: Ideally, Flush() would get a context of its own:
+	ctx := context.Background()
+	sss.submitBatch(ctx, batch)
 
 	samples := &ssf.Samples{}
 	samples.Add(
 		ssf.Count(
 			sinks.MetricKeyTotalSpansFlushed,
-			float32(flushed),
+			float32(atomic.SwapUint32(&sss.ingestedSpans, 0)),
 			map[string]string{"sink": sss.Name()}),
 		ssf.Count(
 			sinks.MetricKeyTotalSpansDropped,
-			float32(dropped),
+			float32(atomic.SwapUint32(&sss.droppedSpans, 0)),
 			map[string]string{"sink": sss.Name()},
 		),
 	)
@@ -134,22 +179,21 @@ func (sss *splunkSpanSink) Flush() {
 	return
 }
 
-// Name returns this sink's name
-func (*splunkSpanSink) Name() string {
-	return "splunk"
-}
-
 // Ingest takes in a span and batches it up to be sent in the next
 // Flush() iteration.
 func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
+	ctx := context.Background()
+	if sss.ingestTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, sss.ingestTimeout)
+		defer cancel()
+	}
+
 	// Only send properly filled-out spans to the HEC:
 	if err := protocol.ValidateTrace(ssfSpan); err != nil {
 		return err
 	}
-	if sss.maxSpanCapacity != 0 && atomic.LoadUint32(&sss.ingestedSpans) >= uint32(sss.maxSpanCapacity) {
-		return ErrTooManySpans
-	}
-	atomic.AddUint32(&sss.ingestedSpans, 1)
+
 	serialized := SerializedSSF{
 		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 10),
 		Id:             strconv.FormatInt(ssfSpan.Id, 10),
@@ -172,8 +216,14 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	event.SetSourceType(ssfSpan.Service)
 
 	event.SetTime(time.Unix(0, ssfSpan.StartTimestamp))
-	sss.ingest <- event
-	return nil
+	select {
+	case sss.ingest <- event:
+		atomic.AddUint32(&sss.ingestedSpans, 1)
+		return nil
+	case <-ctx.Done():
+		atomic.AddUint32(&sss.droppedSpans, 1)
+		return ErrTooManySpans
+	}
 }
 
 // SerializedSSF holds a set of fields in a format that Splunk can

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -117,7 +117,7 @@ func (sss *splunkSpanSink) submitBatch(ctx context.Context, batch []*hec.Event) 
 	} else {
 		samples.Add(ssf.Count("splunk.span_submitted_total", float32(len(batch)), map[string]string{}))
 	}
-	samples.Add(ssf.Timing("splunk.span_submission_duration_ns", start.Sub(time.Now()), time.Nanosecond, map[string]string{}))
+	samples.Add(ssf.Timing("splunk.span_submission_duration_ns", time.Now().Sub(start), time.Nanosecond, map[string]string{}))
 }
 
 func (sss *splunkSpanSink) batchAndSend() {

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -121,7 +121,7 @@ func TestSpanIngestLimits(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, nil))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(1*time.Millisecond), time.Duration(0), 1, 0)
+		"test-host", "", logger, time.Duration(10*time.Millisecond), time.Duration(0), 1, 0)
 	require.NoError(t, err)
 	err = sink.Start(nil)
 	require.NoError(t, err)

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -56,7 +56,7 @@ func TestSpanIngestBatch(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), 0)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), 0, 0)
 	require.NoError(t, err)
 	err = sink.Start(nil)
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestSpanIngestBatch(t *testing.T) {
 	for i := 0; i < nToFlush; i++ {
 		span.Id = int64(i + 1)
 		err = sink.Ingest(span)
-		require.NoError(t, err)
+		require.NoError(t, err, "error ingesting the %dth span", i)
 	}
 
 	sink.Flush()
@@ -121,7 +121,7 @@ func TestSpanIngestLimits(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, nil))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), 1)
+		"test-host", "", logger, time.Duration(1*time.Millisecond), time.Duration(0), 1, 0)
 	require.NoError(t, err)
 	err = sink.Start(nil)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestSpanIngestLimits(t *testing.T) {
 	}
 	// First ingest should succeed:
 	err = sink.Ingest(span)
-	require.NoError(t, err)
+	require.NoError(t, err, "first ingest")
 
 	// Now it's at capacity, next one should fail:
 	err = sink.Ingest(span)
@@ -158,7 +158,7 @@ func TestSpanIngestLimits(t *testing.T) {
 	// After flushing, it should succeed again:
 	sink.Flush()
 	err = sink.Ingest(span)
-	require.NoError(t, err)
+	require.NoError(t, err, "second ingest")
 }
 
 func BenchmarkBatchFlushing(b *testing.B) {
@@ -169,7 +169,7 @@ func BenchmarkBatchFlushing(b *testing.B) {
 	ts := httptest.NewServer(jsonEndpoint(b, nil))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), 0)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), 0, 0)
 	require.NoError(b, err)
 	err = sink.Start(nil)
 	require.NoError(b, err)
@@ -217,7 +217,7 @@ func BenchmarkBatchIngest(b *testing.B) {
 	ts := httptest.NewServer(jsonEndpoint(b, nil))
 	defer ts.Close()
 	sink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), 0)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), 0, 0)
 	require.NoError(b, err)
 	err = sink.Start(nil)
 	require.NoError(b, err)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR adds two configuration settings:

* `splunk_hec_ingest_timeout`: a time duration to limit how long blocking a single span should be allowed to take.

* `splunk_hec_early_flush_threshold`: the number of spans to ingest before attempting to flush the batch "early" (that is, before the flush interval has expired). This should allow veneur to keep up a steady stream of smaller flushes to the HEC endpoint, which ought to improve throughput & latency.

As an added bonus, it gets rid of the (mildly convoluted) capacity checking logic (where previously Ingest did the validation that ingesting a span wouldn't run out of capacity, now the background ingestion routine does), and introduces a few more useful metrics for span submission / ingestion:

* the standard sink "flushed" / "dropped" metrics now mean what they mean everywhere else: successfully ingested vs. dropped-at-ingest span counts.
* new metrics `veneur.splunk.span_submission_failed_total` and `splunk.span_submitted_total`: number of spans that failed to submit in a batch / successfully submitted in a batch.
* new metric `veneur.splunk.span_submission_duration_ns`: time that a flush took.

#### Motivation

Running on very span-emitty boxes, we saw that veneur drops a ton of spans, consumes a hell of a lot of memory and overloads the splunk HEC endpoints with its huge batches. Smaller batches are the better way forward!


#### Test plan

- [ ] roll this, configured with an ingestion & submission timeout & early submit threshold, to a span-submitty box in our infra, see if memory usage holds & if HEC endpoints are happier.

#### Rollout/monitoring/revert plan

Merge & roll to our infra *with the config from tests!*