### PR TITLE
Complain in veneur-emit if no data would have been sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Go 1.11 is now supported and used for all public Docker images. Thanks, [aditya](https://github.com/chimeracoder)!
 * The `veneur/trace` package now supports setting the indicator bit on a span manually. Thanks, [aditya](https://github.com/chimeracoder)!
 * The `-validate-config` and `validate-config-strict` flags will make veneur exit appropriately after checking the specified (`-f`) config file. Thanks, [sdboyer](https://github.com/sdboyer)!
+* `veneur-emit` will now exit with an error if no data would have been sent. Thanks, [sdboyer](https://github.com/sdboyer)!
 
 ## Bugfixes
 * The trace client can now correctly parse trace headers emitted by Envoy. Thanks, [aditya](https://github.com/chimeracoder)!

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -227,7 +227,7 @@ func main() {
 	if span.TraceId != 0 {
 		if !*toSSF {
 			logrus.WithField("ssf", *toSSF).
-				Fatal("Can's use tracing in non-ssf operation: Use -ssf to emit trace spans.")
+				Fatal("Can't use tracing in non-ssf operation: Use -ssf to emit trace spans.")
 		}
 		logrus.WithField("trace_id", span.TraceId).
 			WithField("span_id", span.Id).
@@ -240,6 +240,9 @@ func main() {
 	status, err := createMetric(span, passedFlags, *name, *tag)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating metrics.")
+	}
+	if len(span.Metrics) == 0 {
+		logrus.Fatal("No metrics to send. Must pass metric data via at least one of -count, -gauge, -timing, or -set.")
 	}
 	if *toSSF {
 		client, err := trace.NewClient(addr)


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Checks to see if any metrics would actually have been sent, and exits informatively if not.


#### Motivation
<!-- Why are you making this change? -->

Having the no-data and some-data cases look the same to the user is a really confusing UX.


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Local tests. These error:

```
veneur-emit
veneur-emit -name foo
```

This does not:

```
veneur-emit -name foo -gauge 100
````

r? @sjung-stripe
