### PR TITLE
Support statsd metric ingestion over Unix domain sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # 12.0.0, in progress
-
 ## Added
 
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
 * SSF packets are now validated to ensure they contain either a valid span or at least one metric. The metric `veneur.worker.ssf.empty_total` tracks the number of empty SSF packets encountered, which indicates a client error. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
 * SSF indicator spans can now report an additional "objective" metric, tagged with their service and name. Thanks, [tummychow](https://github.com/tummychow)!
-
+* Support for listening to statsd metrics on Unix Domain Socket(Datagram type)
 ## Updated
 * The metric `veneur.sink.spans_dropped_total` now includes packets that were skipped due to UDP write errors. Thanks, [aditya](https://github.com/chimeracoder)!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # 12.0.0, in progress
+
 ## Added
 
 * The OpenTracing implementation's `Tracer.Inject` in the `trace` package now sets HTTP headers in a way that tools like [Envoy](https://www.envoyproxy.io/) can propagate on traces. Thanks, [antifuchs](https://github.com/antifuchs)!
 * SSF packets are now validated to ensure they contain either a valid span or at least one metric. The metric `veneur.worker.ssf.empty_total` tracks the number of empty SSF packets encountered, which indicates a client error. Thanks, [tummychow](https://github.com/tummychow) and [aditya](https://github.com/chimeracoder)!
 * SSF indicator spans can now report an additional "objective" metric, tagged with their service and name. Thanks, [tummychow](https://github.com/tummychow)!
-* Support for listening to statsd metrics on Unix Domain Socket(Datagram type)
+* Support for listening to statsd metrics on Unix Domain Socket(Datagram type). Thanks, [prudhvi](https://github.com/prudhvi)!
+
 ## Updated
 * The metric `veneur.sink.spans_dropped_total` now includes packets that were skipped due to UDP write errors. Thanks, [aditya](https://github.com/chimeracoder)!
 

--- a/example.yaml
+++ b/example.yaml
@@ -3,7 +3,7 @@
 
 # The addresses on which to listen for statsd metrics. These are
 # formatted as URLs, with schemes corresponding to valid "network"
-# arguments on https://golang.org/pkg/net/#Listen.Currently, only udp
+# arguments on https://golang.org/pkg/net/#Listen. Currently, only udp,
 # tcp(including IPv4 and 6-only) and unixgram(datagram only) schemes are
 # supported. This option supersedes the "udp_address" and "tcp_address" options.
 statsd_listen_addresses:

--- a/example.yaml
+++ b/example.yaml
@@ -5,7 +5,7 @@
 # formatted as URLs, with schemes corresponding to valid "network"
 # arguments on https://golang.org/pkg/net/#Listen.Currently, only udp
 # tcp(including IPv4 and 6-only) and unixgram(datagram only) schemes are
-# supported.This option supersedes the "udp_address" and "tcp_address" options.
+# supported. This option supersedes the "udp_address" and "tcp_address" options.
 statsd_listen_addresses:
  - udp://localhost:8126
  - tcp://localhost:8126

--- a/example.yaml
+++ b/example.yaml
@@ -3,12 +3,13 @@
 
 # The addresses on which to listen for statsd metrics. These are
 # formatted as URLs, with schemes corresponding to valid "network"
-# arguments on https://golang.org/pkg/net/#Listen. Currently, only udp
-# and tcp (including IPv4 and 6-only) schemes are supported.
-# This option supersedes the "udp_address" and "tcp_address" options.
+# arguments on https://golang.org/pkg/net/#Listen.Currently, only udp
+# tcp(including IPv4 and 6-only) and unixgram(datagram only) schemes are
+# supported.This option supersedes the "udp_address" and "tcp_address" options.
 statsd_listen_addresses:
  - udp://localhost:8126
  - tcp://localhost:8126
+ - unixgram:///tmp/veneur-statsd.sock
 
 # The addresses on which to listen for SSF data. As with
 # statsd_listen_addresses, these are formatted as URLs, with schemes

--- a/networking.go
+++ b/networking.go
@@ -21,8 +21,11 @@ func StartStatsd(s *Server, a net.Addr, packetPool *sync.Pool) net.Addr {
 		return startStatsdUDP(s, addr, packetPool)
 	case *net.TCPAddr:
 		return startStatsdTCP(s, addr, packetPool)
+	case *net.UnixAddr:
+		_, b := startStatsdUnix(s, addr, packetPool)
+		return b
 	default:
-		panic(fmt.Sprintf("Can't listen on %v: only TCP and UDP are supported", a))
+		panic(fmt.Sprintf("Can't listen on %v: only TCP , UDP and unixgram:// are supported", a))
 	}
 }
 
@@ -131,6 +134,57 @@ func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) net.Add
 		s.ReadTCPSocket(listener)
 	}()
 	return listener.Addr()
+}
+
+// startStatsdUnix starts listening for datagram statsd metric packets
+// on a UNIX domain socket address. It does so until the
+// server's shutdown socket is closed. startStatsdUnix returns a channel
+// that is closed once the listening connection has terminated.
+func startStatsdUnix(s *Server, addr *net.UnixAddr, packetPool *sync.Pool) (<-chan struct{}, net.Addr) {
+	done := make(chan struct{})
+	if addr.Network() != "unixgram" {
+		panic(fmt.Sprintf("Can't listen for statsd metrics on %v: only udp:// and unixgram:// addresses are supported", addr))
+	}
+	// ensure we are the only ones locking this socket:
+	lockname := fmt.Sprintf("%s.lock", addr.String())
+	lock := flock.NewFlock(lockname)
+	locked, err := lock.TryLock()
+	if err != nil {
+		panic(fmt.Sprintf("Could not acquire the lock %q to listen on %v: %v", lockname, addr, err))
+	}
+	if !locked {
+		panic(fmt.Sprintf("Lock file %q for %v is in use by another process already", lockname, addr))
+	}
+	// We have the exclusive use of the socket, clear away any old sockets and listen:
+	_ = os.Remove(addr.String())
+	conn, err := net.ListenUnixgram(addr.Network(), addr)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't listen on UNIX socket %v: %v", addr, err))
+	}
+
+	// Make the socket connectable by everyone with access to the socket pathname:
+	err = os.Chmod(addr.String(), 0666)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't set permissions on %v: %v", addr, err))
+	}
+	go func() {
+		go func() {
+			defer func() {
+				lock.Unlock()
+				close(done)
+			}()
+			for {
+				_, open := <-s.shutdown
+				// occurs when cleanly shutting down the server e.g. in tests; ignore errors
+				if !open {
+					conn.Close()
+					return
+				}
+			}
+		}()
+		go s.ReadStatsdDatagramSocket(conn, packetPool)
+	}()
+	return done, addr
 }
 
 // StartSSF starts listening for SSF on an address a, and returns the

