### PR TITLE
Improve logging in blackhole debug sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Updated
 * The metric `veneur.sink.spans_dropped_total` now includes packets that were skipped due to UDP write errors. Thanks, [aditya](https://github.com/chimeracoder)!
+* The `debug` blackhole sink features improved logging output, with more data and better formatting. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/protocol"
 	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/ssf"
@@ -109,16 +110,17 @@ func (b *debugSpanSink) Ingest(span *ssf.SSFSpan) error {
 
 	duration := time.Duration(span.EndTimestamp - span.StartTimestamp)
 	b.log.WithFields(logrus.Fields{
-		"service":    span.Service,
-		"name":       span.Name,
-		"traceId":    span.TraceId,
-		"parentId":   span.ParentId,
-		"id":         span.Id,
-		"tags":       span.Tags,
-		"start":      span.StartTimestamp,
-		"duration":   duration,
-		"info":       info,
-		"numMetrics": len(span.Metrics),
+		"service":         span.Service,
+		"validationError": protocol.ValidateTrace(span),
+		"name":            span.Name,
+		"traceId":         span.TraceId,
+		"parentId":        span.ParentId,
+		"id":              span.Id,
+		"tags":            span.Tags,
+		"start":           span.StartTimestamp,
+		"duration":        duration,
+		"info":            info,
+		"numMetrics":      len(span.Metrics),
 	}).Debug("Received span")
 	return nil
 }

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -106,13 +106,20 @@ func (b *debugSpanSink) Ingest(span *ssf.SSFSpan) error {
 	if len(info) > 0 {
 		info = " (" + info + ")"
 	}
+
 	duration := time.Duration(span.EndTimestamp - span.StartTimestamp)
-	b.log.Debugf("Span %s:%s(%v) %x/%x/%x %v+%v%s (m:%d)",
-		span.Service, span.Name, span.Tags,
-		span.TraceId, span.ParentId, span.Id,
-		span.StartTimestamp, duration,
-		info, len(span.Metrics),
-	)
+	b.log.WithFields(logrus.Fields{
+		"service":    span.Service,
+		"name":       span.Name,
+		"traceId":    span.TraceId,
+		"parentId":   span.ParentId,
+		"id":         span.Id,
+		"tags":       span.Tags,
+		"start":      span.StartTimestamp,
+		"duration":   duration,
+		"info":       info,
+		"numMetrics": len(span.Metrics),
+	}).Debug("Received span")
 	return nil
 }
 

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -121,7 +121,7 @@ func (b *debugSpanSink) Ingest(span *ssf.SSFSpan) error {
 		"duration":        duration,
 		"info":            info,
 		"numMetrics":      len(span.Metrics),
-	}).Debug("Received span")
+	}).Debug("Span")
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

After #698, this also structures the log fields in the sink using logrus instead of `printf`, and it adds the result of `protocol.ValidateTrace` to the fields logged.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @asf-stripe 
cc @stripe/observability 