### PR TITLE
Remove tests and support for Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - "1.10"
   - "1.11"
+  - "1.12"
   - tip
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!
 * SSF packets without a name are no longer considered valid for `protocol.ValidTrace`. Thanks, [tummychow](https://github.com/tummychow)!
 
+## Removed
+* Go 1.10 is no longer supported.
+
 # 11.0.0, 2019-01-22
 
 ## Added


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Remove support for Go 1.10.

Go 1.12 came out last week, which means that Go 1.10 is officially no longer supported.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 