### PR TITLE
Actually re-use HTTP connections in the splunk HEC span sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bugfixes
 * The splunk span sink no longer reports an internal error for timeouts encountered in event submissions; instead, it reports a failure metric with a cause tag set to `submission_timeout`. Thanks, [antifuchs](https://github.com/antifuchs)!
+* The splunk span sink now honors `Connection: keep-alive` from the HEC endpoint and keeps around as many idle HTTP connections in reserve as it has HEC submission workers. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 8.0.0, 2018-09-20
 

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -79,6 +79,10 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 
 	trnsp := &http.Transport{}
 	httpC := &http.Client{Transport: trnsp}
+
+	// keep an idle connection in reserve for every worker:
+	trnsp.MaxIdleConnsPerHost = workers
+
 	if validateServerName != "" {
 		tlsCfg := &tls.Config{}
 		tlsCfg.ServerName = validateServerName

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -219,6 +221,7 @@ func (sss *splunkSpanSink) makeHTTPRequest(req *http.Request) {
 	}
 
 	defer func() {
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adjusts the splunk span sink's behavior to re-use HTTP connections:
* read the response bodies fully before closing them
* set a max idle connection count that's 2x the number of submission workers (so that there's one connection waiting to be re-used per submission worker)

#### Motivation

We saw some mildly displeasing behavior:

* veneur made tons of AAAA queries for the hostname per second (I counted up to 27/s on hosts that see a lot of spans), which actually impacted our DNS server performance.
* things got pretty slow, proooobably due to veneur making new connections instead of reusing the ones that it had.

#### Test plan

- [x] gonna roll this to prod and see if this affects our dns-lookup behavior
- [x] and see if it affects ingestion/drop rates.

#### Rollout/monitoring/revert plan

1. merge
2. configure the sink again
3. roll it out!