### PR TITLE
Add a jitter setting for splunk span sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 9.0.0, in progress
 
+## Added
+* The splunk span sink's workers now jitter their submission intervals by a configurable number of spans, using the `splunk_hec_batch_size_jitter` configuration setting. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 ## Bugfixes
 * The splunk span sink no longer reports an internal error for timeouts encountered in event submissions; instead, it reports a failure metric with a cause tag set to `submission_timeout`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The splunk span sink now honors `Connection: keep-alive` from the HEC endpoint and keeps around as many idle HTTP connections in reserve as it has HEC submission workers. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 9.0.0, in progress
 
 ## Added
-* The splunk span sink's workers now jitter their submission intervals by a configurable number of spans, using the `splunk_hec_batch_size_jitter` configuration setting. Thanks, [antifuchs](https://github.com/antifuchs)!
+* The splunk span sink's workers now jitter their submission and flush intervals intervals by a configurable number of spans, using the `splunk_hec_batch_size_jitter` and `splunk_hec_sync_jitter` configuration settings. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Bugfixes
 * The splunk span sink no longer reports an internal error for timeouts encountered in event submissions; instead, it reports a failure metric with a cause tag set to `submission_timeout`. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/config.go
+++ b/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	SpanChannelCapacity           int      `yaml:"span_channel_capacity"`
 	SplunkHecAddress              string   `yaml:"splunk_hec_address"`
 	SplunkHecBatchSize            int      `yaml:"splunk_hec_batch_size"`
+	SplunkHecBatchSizeJitter      int      `yaml:"splunk_hec_batch_size_jitter"`
 	SplunkHecIngestTimeout        string   `yaml:"splunk_hec_ingest_timeout"`
 	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
 	SplunkHecSubmissionWorkers    int      `yaml:"splunk_hec_submission_workers"`

--- a/config.go
+++ b/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	SplunkHecIngestTimeout        string   `yaml:"splunk_hec_ingest_timeout"`
 	SplunkHecSendTimeout          string   `yaml:"splunk_hec_send_timeout"`
 	SplunkHecSubmissionWorkers    int      `yaml:"splunk_hec_submission_workers"`
+	SplunkHecSyncJitter           string   `yaml:"splunk_hec_sync_jitter"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`
 	SplunkSpanSampleRate          int      `yaml:"splunk_span_sample_rate"`

--- a/example.yaml
+++ b/example.yaml
@@ -366,6 +366,18 @@ splunk_hec_token: "00000000-0000-0000-0000-000000000000"
 # maximum event count per batch according to Splunk).
 splunk_hec_batch_size: 100
 
+# (optional) The maximum number of additional spans (in addition to
+# splunk_hec_batch_size) to allow for as jitter in each submission
+# period, to avoid all workers blocking span ingestion at the same
+# time.
+#
+# On startup, each worker picks a random number less than or equal to
+# the jitter set here, and will batch up to batch_size spans + that
+# jitter for each submission.
+#
+# If unset, this defaults to 0.
+splunk_hec_batch_size_jitter: 50
+
 # (optional) The maximum number of parallel submissions to do to the
 # splunk HEC endpoint. Must be greater than 0. If this setting is
 # omitted, defaults to 1.

--- a/example.yaml
+++ b/example.yaml
@@ -371,9 +371,9 @@ splunk_hec_batch_size: 100
 # period, to avoid all workers blocking span ingestion at the same
 # time.
 #
-# On startup, each worker picks a random number less than or equal to
-# the jitter set here, and will batch up to batch_size spans + that
-# jitter for each submission.
+# For each submission batch, every worker picks a new random maximum
+# batch size that lies between (splunk_hec_batch_size) and
+# (splunk_hec_batch_size)+(splunk_hec_batch_size_jitter).
 #
 # If unset, this defaults to 0.
 splunk_hec_batch_size_jitter: 50

