### PR TITLE
Add benchmark for protocol.ValidTrace

### DIFF
--- a/protocol/wire.go
+++ b/protocol/wire.go
@@ -80,13 +80,11 @@ func (e *InvalidTrace) Error() string {
 // ValidTrace takes in an SSF span and determines if it is valid or not.
 // It also makes sure the Tags is non-nil, since we use it later.
 func ValidTrace(span *ssf.SSFSpan) bool {
-	ret := true
-	ret = ret && span.Id != 0
-	ret = ret && span.TraceId != 0
-	ret = ret && span.StartTimestamp != 0
-	ret = ret && span.EndTimestamp != 0
-	ret = ret && span.Name != ""
-	return ret
+	return span.Id != 0 &&
+		span.TraceId != 0 &&
+		span.StartTimestamp != 0 &&
+		span.EndTimestamp != 0 &&
+		span.Name != ""
 }
 
 // ValidateTrace takes in an SSF span and determines if it is valid or

--- a/protocol/wire.go
+++ b/protocol/wire.go
@@ -77,8 +77,8 @@ func (e *InvalidTrace) Error() string {
 	return fmt.Sprintf("not a valid trace span: %#v", e.span)
 }
 
-// ValidTrace takes in an SSF span and determines if it is valid or not.
-// It also makes sure the Tags is non-nil, since we use it later.
+// ValidTrace returns true if an SSFSpan contains all data necessary
+// to synthesize a span that can be used as part of a trace.
 func ValidTrace(span *ssf.SSFSpan) bool {
 	return span.Id != 0 &&
 		span.TraceId != 0 &&
@@ -87,9 +87,9 @@ func ValidTrace(span *ssf.SSFSpan) bool {
 		span.Name != ""
 }
 
-// ValidateTrace takes in an SSF span and determines if it is valid or
-// not.  It also makes sure the Tags is non-nil, since we use it
-// later. If the span is not valid, it returns an error.
+// ValidateTrace is identical to ValidTrace, except instead of returning
+// a boolean, it returns a non-nil error if the SSFSpan cannot be interpreted
+// as a span, and nil otherwise.
 func ValidateTrace(span *ssf.SSFSpan) error {
 	if !ValidTrace(span) {
 		return &InvalidTrace{span}


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

This is not particularly expensive, but I want to make sure we *know* that it's not expensive, since we end up having to call it more than once per SSF packet.


Also, while it doesn't have an effect on the performance (presumably due to already-inlined behavior), I also consolidated the boolean logic, because `ret` is a bit of an anti-pattern.

r? @stripe/observability 

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

```
$ go test -bench ValidTrace
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur/protocol
BenchmarkValidTrace-8           2000000000               1.91 ns/op
PASS
ok      github.com/stripe/veneur/protocol       4.078s
```

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
