### PR TITLE
Added simple retry logic for failed post requests (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Added
 * The splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
+* Added retry logic to POST requests if they fail due to IO exceptions (such as timeouts and connection resets). Requests now are tried four times; One initially and another three if the 1st request fails. Thanks, [volfco](https://github.com/volfco)!
 
 # 8.0.0, 2018-09-20
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Added a for loop in the PostHelper method to retry the request if the first request failed due to an IO exception, it'd try 3 more times with a 50ms pause after each retry. If these 3 requests fails, it executes the existing failure logic. If one of these 3 requests succeeds, the for loop is broken and execution resumes as normal.


#### Motivation
I'm seeing failing requests to Datadog in production, and less dataloss is always something that should be desired.

#### Test plan
I added a print statement in my local code to print when the post failed. I routed the datadog url to localhost and got....

![image](https://user-images.githubusercontent.com/433045/46762233-2c992a80-cc9c-11e8-8875-3f4c95fe912e.png)

Ta Da!


#### Rollout/monitoring/revert plan
Nothing should need to be done other than watch errors drop