--- a/example.yaml
+++ b/example.yaml
@@ -398,7 +398,6 @@ splunk_hec_send_timeout: "10ms"
 # 0, ingestion will wait indefintely until the span can be ingested.
 splunk_hec_ingest_timeout: "10ms"
 
-
 # (optional) The fraction of traces that are chosen to be reported to
 # Splunk.  On average, 1/N traces will be chosen to be reported to
 # Splunk. Setting this value to 1 or 0 disables sampling, reporting
@@ -407,6 +406,13 @@ splunk_hec_ingest_timeout: "10ms"
 # or none will.  Spans get excluded from sampling if they have
 # indicator=true set, or if they have a trace ID of 0.
 splunk_span_sample_rate: 10
+
+# (optional) The maximum (random) duration to wait, per worker, to
+# submit and re-open an HTTP request per flush period. If unset, the
+# splunk span sink does not wait and closes & re-opens every worker at
+# the same time, blocking span ingestion into the sink for the
+# duration it takes to make at least one HTTP request.
+splunk_hec_sync_jitter: "1s"
 
 # == PLUGINS ==
 

--- a/server.go
+++ b/server.go
@@ -416,7 +416,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, fmt.Errorf("both splunk_hec_address and splunk_hec_token need to be set!")
 		}
 		if conf.SplunkHecToken != "" && conf.SplunkHecAddress != "" {
-			var sendTimeout, ingestTimeout time.Duration
+			var sendTimeout, ingestTimeout, syncJitter time.Duration
 			if conf.SplunkHecSendTimeout != "" {
 				sendTimeout, err = time.ParseDuration(conf.SplunkHecSendTimeout)
 				if err != nil {
@@ -429,7 +429,13 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecBatchSize, conf.SplunkHecBatchSizeJitter, conf.SplunkHecSubmissionWorkers, conf.SplunkSpanSampleRate)
+			if conf.SplunkHecSyncJitter != "" {
+				syncJitter, err = time.ParseDuration(conf.SplunkHecSyncJitter)
+				if err != nil {
+					return ret, err
+				}
+			}
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, syncJitter, conf.SplunkHecBatchSize, conf.SplunkHecBatchSizeJitter, conf.SplunkHecSubmissionWorkers, conf.SplunkSpanSampleRate)
 			if err != nil {
 				return ret, err
 			}

--- a/server.go
+++ b/server.go
@@ -429,7 +429,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecBatchSize, conf.SplunkHecSubmissionWorkers, conf.SplunkSpanSampleRate)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecBatchSize, conf.SplunkHecBatchSizeJitter, conf.SplunkHecSubmissionWorkers, conf.SplunkSpanSampleRate)
 			if err != nil {
 				return ret, err
 			}

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -44,6 +44,7 @@ type splunkSpanSink struct {
 	hostname      string
 	sendTimeout   time.Duration
 	ingestTimeout time.Duration
+	syncJitter    time.Duration
 
 	workers int
 
@@ -83,7 +84,7 @@ var _ TestableSplunkSpanSink = &splunkSpanSink{}
 // that all spans in the trace will be chosen for the sample is 1/spanSampleRate.
 // Sampling is performed on the trace ID, so either all spans within a given trace
 // will be chosen, or none will.
-func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, batchSize int, batchSizeJitter int, workers int, spanSampleRate int) (sinks.SpanSink, error) {
+func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, syncJitter time.Duration, batchSize int, batchSizeJitter int, workers int, spanSampleRate int) (sinks.SpanSink, error) {
 	client, err := newHecClient(server, token)
 	if err != nil {
 		return nil, err
@@ -112,6 +113,7 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 		log:             log,
 		sendTimeout:     sendTimeout,
 		ingestTimeout:   ingestTimeout,
+		syncJitter:      syncJitter,
 		batchSize:       batchSize,
 		batchSizeJitter: batchSizeJitter,
 		spanSampleRate:  int64(spanSampleRate),
@@ -142,9 +144,16 @@ func (sss *splunkSpanSink) Start(cl *trace.Client) error {
 			}
 			batchSize += int(jitter.Int64())
 		}
-
+		syncJitter := time.Duration(0)
+		if sss.syncJitter != time.Duration(0) {
+			jitter, err := rand.Int(rand.Reader, big.NewInt(int64(sss.syncJitter)))
+			if err != nil {
+				return err
+			}
+			syncJitter = time.Duration(jitter.Int64())
+		}
 		ch := make(chan struct{})
-		go sss.submitter(ch, batchSize)
+		go sss.submitter(ch, batchSize, syncJitter)
 		sss.sync[i] = ch
 	}
 
