### PR TITLE
Fix sfx submissions reporting a timeout when one encounters an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 12.0.0, in progress
 
+## Bugfixes
+* The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 11.0.0, 2019-01-22
 

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -51,9 +51,8 @@ func submitDatapoints(ctx context.Context, cl *trace.Client, client dpsink.Sink,
 	if err != nil {
 		span.Error(err)
 		span.Add(ssf.Count("flush.error_total", 1, map[string]string{"cause": "io", "sink": "signalfx"}))
-		errs <- err
 	}
-	errs <- nil
+	errs <- err
 }
 
 func (c *collection) submit(ctx context.Context, cl *trace.Client, maxPerFlush int) error {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR makes `submitDataponts` send only exactly the error value into the results channel if an error occurs, instead of first sending an error and then nil. This fixes a leaked channel&goroutine, as well as the span structure that is reported on errors.

#### Motivation
Now this is an embarrassing bug: I made the submitDatapoints function send to the error chan twice. This causes the overall Flush to report an error (after 9s) rather than actually report the error.


#### Test plan

I wish we had something to test for leaked goroutines/channels, it would have caught this exact problem I think.

#### Rollout/monitoring/revert plan

Merge & deploy across the world.