### PR TITLE
Don't report Splunk HEC submission timeouts as sentry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 9.0.0, in progress
 
+## Bugfixes
+* The splunk span sink no longer reports an internal error for timeouts encountered in event submissions; instead, it reports a failure metric with a cause tag set to `submission_timeout`. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 # 8.0.0, 2018-09-20
 
 ## Added


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR makes timeouts encountered in finalizing splunk HTTP requests an error that doesn't go to sentry. They'll be reported as a metric instead.


#### Motivation

We're seeing some alert fatigue from these, and they're not exactly *bugs*.

#### Test plan

- [x] write a test
- [ ] try this out

#### Rollout/monitoring/revert plan

Merge & roll (: