### PR TITLE
Enable sampling by trace ID for Splunk sink

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	SplunkHecSubmissionWorkers    int      `yaml:"splunk_hec_submission_workers"`
 	SplunkHecTLSValidateHostname  string   `yaml:"splunk_hec_tls_validate_hostname"`
 	SplunkHecToken                string   `yaml:"splunk_hec_token"`
+	SplunkSpanSampleRate          int      `yaml:"splunk_span_sample_rate"`
 	SsfBufferSize                 int      `yaml:"ssf_buffer_size"`
 	SsfListenAddresses            []string `yaml:"ssf_listen_addresses"`
 	StatsAddress                  string   `yaml:"stats_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -386,6 +386,14 @@ splunk_hec_send_timeout: "10ms"
 # 0, ingestion will wait indefintely until the span can be ingested.
 splunk_hec_ingest_timeout: "10ms"
 
+
+# (optional) The fraction of traces that are chosen to be reported to Splunk.
+# On average, 1/N traces will be chosen to be reported to Splunk. Setting this
+# value to 1 or 0 disables sampling, reporting all spans from all traces to Splunk.
+# Sampling is performed on the trace ID, so either all spans from a given trace
+# will be reported, or none will.
+splunk_span_sample_rate: 99
+
 # == PLUGINS ==
 
 # == S3 Output ==

--- a/server.go
+++ b/server.go
@@ -429,7 +429,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					return ret, err
 				}
 			}
-			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecBatchSize, conf.SplunkHecSubmissionWorkers)
+			sss, err := splunk.NewSplunkSpanSink(conf.SplunkHecAddress, conf.SplunkHecToken, conf.Hostname, conf.SplunkHecTLSValidateHostname, log, ingestTimeout, sendTimeout, conf.SplunkHecBatchSize, conf.SplunkHecSubmissionWorkers, conf.SplunkSpanSampleRate)
 			if err != nil {
 				return ret, err
 			}

--- a/sinks/sinks.go
+++ b/sinks/sinks.go
@@ -73,6 +73,10 @@ const MetricKeySpanIngestDuration = "sink.span_ingest_total_duration_ns"
 // this.
 const MetricKeyTotalSpansDropped = "sink.spans_dropped_total"
 
+// MetricKeyTotalSpansSkipped tracks the number of spans that are skipped due to
+// sampling, if sampling is enabled.
+const MetricKeyTotalSpansSkipped = "sink.spans_skipped_total"
+
 // SpanSink is a receiver of spans that handles sending those spans to some
 // downstream sink. Calls to `Ingest(span)` are meant to give the sink control
 // of the span, with periodic calls to flush as a signal for sinks that don't

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -61,7 +61,7 @@ func TestSpanIngestBatch(t *testing.T) {
 	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), nToFlush, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -153,7 +153,7 @@ func TestTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), nToFlush, 0)
+		"test-host", "", logger, time.Duration(0), time.Duration(10*time.Millisecond), nToFlush, 0, 1)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -213,7 +213,7 @@ func BenchmarkBatchIngest(b *testing.B) {
 	ts := httptest.NewServer(jsonEndpoint(b, nil))
 	defer ts.Close()
 	gsink, err := splunk.NewSplunkSpanSink(ts.URL, "00000000-0000-0000-0000-000000000000",
-		"test-host", "", logger, time.Duration(0), time.Duration(0), benchmarkCapacity, benchmarkWorkers)
+		"test-host", "", logger, time.Duration(0), time.Duration(0), benchmarkCapacity, benchmarkWorkers, 1)
 	require.NoError(b, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Enable sampling by trace ID for the Splunk sink. This allows us to report only 50%, or 33%, or 1%, etc. of traces to Splunk. Sampling is performed on the trace ID, so we will only ever report complete traces, even if sampling is enabled.


I'm using the 1/n syntax for this instead of the Kafka fractional version, because that's how the blocking profile, etc. already work, and we will rarely need further precision than that.

#### Motivation
<!-- Why are you making this change? -->

https://jira.corp.stripe.com/browse/OBS-8358

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @asf-stripe 
cc @stripe/observability 