### PR TITLE
Ensure SSF packets contain a span or a metric before passing to sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Added
 
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
-* Spans are now validated before being passed to sinks, instead of requiring each sink to perform validation separately. The metric `veneur.worker.span.invalid_total` tracks the number of invalid spans encountered. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
+* SSF packets are now validated to ensure they contain either a valid span or at least one metric. The metric `veneur.worker.ssf.empty_total` tracks the number of empty SSF packets encountered, which indicates a client error. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
 
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Spans are now validated before being passed to sinks, instead of requiring each sink to perform validation separately. The metric `veneur.worker.span.invalid_total` tracks the number of invalid spans encountered. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
 
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/worker.go
+++ b/worker.go
@@ -568,6 +568,11 @@ func (tw *SpanWorker) Work() {
 			}
 		}
 
+		if err := protocol.ValidateTrace(m); err != nil {
+			atomic.AddInt64(&tw.invalidSpanCount, 1)
+			continue
+		}
+
 		var wg sync.WaitGroup
 		for i, s := range tw.sinks {
 			tags := tw.sinkTags[i]

--- a/worker.go
+++ b/worker.go
@@ -521,10 +521,11 @@ type SpanWorker struct {
 	sinks      []sinks.SpanSink
 
 	// cumulative time spent per sink, in nanoseconds
-	cumulativeTimes []int64
-	traceClient     *trace.Client
-	statsd          *statsd.Client
-	capCount        int64
+	cumulativeTimes  []int64
+	traceClient      *trace.Client
+	statsd           *statsd.Client
+	capCount         int64
+	invalidSpanCount int64
 }
 
 // NewSpanWorker creates a SpanWorker ready to collect events and service checks.
@@ -647,4 +648,5 @@ func (tw *SpanWorker) Flush() {
 
 	metrics.Report(tw.traceClient, samples)
 	tw.statsd.Count("worker.span.hit_chan_cap", atomic.SwapInt64(&tw.capCount, 0), nil, 1.0)
+	tw.statsd.Count("worker.span.invalid_total", atomic.SwapInt64(&tw.invalidSpanCount, 0), nil, 1.0)
 }

--- a/worker.go
+++ b/worker.go
@@ -578,6 +578,7 @@ func (tw *SpanWorker) Work() {
 		if err := protocol.ValidateTrace(m); err != nil {
 			if len(m.Metrics) == 0 {
 				atomic.AddInt64(&tw.emptySSFCount, 1)
+				log.WithError(err).Debug("Invalid SSF packet: packet contains neither valid metrics nor a valid span")
 				continue
 			}
 		}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

SSF packets can contain one or more metrics, or they can contain a span, or they can contain a span *and* one or more metrics. If they contain neither, then they are considered invalid, and this indicates client error. This is a rare circumstance and is generally only encountered when writing a new SSF client library.

If this happens, increment an error metric and emit a log line at debug-level.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @sjung-stripe 
cc @stripe/observability 