### PR TITLE
Only emit metrics error when reporting over UDP

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -241,9 +241,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating metrics.")
 	}
-	if len(span.Metrics) == 0 {
-		logrus.Fatal("No metrics to send. Must pass metric data via at least one of -count, -gauge, -timing, or -set.")
-	}
 	if *toSSF {
 		client, err := trace.NewClient(addr)
 		if err != nil {
@@ -261,6 +258,9 @@ func main() {
 			logrus.WithField("address", addr).
 				WithField("network", netAddr.Network()).
 				Fatal("hostport must be a UDP address for statsd metrics")
+		}
+		if len(span.Metrics) == 0 {
+			logrus.Fatal("No metrics to send. Must pass metric data via at least one of -count, -gauge, -timing, or -set.")
 		}
 		sendStatsd(netAddr.String(), span)
 	}


### PR DESCRIPTION

#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
r? @asf-stripe 

#### Motivation
<!-- Why are you making this change? -->
https://github.com/stripe/veneur/pull/547 breaks reporting of spans with no metrics

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
n/a

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
puppet