### PR TITLE
Don't sample indicator spans in splunk sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * The splunk span sink no longer reports an internal error for timeouts encountered in event submissions; instead, it reports a failure metric with a cause tag set to `submission_timeout`. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The splunk span sink now honors `Connection: keep-alive` from the HEC endpoint and keeps around as many idle HTTP connections in reserve as it has HEC submission workers. Thanks, [antifuchs](https://github.com/antifuchs)!
 
+## Added
+* The splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
+
 # 8.0.0, 2018-09-20
 
 ## Added

--- a/example.yaml
+++ b/example.yaml
@@ -387,11 +387,13 @@ splunk_hec_send_timeout: "10ms"
 splunk_hec_ingest_timeout: "10ms"
 
 
-# (optional) The fraction of traces that are chosen to be reported to Splunk.
-# On average, 1/N traces will be chosen to be reported to Splunk. Setting this
-# value to 1 or 0 disables sampling, reporting all spans from all traces to Splunk.
-# Sampling is performed on the trace ID, so either all spans from a given trace
-# will be reported, or none will.
+# (optional) The fraction of traces that are chosen to be reported to
+# Splunk.  On average, 1/N traces will be chosen to be reported to
+# Splunk. Setting this value to 1 or 0 disables sampling, reporting
+# all spans from all traces to Splunk.  Sampling is performed on the
+# trace ID, so either all spans from a given trace will be reported,
+# or none will.  Spans get excluded from sampling if they have
+# indicator=true set, or if they have a trace ID of 0.
 splunk_span_sample_rate: 10
 
 # == PLUGINS ==

--- a/example.yaml
+++ b/example.yaml
@@ -392,7 +392,7 @@ splunk_hec_ingest_timeout: "10ms"
 # value to 1 or 0 disables sampling, reporting all spans from all traces to Splunk.
 # Sampling is performed on the trace ID, so either all spans from a given trace
 # will be reported, or none will.
-splunk_span_sample_rate: 99
+splunk_span_sample_rate: 10
 
 # == PLUGINS ==
 

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -318,10 +318,10 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		return err
 	}
 
-	// choose (1/spanSampleRate) spans for sampling
-	// if any spans have the traceID of 0, they will always
-	// be chosen, regardless of the sample rate.
-	if ssfSpan.TraceId%sss.spanSampleRate != 0 {
+	// choose (1/spanSampleRate) spans for sampling if any spans
+	// have the traceID of 0 or are declared indicator spans, they
+	// will always be chosen, regardless of the sample rate.
+	if !ssfSpan.Indicator && ssfSpan.TraceId%sss.spanSampleRate != 0 {
 		atomic.AddUint32(&sss.skippedSpans, 1)
 		return nil
 	}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR updates the sampling logic to not sample away indicator spans. It also adds tests.

#### Motivation

indicator spans are important, we oughtn't sample them.

#### Test plan

Wrote 2 tests!

#### Rollout/monitoring/revert plan

Merge & roll!

R, @aditya-stripe