### PR TITLE
Don't treat "No data" from HEC as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Added
 * The Splunk span sink can be configured with a sample rate for non-indicator spans with the `splunk_span_sample_rate` setting. Thanks, [aditya](https://github.com/chimeracoder)!
+* The splunk span sink now has configuration parameters `splunk_hec_max_connection_lifetime` and `splunk_hec_connection_lifetime_jitter` to regulate how long HTTP connections can be kept alive for. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The SignalFx sink can now filter metric names by prefix with `signalfx_metric_name_prefix_drops` and tag literals (case-insensitive) with `signalfx_metric_tag_literal_drops`. Thanks [gphat](https://github.com/gphat)!
 
 ## Updated


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This PR makes the splunk span sink handle the "no data"/code:5 response as a peaceful condition & reports a metric (which should allow us to determine how over/under-provisioned certain boxes are in terms of HEC consumption capacity)

#### Motivation

We were getting errors.

#### Test plan

I'll roll this to QA & see if this resolves it.

#### Rollout/monitoring/revert plan

merge & deploy everywhere (:

R, @aditya-stripe?