--- a/networking_test.go
+++ b/networking_test.go
@@ -3,6 +3,7 @@ package veneur
 import (
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,13 +72,68 @@ func TestConnectUNIX(t *testing.T) {
 			}
 			assert.Equal(t, 3, wrote, "Writing to %d", n)
 			assert.NotNil(t, c)
-
 			n, _ = c.Read(make([]byte, 20))
 			assert.Equal(t, 0, n)
 
 			err = c.Close()
 			assert.NoError(t, err)
 
+			conns <- struct{}{}
+		}()
+	}
+	timeout := time.After(3 * time.Second)
+	for i := 0; i < 5; i++ {
+		select {
+		case <-timeout:
+			t.Fatalf("Timed out waiting for connection, %d made it", i)
+		case <-conns:
+			// pass
+		}
+	}
+	close(srv.shutdown)
+}
+
+func TestConnectUNIXStatsd(t *testing.T) {
+	srv := &Server{}
+	srv.shutdown = make(chan struct{})
+	srv.metricMaxLength = 4096
+
+	dir, err := ioutil.TempDir("", "unix-domain-listener")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	addrNet, err := protocol.ResolveAddr(fmt.Sprintf("unixgram://%s/datagramsocket", dir))
+	require.NoError(t, err)
+	addr, ok := addrNet.(*net.UnixAddr)
+	require.True(t, ok)
+	statsdPool := &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, 4097)
+		},
+	}
+	startStatsdUnix(srv, addr, statsdPool)
+
+	conns := make(chan struct{})
+	for i := 0; i < 5; i++ {
+		n := i
+		go func() {
+			// Dial the server, send it invalid data, wait
+			// for it to hang up:
+			c, err := net.DialUnix("unixgram", nil, addr)
+			assert.NoError(t, err, "Connecting %d", n)
+			wrote, err := c.Write([]byte("foo"))
+			if !assert.NoError(t, err, "Writing to %d", n) {
+				fmt.Println("Error writing to socket")
+				return
+			}
+			assert.Equal(t, 3, wrote, "Writing to %d", n)
+			assert.NotNil(t, c)
+			c.SetReadDeadline(time.Now().Add(1 * time.Second))
+			n, _ = c.Read(make([]byte, 20))
+			assert.Equal(t, 0, n)
+
+			err = c.Close()
+			assert.NoError(t, err)
 			conns <- struct{}{}
 		}()
 	}

