### PR TITLE
Add Datadog distribution support to Veneur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Added
 * The new X-Ray sink provides support for [AWS X-Ray](https://aws.amazon.com/xray/) as a tracing backend. Thanks, [gphat](https://github.com/gphat) and [aditya](https://github.com/chimeracoder)!
 * A new package `github.com/stripe/veneur/trace/testbackend` contains two trace client backends that can be used to test the trace data emitted by applications. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/distributions/) type for DogStatsD is now permitted and treated as a plain histogram for compatibility. Thanks, [gphat](https://github.com/gphat)!
 
 ## Updated
 * Updated the vendored version of x/net, which picks up a package rename that can lead issues when integrating veneur into other codebases. Thanks, [nicktrav](https://github.com/nicktrav)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # 11.0.0, in progress
 
+## Added
+* Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/distributions/) type for DogStatsD is now supported and treated as a plain histogram for compatibility. Thanks, [gphat](https://github.com/gphat)!
 
 # 10.0.0, 2018-12-19
 
 ## Added
 * The new X-Ray sink provides support for [AWS X-Ray](https://aws.amazon.com/xray/) as a tracing backend. Thanks, [gphat](https://github.com/gphat) and [aditya](https://github.com/chimeracoder)!
 * A new package `github.com/stripe/veneur/trace/testbackend` contains two trace client backends that can be used to test the trace data emitted by applications. Thanks, [antifuchs](https://github.com/antifuchs)!
-* Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/distributions/) type for DogStatsD is now permitted and treated as a plain histogram for compatibility. Thanks, [gphat](https://github.com/gphat)!
 
 ## Updated
 * Updated the vendored version of x/net, which picks up a package rename that can lead issues when integrating veneur into other codebases. Thanks, [nicktrav](https://github.com/nicktrav)!

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ More generically, Veneur is a convenient sink for various observability primitiv
 
 Once you cross a threshold into dozens, hundreds or (gasp!) thousands of machines emitting metric data for an application, you've moved into that world where data about individual hosts is uninteresting except in aggregate form. Instead of paying to store tons of data points and then aggregating them later at read-time, Veneur can calculate global aggregates, like percentiles and forward those along to your time series database, etc.
 
-Veneur is also a StatsD or [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) protocol transport, fowarding the locally collected metrics over more reliable TCP
+Veneur is also a StatsD or [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) protocol transport, forwarding the locally collected metrics over more reliable TCP
 implementations.
 
 Here are some examples of why Stripe and other companies are using Veneur today:
@@ -120,6 +120,10 @@ Clients can choose to override this behavior by [including the tag `veneurlocalo
 Because Veneur is built to handle lots and lots of data, it uses approximate histograms. We have our own implementation of [Dunning's t-digest](tdigest/merging_digest.go), which has bounded memory consumption and reduced error at extreme quantiles. Metrics are consistently routed to the same worker to distribute load and to be added to the same histogram.
 
 Datadog's DogStatsD — and StatsD — uses an exact histogram which retains all samples and is reset every flush period. This means that there is a loss of precision when using Veneur, but the resulting percentile values are meant to be more representative of a global view.
+
+### Datadog Distributions
+
+Because Veneur already handles "global" histograms, any DogStatsD packets received with type `d` — [Datadog's distribution type](https://docs.datadoghq.com/developers/metrics/distributions/) — will be considered a histogram and therefore compatible with all sinks. Veneur does **not** send any metrics to Datadog typed as a Datadog-native distribution.
 
 ## Approximate Sets
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -448,6 +448,14 @@ func TestParserTimer(t *testing.T) {
 	assert.Equal(t, "timer", m.Type, "Type")
 }
 
+func TestParserDistribution(t *testing.T) {
+	m, _ := samplers.ParseMetric([]byte("a.b.c:0.1716441474854946|d|#filter:flatulent"))
+	assert.NotNil(t, m, "Got nil metric!")
+	assert.Equal(t, "a.b.c", m.Name, "Name")
+	assert.Equal(t, float64(0.1716441474854946), m.Value, "Value")
+	assert.Equal(t, "histogram", m.Type, "Type")
+}
+
 func TestParserTimerFloat(t *testing.T) {
 	m, _ := samplers.ParseMetric([]byte("a.b.c:1.234|ms"))
 	assert.NotNil(t, m, "Got nil metric!")

--- a/samplers/parser.go
+++ b/samplers/parser.go
@@ -295,7 +295,7 @@ func ParseMetric(packet []byte) (*UDPMetric, error) {
 		ret.Type = "counter"
 	case 'g':
 		ret.Type = "gauge"
-	case 'h':
+	case 'd', 'h': // consider DogStatsD's "distribution" to be a histogram
 		ret.Type = "histogram"
 	case 'm': // We can ignore the s in "ms"
 		ret.Type = "timer"

--- a/sinks/datadog/README.md
+++ b/sinks/datadog/README.md
@@ -38,6 +38,7 @@ Veneur adheres to [the official DogStatsD datagram format](http://docs.datadoghq
 
 * The tag `veneurlocalonly` is stripped and influences forwarding behavior, as discussed below.
 * The tag `veneurglobalonly` is stripped and influences forwarding behavior, as discussed below.
+* [Distributions](https://docs.datadoghq.com/developers/metrics/distributions/) are treated as normal histograms, which are global when veneur is configured to merge. As such, Veneur will not send any metrics as distributions to Datadog.
 
 ## Lack of Host Tags for Aggregated Metrics
 


### PR DESCRIPTION
#### Summary
Adds support for Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/distributions/) metric type. Also fixes a typo I found. 😀 

#### Motivation
Now that this feature is alive in Datadog by way of a new DogStatsD metric type of `d`, some users may need Veneur to not explode when it encounters the metric.

Specifically, since Veneur is already in the business of global histograms, we can just treat this as a histogram.  

#### Test plan
New test included