### PR TITLE
Do not report an error if the splunk sink can't HTTP POST

### DIFF
--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -212,8 +212,6 @@ func (sss *splunkSpanSink) makeHTTPRequest(req *http.Request) {
 		return
 	}
 	if err != nil {
-		sss.log.WithError(err).
-			Error("Could not execute HEC request")
 		samples.Add(ssf.Count(failureMetric, 1, map[string]string{
 			"cause": "execution",
 		}))


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR silences the error from HTTP POSTs which tend to be super useless but very voluminous.


#### Motivation

We have a metric, which is better at helping us detect problems.


R, @sjung-stripe