### PR TITLE
Fix hangs/excessive span droppage when connections go away

### DIFF
--- a/sinks/splunk/protocol.go
+++ b/sinks/splunk/protocol.go
@@ -2,7 +2,6 @@ package splunk
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
@@ -56,7 +55,7 @@ type hecRequest struct {
 	authHeader string
 }
 
-func (r *hecRequest) Start(ctx context.Context) (*http.Request, *json.Encoder, error) {
+func (r *hecRequest) Start(ctx context.Context) (*http.Request, io.Writer, error) {
 	req, err := http.NewRequest("POST", r.url, r.r)
 	if err != nil {
 		return nil, nil, err
@@ -64,7 +63,7 @@ func (r *hecRequest) Start(ctx context.Context) (*http.Request, *json.Encoder, e
 	req.Header.Add("Authorization", r.authHeader)
 	req = req.WithContext(ctx)
 
-	return req, json.NewEncoder(r.w), nil
+	return req, r.w, nil
 }
 
 func (r *hecRequest) Close() error {

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -3,6 +3,7 @@ package splunk_test
 import (
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -26,7 +27,10 @@ func jsonEndpoint(t testing.TB, ch chan<- splunk.Event) http.Handler {
 		}
 		failed := false
 		j := json.NewDecoder(r.Body)
-		defer r.Body.Close()
+		defer func() {
+			ioutil.ReadAll(r.Body)
+			r.Body.Close()
+		}()
 
 		j.DisallowUnknownFields()
 		for {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR includes a test and a fix for the case where the splunk HEC connection gets closed: Previously, the HEC submitter would keep attempting to submit to the same, unusable HTTP connection (and in one particularly nefarious case, try to write stuff synchronously on a connection that just hung).

Now, we detect that particular error (`io.Pipe` is gracious enough to give us the correct error), and only try to write that event until the batch timeout expires.

The new test for this behavior confirms that where previously we'd not manage to deliver more than 60% of spans, now we drop about 3-5 total (Exact measurement is not quite possible, since this is all happening in parallel).

#### Motivation

We saw these errors a lot & one time even saw a hang on splunkd restarts.

#### Test plan

Added a test!

#### Rollout/monitoring/revert plan

Merge & deploy, no config change necessary.