### PR TITLE
Add option to skip zero values for counters in SignalFx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## Added
 * The Splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
 * The SignalFx sink can now filter metric names by prefix with `signalfx_metric_name_prefix_drops` and tag literals (case-insensitive) with `signalfx_metric_tag_literal_drops`. Thanks [gphat](https://github.com/gphat)!
+* The splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
+* The SignalFx sink now has a `signalfx_emit_zero_counters` option that, if false, prevents emitting counters with a value of zero, as they dont' mean much. Thanks, [gphat](https://github.com/gphat)!
 
 ## Updated
 * The README's [Metrics section](https://github.com/stripe/veneur#metrics) has been updated, as it referred to some missing metrics. Thanks, [gphat](https://github.com/gphat)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 ## Added
 * The Splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
 * The SignalFx sink can now filter metric names by prefix with `signalfx_metric_name_prefix_drops` and tag literals (case-insensitive) with `signalfx_metric_tag_literal_drops`. Thanks [gphat](https://github.com/gphat)!
-* The splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
-* The SignalFx sink now has a `signalfx_emit_zero_counters` option that, if false, prevents emitting counters with a value of zero, as they dont' mean much. Thanks, [gphat](https://github.com/gphat)!
+* The SignalFx sink now has a `signalfx_drop_zero_counters` option that, if true, prevents emitting counters with a value of zero, as they dont' mean much. Thanks, [gphat](https://github.com/gphat)!
 
 ## Updated
 * The README's [Metrics section](https://github.com/stripe/veneur#metrics) has been updated, as it referred to some missing metrics. Thanks, [gphat](https://github.com/gphat)!

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package veneur
 
 type Config struct {
+<<<<<<< HEAD
 	Aggregates                    []string  `yaml:"aggregates"`
 	AwsAccessKeyID                string    `yaml:"aws_access_key_id"`
 	AwsRegion                     string    `yaml:"aws_region"`
@@ -64,6 +65,70 @@ type Config struct {
 	SignalfxMetricNamePrefixDrops []string  `yaml:"signalfx_metric_name_prefix_drops"`
 	SignalfxMetricTagPrefixDrops  []string  `yaml:"signalfx_metric_tag_prefix_drops"`
 	SignalfxPerTagAPIKeys         []struct {
+=======
+	Aggregates                   []string  `yaml:"aggregates"`
+	AwsAccessKeyID               string    `yaml:"aws_access_key_id"`
+	AwsRegion                    string    `yaml:"aws_region"`
+	AwsS3Bucket                  string    `yaml:"aws_s3_bucket"`
+	AwsSecretAccessKey           string    `yaml:"aws_secret_access_key"`
+	BlockProfileRate             int       `yaml:"block_profile_rate"`
+	DatadogAPIHostname           string    `yaml:"datadog_api_hostname"`
+	DatadogAPIKey                string    `yaml:"datadog_api_key"`
+	DatadogFlushMaxPerBody       int       `yaml:"datadog_flush_max_per_body"`
+	DatadogSpanBufferSize        int       `yaml:"datadog_span_buffer_size"`
+	DatadogTraceAPIAddress       string    `yaml:"datadog_trace_api_address"`
+	Debug                        bool      `yaml:"debug"`
+	DebugFlushedMetrics          bool      `yaml:"debug_flushed_metrics"`
+	DebugIngestedSpans           bool      `yaml:"debug_ingested_spans"`
+	EnableProfiling              bool      `yaml:"enable_profiling"`
+	FalconerAddress              string    `yaml:"falconer_address"`
+	FlushFile                    string    `yaml:"flush_file"`
+	FlushMaxPerBody              int       `yaml:"flush_max_per_body"`
+	ForwardAddress               string    `yaml:"forward_address"`
+	ForwardUseGrpc               bool      `yaml:"forward_use_grpc"`
+	GrpcAddress                  string    `yaml:"grpc_address"`
+	Hostname                     string    `yaml:"hostname"`
+	HTTPAddress                  string    `yaml:"http_address"`
+	IndicatorSpanTimerName       string    `yaml:"indicator_span_timer_name"`
+	Interval                     string    `yaml:"interval"`
+	KafkaBroker                  string    `yaml:"kafka_broker"`
+	KafkaCheckTopic              string    `yaml:"kafka_check_topic"`
+	KafkaEventTopic              string    `yaml:"kafka_event_topic"`
+	KafkaMetricBufferBytes       int       `yaml:"kafka_metric_buffer_bytes"`
+	KafkaMetricBufferFrequency   string    `yaml:"kafka_metric_buffer_frequency"`
+	KafkaMetricBufferMessages    int       `yaml:"kafka_metric_buffer_messages"`
+	KafkaMetricRequireAcks       string    `yaml:"kafka_metric_require_acks"`
+	KafkaMetricTopic             string    `yaml:"kafka_metric_topic"`
+	KafkaPartitioner             string    `yaml:"kafka_partitioner"`
+	KafkaRetryMax                int       `yaml:"kafka_retry_max"`
+	KafkaSpanBufferBytes         int       `yaml:"kafka_span_buffer_bytes"`
+	KafkaSpanBufferFrequency     string    `yaml:"kafka_span_buffer_frequency"`
+	KafkaSpanBufferMesages       int       `yaml:"kafka_span_buffer_mesages"`
+	KafkaSpanRequireAcks         string    `yaml:"kafka_span_require_acks"`
+	KafkaSpanSampleRatePercent   int       `yaml:"kafka_span_sample_rate_percent"`
+	KafkaSpanSampleTag           string    `yaml:"kafka_span_sample_tag"`
+	KafkaSpanSerializationFormat string    `yaml:"kafka_span_serialization_format"`
+	KafkaSpanTopic               string    `yaml:"kafka_span_topic"`
+	LightstepAccessToken         string    `yaml:"lightstep_access_token"`
+	LightstepCollectorHost       string    `yaml:"lightstep_collector_host"`
+	LightstepMaximumSpans        int       `yaml:"lightstep_maximum_spans"`
+	LightstepNumClients          int       `yaml:"lightstep_num_clients"`
+	LightstepReconnectPeriod     string    `yaml:"lightstep_reconnect_period"`
+	MetricMaxLength              int       `yaml:"metric_max_length"`
+	MutexProfileFraction         int       `yaml:"mutex_profile_fraction"`
+	NumReaders                   int       `yaml:"num_readers"`
+	NumSpanWorkers               int       `yaml:"num_span_workers"`
+	NumWorkers                   int       `yaml:"num_workers"`
+	OmitEmptyHostname            bool      `yaml:"omit_empty_hostname"`
+	Percentiles                  []float64 `yaml:"percentiles"`
+	ReadBufferSizeBytes          int       `yaml:"read_buffer_size_bytes"`
+	SentryDsn                    string    `yaml:"sentry_dsn"`
+	SignalfxAPIKey               string    `yaml:"signalfx_api_key"`
+	SignalfxEmitZeroCounters     bool      `yaml:"signalfx_emit_zero_counters"`
+	SignalfxEndpointBase         string    `yaml:"signalfx_endpoint_base"`
+	SignalfxHostnameTag          string    `yaml:"signalfx_hostname_tag"`
+	SignalfxPerTagAPIKeys        []struct {
+>>>>>>> Add option to skip zero values for counters in SignalFx
 		APIKey string `yaml:"api_key"`
 		Name   string `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package veneur
 
 type Config struct {
-<<<<<<< HEAD
 	Aggregates                    []string  `yaml:"aggregates"`
 	AwsAccessKeyID                string    `yaml:"aws_access_key_id"`
 	AwsRegion                     string    `yaml:"aws_region"`
@@ -60,75 +59,12 @@ type Config struct {
 	ReadBufferSizeBytes           int       `yaml:"read_buffer_size_bytes"`
 	SentryDsn                     string    `yaml:"sentry_dsn"`
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
+	SignalfxDropZeroCounters      bool      `yaml:"signalfx_drop_zero_counters"`
 	SignalfxEndpointBase          string    `yaml:"signalfx_endpoint_base"`
 	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
 	SignalfxMetricNamePrefixDrops []string  `yaml:"signalfx_metric_name_prefix_drops"`
 	SignalfxMetricTagPrefixDrops  []string  `yaml:"signalfx_metric_tag_prefix_drops"`
 	SignalfxPerTagAPIKeys         []struct {
-=======
-	Aggregates                   []string  `yaml:"aggregates"`
-	AwsAccessKeyID               string    `yaml:"aws_access_key_id"`
-	AwsRegion                    string    `yaml:"aws_region"`
-	AwsS3Bucket                  string    `yaml:"aws_s3_bucket"`
-	AwsSecretAccessKey           string    `yaml:"aws_secret_access_key"`
-	BlockProfileRate             int       `yaml:"block_profile_rate"`
-	DatadogAPIHostname           string    `yaml:"datadog_api_hostname"`
-	DatadogAPIKey                string    `yaml:"datadog_api_key"`
-	DatadogFlushMaxPerBody       int       `yaml:"datadog_flush_max_per_body"`
-	DatadogSpanBufferSize        int       `yaml:"datadog_span_buffer_size"`
-	DatadogTraceAPIAddress       string    `yaml:"datadog_trace_api_address"`
-	Debug                        bool      `yaml:"debug"`
-	DebugFlushedMetrics          bool      `yaml:"debug_flushed_metrics"`
-	DebugIngestedSpans           bool      `yaml:"debug_ingested_spans"`
-	EnableProfiling              bool      `yaml:"enable_profiling"`
-	FalconerAddress              string    `yaml:"falconer_address"`
-	FlushFile                    string    `yaml:"flush_file"`
-	FlushMaxPerBody              int       `yaml:"flush_max_per_body"`
-	ForwardAddress               string    `yaml:"forward_address"`
-	ForwardUseGrpc               bool      `yaml:"forward_use_grpc"`
-	GrpcAddress                  string    `yaml:"grpc_address"`
-	Hostname                     string    `yaml:"hostname"`
-	HTTPAddress                  string    `yaml:"http_address"`
-	IndicatorSpanTimerName       string    `yaml:"indicator_span_timer_name"`
-	Interval                     string    `yaml:"interval"`
-	KafkaBroker                  string    `yaml:"kafka_broker"`
-	KafkaCheckTopic              string    `yaml:"kafka_check_topic"`
-	KafkaEventTopic              string    `yaml:"kafka_event_topic"`
-	KafkaMetricBufferBytes       int       `yaml:"kafka_metric_buffer_bytes"`
-	KafkaMetricBufferFrequency   string    `yaml:"kafka_metric_buffer_frequency"`
-	KafkaMetricBufferMessages    int       `yaml:"kafka_metric_buffer_messages"`
-	KafkaMetricRequireAcks       string    `yaml:"kafka_metric_require_acks"`
-	KafkaMetricTopic             string    `yaml:"kafka_metric_topic"`
-	KafkaPartitioner             string    `yaml:"kafka_partitioner"`
-	KafkaRetryMax                int       `yaml:"kafka_retry_max"`
-	KafkaSpanBufferBytes         int       `yaml:"kafka_span_buffer_bytes"`
-	KafkaSpanBufferFrequency     string    `yaml:"kafka_span_buffer_frequency"`
-	KafkaSpanBufferMesages       int       `yaml:"kafka_span_buffer_mesages"`
-	KafkaSpanRequireAcks         string    `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRatePercent   int       `yaml:"kafka_span_sample_rate_percent"`
-	KafkaSpanSampleTag           string    `yaml:"kafka_span_sample_tag"`
-	KafkaSpanSerializationFormat string    `yaml:"kafka_span_serialization_format"`
-	KafkaSpanTopic               string    `yaml:"kafka_span_topic"`
-	LightstepAccessToken         string    `yaml:"lightstep_access_token"`
-	LightstepCollectorHost       string    `yaml:"lightstep_collector_host"`
-	LightstepMaximumSpans        int       `yaml:"lightstep_maximum_spans"`
-	LightstepNumClients          int       `yaml:"lightstep_num_clients"`
-	LightstepReconnectPeriod     string    `yaml:"lightstep_reconnect_period"`
-	MetricMaxLength              int       `yaml:"metric_max_length"`
-	MutexProfileFraction         int       `yaml:"mutex_profile_fraction"`
-	NumReaders                   int       `yaml:"num_readers"`
-	NumSpanWorkers               int       `yaml:"num_span_workers"`
-	NumWorkers                   int       `yaml:"num_workers"`
-	OmitEmptyHostname            bool      `yaml:"omit_empty_hostname"`
-	Percentiles                  []float64 `yaml:"percentiles"`
-	ReadBufferSizeBytes          int       `yaml:"read_buffer_size_bytes"`
-	SentryDsn                    string    `yaml:"sentry_dsn"`
-	SignalfxAPIKey               string    `yaml:"signalfx_api_key"`
-	SignalfxEmitZeroCounters     bool      `yaml:"signalfx_emit_zero_counters"`
-	SignalfxEndpointBase         string    `yaml:"signalfx_endpoint_base"`
-	SignalfxHostnameTag          string    `yaml:"signalfx_hostname_tag"`
-	SignalfxPerTagAPIKeys        []struct {
->>>>>>> Add option to skip zero values for counters in SignalFx
 		APIKey string `yaml:"api_key"`
 		Name   string `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`

--- a/example.yaml
+++ b/example.yaml
@@ -277,7 +277,7 @@ signalfx_metric_tag_prefix_drops:
 # that can be defaulted on the SignalFx-side. This is an optimization — similar
 # to StatsD's `deleteCounters` — but for situations where clients may be blindly
 # emitting counters that have accumulated no zeros. (Veneur itself does this!)
-signalfx_drop_zero_counters: true
+signalfx_drop_zero_counters: false
 
 # == LightStep ==
 # LightStep can be a sink for trace spans.

--- a/example.yaml
+++ b/example.yaml
@@ -273,6 +273,12 @@ signalfx_metric_name_prefix_drops:
 signalfx_metric_tag_prefix_drops:
   - ""
 
+# If true, skips emission of any counter metrics with a value of zero, since
+# that can be defaulted on the SignalFx-side. This is an optimization — similar
+# to StatsD's `deleteCounters` — but for situations where clients may be blindly
+# emitting counters that have accumulated no zeros. (Veneur itself does this!)
+signalfx_drop_zero_counters: true
+
 # == LightStep ==
 # LightStep can be a sink for trace spans.
 

--- a/server.go
+++ b/server.go
@@ -358,7 +358,11 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		for _, perTag := range conf.SignalfxPerTagAPIKeys {
 			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, &tracedHTTP)
 		}
+<<<<<<< HEAD
 		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink)
+=======
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxEmitZeroCounters, metricSink)
+>>>>>>> Add option to skip zero values for counters in SignalFx
 		if err != nil {
 			return ret, err
 		}

--- a/server.go
+++ b/server.go
@@ -358,11 +358,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		for _, perTag := range conf.SignalfxPerTagAPIKeys {
 			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, &tracedHTTP)
 		}
-<<<<<<< HEAD
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink)
-=======
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxEmitZeroCounters, metricSink)
->>>>>>> Add option to skip zero values for counters in SignalFx
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, conf.SignalfxDropZeroCounters, metricSink)
 		if err != nil {
 			return ret, err
 		}

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -395,9 +395,9 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 		Tags: map[string]string{
 			dogstatsd.EventIdentifierKey: "",
-			"foo":     "bar",
-			"baz":     "gorch",
-			"novalue": "",
+			"foo":                        "bar",
+			"baz":                        "gorch",
+			"novalue":                    "",
 		},
 	}
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -395,9 +395,9 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 		Tags: map[string]string{
 			dogstatsd.EventIdentifierKey: "",
-			"foo":                        "bar",
-			"baz":                        "gorch",
-			"novalue":                    "",
+			"foo":     "bar",
+			"baz":     "gorch",
+			"novalue": "",
 		},
 	}
 


### PR DESCRIPTION
#### Summary
Add SFx sink option to skip emitting counters with a value of zero.

#### Motivation
It's common in many code bases to create an integer value and increment it when something happens. Periodically you emit the value of this counter and reset it to 0. Most times this code — or the client library — do not skip this behavior if the value is 0.

Since SignalFx is ok with sparse data and can default to 0, there's no reason to emit this all the time. Doing so just wastes DPM. The tradeoff is that if a metric is 0 and a user wants to verify it exists, they won't see it / SignalFx won't know about it. 

#### Test plan
Unit tests

r? @asf-stripe 
cc @stripe/observability 