### PR TITLE
Don't log X-Ray write errors at Error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
 * SSF packets are now validated to ensure they contain either a valid span or at least one metric. The metric `veneur.worker.ssf.empty_total` tracks the number of empty SSF packets encountered, which indicates a client error. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
 
+## Updated
+* The metric `veneur.sink.spans_dropped_total` now includes packets that were skipped due to UDP write errors. Thanks, [aditya](https://github.com/chimeracoder)!
+
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!
 

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -221,7 +221,8 @@ func (x *XRaySpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	// Send the segment
 	_, err = x.conn.Write(append(segmentHeader, b...))
 	if err != nil {
-		x.log.WithError(err).Error("Error sending segment")
+		x.log.WithError(err).Warn("Error sending segment")
+		atomic.AddInt64(&x.spansDropped, 1)
 		return err
 	}
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Writing to the X-Ray daemon can be flaky. This is fine, because it's UDP, but it's noisy enough that it causes spurious Sentry alerts.

I'm undecided on two points:

1. Should we log these at sub-error (e.g. `Warn`), which means that they'll be written to disk without being sent to Sentry, or should we not log them at all? If we log them at Warn, we'll at least have some indication of what's happening if we need to debug, but if the write errors happen all at once, we could suddenly generate large volumes of traffic.

2. Should we consider this to be a dropped span or not? We typically use that metric for spans which are sampled, but I think this qualifies - really, we care about how many spans are being sent vs. how many are being not-sent.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @sjung-stripe 
cc @stripe/observability 