@@ -165,7 +174,11 @@ func (sss *splunkSpanSink) Sync() {
 	sss.synced.Wait()
 }
 
-func (sss *splunkSpanSink) submitter(sync chan struct{}, batchSize int) {
+func (sss *splunkSpanSink) submitter(sync chan struct{}, batchSize int, syncJitter time.Duration) {
+	syncTimer := time.NewTimer(0)
+	if !syncTimer.Stop() {
+		<-syncTimer.C
+	}
 	for {
 		var req *http.Request
 		hecReq, err := sss.hec.newRequest()
@@ -176,11 +189,19 @@ func (sss *splunkSpanSink) submitter(sync chan struct{}, batchSize int) {
 		for {
 			select {
 			case _, ok := <-sync:
-				hecReq.Close()
 				if !ok {
-					// sink is shutting down, exit forever:
+					// sink is shutting down, exit forever now:
+					hecReq.Close()
 					return
 				}
+				// If the timer was already running,
+				// kick the sync off immediately;
+				// otherwise, wait for jitter seconds:
+				if !syncTimer.Stop() {
+					syncTimer.Reset(syncJitter)
+				}
+			case <-syncTimer.C:
+				hecReq.Close()
 				sss.synced.Done()
 				break Batch
 			case ev := <-sss.ingest:

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -2,10 +2,12 @@ package splunk
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -46,6 +48,7 @@ type splunkSpanSink struct {
 	workers int
 
 	batchSize            int
+	batchSizeJitter      int
 	hecSubmissionWorkers int
 	ingestedSpans        uint32
 	droppedSpans         uint32
@@ -80,11 +83,7 @@ var _ TestableSplunkSpanSink = &splunkSpanSink{}
 // that all spans in the trace will be chosen for the sample is 1/spanSampleRate.
 // Sampling is performed on the trace ID, so either all spans within a given trace
 // will be chosen, or none will.
-func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, batchSize int, workers int, spanSampleRate int) (sinks.SpanSink, error) {
-	if spanSampleRate < 1 {
-		spanSampleRate = 1
-	}
-
+func NewSplunkSpanSink(server string, token string, localHostname string, validateServerName string, log *logrus.Logger, ingestTimeout time.Duration, sendTimeout time.Duration, batchSize int, batchSizeJitter int, workers int, spanSampleRate int) (sinks.SpanSink, error) {
 	client, err := newHecClient(server, token)
 	if err != nil {
 		return nil, err
@@ -106,15 +105,16 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 	}
 
 	return &splunkSpanSink{
-		hec:            client,
-		httpClient:     httpC,
-		ingest:         make(chan *Event),
-		hostname:       localHostname,
-		log:            log,
-		sendTimeout:    sendTimeout,
-		ingestTimeout:  ingestTimeout,
-		batchSize:      batchSize,
-		spanSampleRate: int64(spanSampleRate),
+		hec:             client,
+		httpClient:      httpC,
+		ingest:          make(chan *Event),
+		hostname:        localHostname,
+		log:             log,
+		sendTimeout:     sendTimeout,
+		ingestTimeout:   ingestTimeout,
+		batchSize:       batchSize,
+		batchSizeJitter: batchSizeJitter,
+		spanSampleRate:  int64(spanSampleRate),
 	}, nil
 }
 
@@ -134,8 +134,17 @@ func (sss *splunkSpanSink) Start(cl *trace.Client) error {
 	sss.sync = make([]chan struct{}, workers)
 
 	for i := 0; i < workers; i++ {
+		batchSize := sss.batchSize
+		if sss.batchSizeJitter > 0 {
+			jitter, err := rand.Int(rand.Reader, big.NewInt(int64(sss.batchSizeJitter)))
+			if err != nil {
+				return err
+			}
+			batchSize += int(jitter.Int64())
+		}
+
 		ch := make(chan struct{})
-		go sss.submitter(ch)
+		go sss.submitter(ch, batchSize)
 		sss.sync[i] = ch
 	}
 
@@ -156,7 +165,7 @@ func (sss *splunkSpanSink) Sync() {
 	sss.synced.Wait()
 }
 
-func (sss *splunkSpanSink) submitter(sync chan struct{}) {
+func (sss *splunkSpanSink) submitter(sync chan struct{}, batchSize int) {
 	for {
 		var req *http.Request
 		hecReq, err := sss.hec.newRequest()
@@ -193,7 +202,7 @@ func (sss *splunkSpanSink) submitter(sync chan struct{}) {
 						Warn("Could not json-encode HEC event")
 					continue Batch
 				}
-				if ingested >= sss.batchSize {
+				if ingested >= batchSize {
 					// we consumed the batch size's worth, let's send it:
 					hecReq.Close()
 					break Batch

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -61,7 +61,7 @@ func TestSpanIngestBatch(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -153,7 +153,7 @@ func TestTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), nToFlush, 0, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), nToFlush, 0, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -205,6 +205,7 @@ func TestTimeout(t *testing.T) {
 
 const benchmarkCapacity = 100
 const benchmarkWorkers = 3
+const benchmarkJitter = 50
 
 func BenchmarkBatchIngest(b *testing.B) {
 	logger := logrus.StandardLogger()
@@ -213,7 +214,7 @@ func BenchmarkBatchIngest(b *testing.B) {
 	ts := httptest.NewServer(jsonEndpoint(b, nil))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), benchmarkCapacity, benchmarkWorkers, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), benchmarkCapacity, benchmarkJitter, benchmarkWorkers, 1)
 	require.NoError(b, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -61,7 +61,8 @@ func TestSpanIngestBatch(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 0, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), time.Duration(0),
+		nToFlush, 0, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -153,7 +154,8 @@ func TestTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), nToFlush, 0, 0, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), time.Duration(0),
+		nToFlush, 0, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -214,7 +216,8 @@ func BenchmarkBatchIngest(b *testing.B) {
 	ts := httptest.NewServer(jsonEndpoint(b, nil))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), benchmarkCapacity, benchmarkJitter, benchmarkWorkers, 1)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), time.Duration(0),
+		benchmarkCapacity, benchmarkJitter, benchmarkWorkers, 1)
 	require.NoError(b, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -259,7 +262,7 @@ func TestSampling(t *testing.T) {
 	ch := make(chan splunk.Event, nToFlush)
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 10)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), time.Duration(0), nToFlush, 0, 0, 10)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -320,7 +323,7 @@ func TestSamplingIndicators(t *testing.T) {
 	ch := make(chan splunk.Event, nToFlush)
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 10)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), time.Duration(0), nToFlush, 0, 0, 10)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adds a configurable jitter setting that makes each splunk span sink worker will determine on startup how many spans they will consume before closing their HTTP request. This should ensure that all workers check out new http connections (and so, block) in irregular intervals, which hopefully will make them less likely to collide (and so, block ingestion entirely).

#### Motivation

We've seen periods where all span workers were blocking ingestion a lot, causing about 50% of spans to get dropped from the sink.

#### Test plan

Try it out for real.

#### Rollout/monitoring/revert plan

Merge & roll