### PR TITLE
Add flag to validate config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Veneur has a new sink that can be configured to send spans as events into a [Splunk HEC](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) endpoint. Thanks, [antifuchs](https://github.com/antifuchs) and [aditya](https://github.com/chimeracoder)!
 * Go 1.11 is now supported and used for all public Docker images. Thanks, [aditya](https://github.com/chimeracoder)!
 * The `veneur/trace` package now supports setting the indicator bit on a span manually. Thanks, [aditya](https://github.com/chimeracoder)!
+* A new `-validate-config` flag can be passed to make veneur exit appropriately after checking the specified config file. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Bugfixes
 * The trace client can now correctly parse trace headers emitted by Envoy. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Veneur has a new sink that can be configured to send spans as events into a [Splunk HEC](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) endpoint. Thanks, [antifuchs](https://github.com/antifuchs) and [aditya](https://github.com/chimeracoder)!
 * Go 1.11 is now supported and used for all public Docker images. Thanks, [aditya](https://github.com/chimeracoder)!
 * The `veneur/trace` package now supports setting the indicator bit on a span manually. Thanks, [aditya](https://github.com/chimeracoder)!
-* A new `-validate-config` flag can be passed to make veneur exit appropriately after checking the specified config file. Thanks, [sdboyer](https://github.com/sdboyer)!
+* The `-validate-config` and `validate-config-strict` flags will make veneur exit appropriately after checking the specified (`-f`) config file. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Bugfixes
 * The trace client can now correctly parse trace headers emitted by Envoy. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ Veneur supports specifying that metrics should only be routed to a specific metr
 
 Veneur expects to have a config file supplied via `-f PATH`. The included [example.yaml](https://github.com/stripe/veneur/blob/master/example.yaml) explains all the options!
 
+The config file can be validated using a pair of flags:
+
+* `-validate-config`: checks that the config file specified via `-f` is valid YAML, and has correct datatypes for all fields.
+* `-validate-config-strict`: checks the above, and also that there are no unknown fields.
+
 ## Configuration via Environment Variables
 
 Veneur and veneur-proxy each allow configuration via environment variables using [envconfig](https://github.com/kelseyhightower/envconfig). Options provided via environment variables take precedent over those in config. This allows stuff like:

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	configFile = flag.String("f", "", "The config file to read for settings.")
+	configFile     = flag.String("f", "", "The config file to read for settings.")
+	validateConfig = flag.Bool("validate-config", false, "Validate the config file, then immediately exit.")
 )
 
 func init() {
@@ -28,12 +29,18 @@ func main() {
 	}
 
 	conf, err := veneur.ReadConfig(*configFile)
+	var exitcode int
 	if err != nil {
+		exitcode = 1
 		if _, ok := err.(*veneur.UnknownConfigKeys); ok {
 			logrus.WithError(err).Warn("Config contains invalid or deprecated keys")
 		} else {
 			logrus.WithError(err).Fatal("Error reading config file")
 		}
+	}
+
+	if *validateConfig {
+		os.Exit(exitcode)
 	}
 
 	logger := logrus.StandardLogger()


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Adds a `-validate-config` flag that will cause Veneur to exit with an appropriate status code reflecting whether the config file passed validation or not.

#### Motivation
<!-- Why are you making this change? -->

It's useful to be able to validate config without hvaing to actually run Veneur.


<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

#### Test plan

Trivial local tests.


r? @aditya-stripe