### PR TITLE
Add OT trace information on outgoing HTTP reqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 12.0.0, in progress
 
+## Added
+
+* The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!
 

--- a/http/http.go
+++ b/http/http.go
@@ -131,6 +131,9 @@ func (tripper *TraceRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	span.SetTag("action", tripper.prefix)
 	defer span.ClientFinish(tripper.tc)
 
+	// Add OpenTracing headers to the request, so downstream reqs can be identified:
+	trace.GlobalTracer.InjectRequest(span.Trace, req)
+
 	hct := newHTTPClientTracer(span.Attach(req.Context()), tripper.tc, tripper.prefix)
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), hct.getClientTrace()))
 	defer hct.finishSpan()

--- a/trace/opentracing_test.go
+++ b/trace/opentracing_test.go
@@ -222,6 +222,11 @@ func TestTracerInjectExtractHeader(t *testing.T) {
 	err = tracer.Inject(trace.context(), opentracing.HTTPHeaders, carrier)
 	assert.NoError(t, err)
 
+	assert.NotEqual(t, "", req.Header.Get(defaultHeaderFormat.SpanID),
+		"Headers %v should contain %q", req.Header, defaultHeaderFormat.SpanID)
+	assert.NotEqual(t, "", req.Header.Get(defaultHeaderFormat.TraceID),
+		"Headers %v should contain %q", req.Header, defaultHeaderFormat.TraceID)
+
 	c, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
 	assert.NoError(t, err)
 
@@ -230,7 +235,6 @@ func TestTracerInjectExtractHeader(t *testing.T) {
 	assert.Equal(t, trace.TraceID, ctx.TraceID())
 
 	assert.Equal(t, trace.SpanID, ctx.SpanID(), "original trace and context should share the same SpanId")
-	assert.Equal(t, trace.Resource, ctx.Resource())
 }
 
 func TestTraceExtractHeaderEnvoy(t *testing.T) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This change adds opentracing context headers to HTTP requests that veneur makes, so that proxies like envoy can attach their spans to ours & we can more easily tell what's going on in big forwarding scenarios. It also shaves the yak of the wrongly-set HTTP headers on outgoing requests that prevented Envoy from actually attaching its spans to our traces (and generating them in the first place!)

#### Motivation

I could do it & I kinda need it to figure out why envoy is unhappy with our submissions.

#### Test plan

I'm going to try this in our staging env.

#### Rollout/monitoring/revert plan

Roll it out. Everything else is already in place.