### PR TITLE
Add WriteConfig functionality to veneur configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
+* The ability to write configs to file using config.WriteConfig(...) so other Go programs can read/modify/write configs to be consumed by veneur. Thanks, [choo-stripe](https://github.com/choo-stripe)!
 
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/config_parse.go
+++ b/config_parse.go
@@ -149,6 +149,23 @@ func readConfig(r io.Reader) (Config, error) {
 	return c, unmarshalErr
 }
 
+// WriteConfig marshals a config into a file. It is useful
+// for dynamically configuring veneur in go and then writing
+// the config to a file to be consumed by veneur.
+func (c *Config) WriteConfig(filename string) error {
+	bts, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filename, bts, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Config) applyDefaults() {
 	if len(c.Aggregates) == 0 {
 		c.Aggregates = defaultConfig.Aggregates

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package veneur
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -63,6 +64,22 @@ debug: true
 	t.Log(err)
 	assert.True(t, ok, "Returned error should indicate a strictness error")
 	assert.Equal(t, true, c.Debug)
+}
+
+func TestWriteConfig(t *testing.T) {
+	c, err := ReadConfig("example.yaml")
+	assert.NoError(t, err)
+
+	tmpConfigFile, err := ioutil.TempFile("", "veneur-conf")
+	assert.NoError(t, err)
+	defer os.Remove(tmpConfigFile.Name())
+
+	err = c.WriteConfig(tmpConfigFile.Name())
+	assert.NoError(t, err)
+
+	c2, err := ReadConfig(tmpConfigFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, c2, c)
 }
 
 func TestHostname(t *testing.T) {


### PR DESCRIPTION
#### Summary
Add WriteConfig functionality to veneur configs


#### Motivation
We run veneur on hosts and in Kubernetes. Env variable config is not fully an option right now, and we'd like to keep our config to either file or env. This will allows us to create an init container that pulls in the veneur config, modifies it a bit in go code, and then writes the config to a volume that veneur will consume.


#### Test plan
Wrote tests.


#### Rollout/monitoring/revert plan
None
