### PR TITLE
Use Go 1.12 for all builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Updated
 * The metric `veneur.sink.spans_dropped_total` now includes packets that were skipped due to UDP write errors. Thanks, [aditya](https://github.com/chimeracoder)!
 * The `debug` blackhole sink features improved logging output, with more data and better formatting. Thanks, [aditya](https://github.com/chimeracoder)!
+* Container images are now built with Go 1.12. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Bugfixes
 * The signalfx client no longer reports a timeout when submission to the datapoint API endpoint encounters an error. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For running Veneur under Docker, you probably want either the pre-built images
 # published at https://hub.docker.com/r/stripe/veneur/
 # or the Dockerfiles in https://github.com/stripe/veneur/tree/master/public-docker-images
-FROM golang:1.11
+FROM golang:1.12
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build

--- a/public-docker-images/Dockerfile-alpine
+++ b/public-docker-images/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-alpine3.8 AS base
+FROM golang:1.12.0-alpine3.9 AS base
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 

--- a/public-docker-images/Dockerfile-debian-sid
+++ b/public-docker-images/Dockerfile-debian-sid
@@ -1,4 +1,4 @@
-FROM golang:1.11.4 AS base
+FROM golang:1.12.0 AS base
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Use Go 1.12 for all builds.

Go 1.12 was released last week. We have been testing against it (via `tip`) for a while and expect no issues.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 