--- a/networking_test.go
+++ b/networking_test.go
@@ -72,6 +72,7 @@ func TestConnectUNIX(t *testing.T) {
 			}
 			assert.Equal(t, 3, wrote, "Writing to %d", n)
 			assert.NotNil(t, c)
+
 			n, _ = c.Read(make([]byte, 20))
 			assert.Equal(t, 0, n)
 

--- a/server.go
+++ b/server.go
@@ -898,7 +898,7 @@ func (s *Server) ReadMetricSocket(serverConn net.PacketConn, packetPool *sync.Po
 	}
 }
 
-// ReadStatsdDatagramSocket reads a statsd metrics packets from  connection off a datagram socket.
+// ReadStatsdDatagramSocket reads statsd metrics packets from connection off a unix datagram socket.
 func (s *Server) ReadStatsdDatagramSocket(serverConn *net.UnixConn, packetPool *sync.Pool) {
 	for {
 		buf := packetPool.Get().([]byte)

--- a/server.go
+++ b/server.go
@@ -893,7 +893,7 @@ func (s *Server) processMetricPacket(numBytes int, buf []byte, packetPool *sync.
 	// trailing newlines
 	splitPacket := samplers.NewSplitBytes(buf[:numBytes], '\n')
 	for splitPacket.Next() {
-		go s.HandleMetricPacket(splitPacket.Chunk())
+		s.HandleMetricPacket(splitPacket.Chunk())
 	}
 
 	// the Metric struct created by HandleMetricPacket has no byte slices in it,
@@ -919,7 +919,7 @@ func (s *Server) ReadStatsdDatagramSocket(serverConn *net.UnixConn, packetPool *
 			}
 		}
 
-		go s.processMetricPacket(n, buf, packetPool)
+		s.processMetricPacket(n, buf, packetPool)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -577,6 +577,49 @@ func TestUDPMetrics(t *testing.T) {
 	assert.Equal(t, "foo.bar", metrics[0].Name, "worker processed the metric")
 }
 
+func TestUnixSocketMetrics(t *testing.T) {
+	ctx := context.TODO()
+	tdir, err := ioutil.TempDir("", "unixmetrics_statsd")
+	require.NoError(t, err)
+	defer os.RemoveAll(tdir)
+
+	config := localConfig()
+	config.NumWorkers = 1
+	config.Interval = "60s"
+	path := filepath.Join(tdir, "testdatagram.sock")
+	config.StatsdListenAddresses = []string{fmt.Sprintf("unixgram://%s", path)}
+	ch := make(chan []samplers.InterMetric, 20)
+	sink, _ := NewChannelMetricSink(ch)
+	f := newFixture(t, config, sink, nil)
+	defer f.Close()
+
+	conn := connectToAddress(t, "unixgram", path, 500*time.Millisecond)
+	defer conn.Close()
+
+	t.Log("Writing the first metric")
+	_, err = conn.Write([]byte("foo.bar:1|c|#baz:gorch"))
+	ctx, firstCancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
+	defer firstCancel()
+	keepFlushing(ctx, f.server)
+	if assert.NoError(t, err) {
+		metrics := <-ch
+		require.Equal(t, 1, len(metrics), "we sent a single metric")
+		assert.Equal(t, "foo.bar", metrics[0].Name, "worker processed the first metric")
+	}
+
+	t.Log("Writing the second metric")
+	_, err = conn.Write([]byte("foo.baz:1|c|#baz:gorch"))
+	secondCtx, secondCancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer secondCancel()
+	keepFlushing(secondCtx, f.server)
+
+	if assert.NoError(t, err) {
+		metrics := <-ch
+		require.Equal(t, 1, len(metrics), "we sent a single metric")
+		assert.Equal(t, "foo.baz", metrics[0].Name, "worker processed the second metric")
+	}
+}
+
 func TestMultipleUDPSockets(t *testing.T) {
 	config := localConfig()
 	config.NumWorkers = 1


### PR DESCRIPTION
#### Summary
Add Unix Domain Socket(datagram type) listening support for statsd metrics.
Addresses https://github.com/stripe/veneur/issues/693

#### Motivation
We are planning to run veneur as a sidecar(one per application) and we run multiple applications on same host. Having this support means we don't need to allocate ports for each veneur sidecar and have port exhaustion. Also other benefits mentioned at https://docs.datadoghq.com/developers/dogstatsd/unix_socket/

#### Test plan
Added tests

#### Rollout/monitoring/revert plan
