### PR TITLE
Introduce a new metrics client that supports dependency injection.

### DIFF
--- a/internal/metricsClient/client.go
+++ b/internal/metricsClient/client.go
@@ -1,0 +1,65 @@
+// package metricsClient exports a metrics client capable
+package metricsClient
+
+import (
+	"time"
+
+	"github.com/stripe/veneur/trace"
+	"github.com/stripe/veneur/trace/metrics"
+
+	"github.com/stripe/veneur/ssf"
+)
+
+// NewSSFAddingClient returns a SSFAddingClient that attaches metrics to an object
+// that supports the Sampler interface.
+//
+// This exists for compatability with the existing convention of adding metrics
+// to a Trace or SSFSample object which is later submitted in batch.
+//
+// Unlike the normal metric client, SSFAddingClient assumes the client will submit
+// the sampler.
+func NewSSFAddingClient(sampler Sampler) SSFAddingClient {
+	return SSFAddingClient{sampler}
+}
+
+type SSFAddingClient struct {
+	adder Sampler
+}
+
+func (s SSFAddingClient) Count(name string, incr float32, tags map[string]string) {
+	s.adder.Add(ssf.Count(name, incr, tags))
+}
+
+func (s SSFAddingClient) Gauge(name string, value float32, tags map[string]string) {
+	s.adder.Add(ssf.Gauge(name, value, tags))
+}
+
+func (s SSFAddingClient) Timing(name string, duration time.Duration, tags map[string]string) {
+	s.adder.Add(ssf.Timing(name, duration, time.Nanosecond, tags))
+}
+
+type Sampler interface {
+	Add(...*ssf.SSFSample)
+}
+
+// NewSSFDirectClient returns a SSFDirectClient that submits metrics directly using
+// the trace client.
+func NewSSFDirectClient(tc *trace.Client) SSFDirectClient {
+	return SSFDirectClient{tc}
+}
+
+type SSFDirectClient struct {
+	tc *trace.Client
+}
+
+func (s SSFDirectClient) Count(name string, incr float32, tags map[string]string) {
+	metrics.ReportOne(s.tc, ssf.Count(name, incr, tags))
+}
+
+func (s SSFDirectClient) Gauge(name string, value float32, tags map[string]string) {
+	metrics.ReportOne(s.tc, ssf.Gauge(name, value, tags))
+}
+
+func (s SSFDirectClient) Timing(name string, duration time.Duration, tags map[string]string) {
+	metrics.ReportOne(s.tc, ssf.Timing(name, duration, time.Nanosecond, tags))
+}


### PR DESCRIPTION
I'd like to propose a metrics client approach that avoids top level functions and allows for dependency injection.

**Motivation**
We have two prescribed ways of adding metrics today:

a.) creating a span, adding metrics, and finishing it.
b.) creating a SSF.Sample, adding metrics to it, and calling metrics.ReportBatch to submit it.

These approaches are tightly coupled with implementation and impose strict dependencies on clients. It's not possible to replace ReportBatch with a mock object, for example, or a different stats backend. Consider this use case:

```
type MyTask struct{
    metricsClient metrics
}

type metrics interface {
    Count(string, int)
}

func (t MyTask) DoJob(ctx context.Context) {
    // do things ...
    t.metricsClient.Count("finished", 1)
}
```

The above code has a couple of nice qualities about it:

a.) It doesn't depend on the metrics implementation in any way. It doesn't even import anything metrics related! We can change out the metrics implementation to a mock for testing, for example. This also facilitates simpler migrations if we need to change out the metrics implementation.

b.) It doesn't need to know anything about tracing. For example, it's not always practical to start a span in every function. For example, I may want to use [runtime.trace instrumentation](https://golang.org/pkg/runtime/trace/) instead of distributed tracing for in-process traces. Moreover,  extracting spans from is very fragile. If DoJob's caller isn't using veneur's tracing library, for example, we simply don't have access to spans.

c.) We don't lose any of the functionality we had before. If we want to add metrics to a span, whoever constructs MyTask needs to inject a SSFAddingClient configured with the trace we want to attach to. This is entirely opaque the MyTask's code.

This approach is much more idiomatic golang and affords us greater flexibility.

For now, I've hidden the implementation inside internal/ because I don't want to make API commitments to external users until we have some experience and can finalize the API.

r? @stripe/observability 
r? @ChimeraCoder @asf-stripe @cory-stripe 