### PR TITLE
Allow configuring SFX flush batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/distributions/) type for DogStatsD is now supported and treated as a plain histogram for compatibility. Thanks, [gphat](https://github.com/gphat)!
 * Add support for `tags_exclude` to the DataDog metrics sink. Thanks, [mhamrah](https://github.com/mhamrah)!
 * The `github.com/stripe/veneur/trace` package has brand new and much more extensive [documentation](https://godoc.org/github.com/stripe/veneur/trace)! Thanks, [antifuchs](https://github.com/antifuchs)!
+* New configuration setting `signalfx_flush_max_per_body` that allows limiting the payload of HTTP POST bodies containing data points destined for SignalFx. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 10.0.0, 2018-12-19
 

--- a/config.go
+++ b/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	SentryDsn                     string    `yaml:"sentry_dsn"`
 	SignalfxAPIKey                string    `yaml:"signalfx_api_key"`
 	SignalfxEndpointBase          string    `yaml:"signalfx_endpoint_base"`
+	SignalfxFlushMaxPerBody       int       `yaml:"signalfx_flush_max_per_body"`
 	SignalfxHostnameTag           string    `yaml:"signalfx_hostname_tag"`
 	SignalfxMetricNamePrefixDrops []string  `yaml:"signalfx_metric_name_prefix_drops"`
 	SignalfxMetricTagPrefixDrops  []string  `yaml:"signalfx_metric_tag_prefix_drops"`

--- a/example.yaml
+++ b/example.yaml
@@ -272,6 +272,14 @@ signalfx_metric_name_prefix_drops:
 signalfx_metric_tag_prefix_drops:
   - ""
 
+# The maximum number of datapoints in a single HTTP request to
+# signalfx. On flush time, if veneur would flush more than the number
+# configured here, it breaks the flushes apart into batches of this
+# configured max size and submits them in parallel HTTP requests. If
+# set to zero (the default), veneur makes a single HTTP request per
+# signalfx flush endpoint.
+signalfx_flush_max_per_body: 0
+
 # == AWS X-Ray ==
 # X-Ray can be a sink for trace spans.
 

--- a/server.go
+++ b/server.go
@@ -360,7 +360,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		for _, perTag := range conf.SignalfxPerTagAPIKeys {
 			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, &tracedHTTP)
 		}
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink, 0)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink, conf.SignalfxFlushMaxPerBody)
 		if err != nil {
 			return ret, err
 		}

--- a/server.go
+++ b/server.go
@@ -360,7 +360,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		for _, perTag := range conf.SignalfxPerTagAPIKeys {
 			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, &tracedHTTP)
 		}
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink, 0)
 		if err != nil {
 			return ret, err
 		}

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -280,7 +280,10 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 	}
 	span.Add(ssf.Timing(sinks.MetricKeyMetricFlushDuration, time.Since(flushStart), time.Nanosecond, tags))
 	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(numPoints), tags))
-	sfx.log.WithField("metrics", len(interMetrics)).Info("Completed flush to SignalFx")
+	sfx.log.WithFields(logrus.Fields{
+		"metrics": len(interMetrics),
+		"success": err == nil,
+	}).Info("Completed flush to SignalFx")
 
 	return err
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This change adds a config setting, `signalfx_max_flush_batch_size`
that allows limiting the number of datapoints that get submitted to
SignalFx in one go.

It also amends the "Completed flush to signalfx" log message by a
field that indicates whether the batch had any errors, so we can find
a reasonable number of datapoints to flush.

#### Motivation
We need this because some proxies limit the HTTP POST payload size,
and this is the easiest way to ensure we ~never exceed that limit. 
Also, feature parity with the datadog sink: it has the same setting.

#### Test plan

I wrote a test to ensure that the batching works; Going to try this
out in our staging environment and see if this improves the situation
re. the payload size errors we saw.

#### Rollout/monitoring/revert plan

1. Merge & roll it out
2. Adjust our config to the p95 of successful flushes.
3. Roll that config