### PR TITLE
Fix worker count in splunk span sink & clean up some lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Updated the vendored version of DataDog/datadog-go which adds support for sending metrics to Unix Domain socket. Thanks, [prudhvi](https://github.com/prudhvi)!
 
+## Bugfixes
+
+* The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
+
 # 12.0.0, 2019-03-06
 
 ## Added

--- a/sinks/splunk/event.go
+++ b/sinks/splunk/event.go
@@ -50,17 +50,6 @@ func (e *Event) SetTime(time time.Time) {
 	e.Time = String(epochTime(&time))
 }
 
-func (e *Event) empty() bool {
-	switch e.Event.(type) {
-	case *string:
-		return e.Event.(*string) == nil || *e.Event.(*string) == ""
-	case string:
-		return e.Event.(string) == ""
-	default:
-		return e.Event == nil
-	}
-}
-
 func epochTime(t *time.Time) string {
 	millis := t.UnixNano() / 1000000
 	return fmt.Sprintf("%d.%03d", millis/1000, millis%1000)

--- a/sinks/splunk/event.go
+++ b/sinks/splunk/event.go
@@ -20,11 +20,11 @@ type Event struct {
 
 func NewEvent(data interface{}) *Event {
 	// Empty event is not allowed, but let HEC complain the error
-	switch data.(type) {
+	switch data := data.(type) {
 	case *string:
-		return &Event{Event: *data.(*string)}
+		return &Event{Event: *data}
 	case string:
-		return &Event{Event: data.(string)}
+		return &Event{Event: data}
 	default:
 		return &Event{Event: data}
 	}

--- a/sinks/splunk/protocol.go
+++ b/sinks/splunk/protocol.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type hecClient struct {
@@ -42,10 +42,10 @@ func init() {
 
 // newRequest creates a new streaming HEC raw request and returns the
 // writer to it. The request is submitted when the writer is closed.
-func (c *hecClient) newRequest() (*hecRequest, error) {
+func (c *hecClient) newRequest() *hecRequest {
 	req := &hecRequest{url: c.url(c.idGen.String()), authHeader: c.authHeader()}
 	req.r, req.w = io.Pipe()
-	return req, nil
+	return req
 }
 
 type hecRequest struct {

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -52,10 +52,9 @@ type splunkSpanSink struct {
 
 	workers int
 
-	batchSize            int
-	hecSubmissionWorkers int
-	ingestedSpans        uint32
-	droppedSpans         uint32
+	batchSize     int
+	ingestedSpans uint32
+	droppedSpans  uint32
 
 	ingest chan *Event
 
@@ -322,7 +321,7 @@ func (sss *splunkSpanSink) makeHTTPRequest(req *http.Request, cancel func()) {
 	start := time.Now()
 	defer func() {
 		cancel()
-		samples.Add(ssf.Timing(timingMetric, time.Now().Sub(start),
+		samples.Add(ssf.Timing(timingMetric, time.Since(start),
 			time.Nanosecond, map[string]string{}))
 	}()
 
@@ -425,7 +424,6 @@ func (sss *splunkSpanSink) Flush() {
 	)
 
 	metrics.Report(sss.traceClient, samples)
-	return
 }
 
 // Ingest takes in a span and batches it up to be sent in the next

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -205,9 +205,10 @@ func (sss *splunkSpanSink) batchTimeout() (time.Duration, bool) {
 // the HEC.
 func (sss *splunkSpanSink) setupHTTPRequest(ctx context.Context) (context.CancelFunc, *hecRequest, io.Writer, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	hecReq, err := sss.hec.newRequest()
+	hecReq := sss.hec.newRequest()
 	req, w, err := hecReq.Start(ctx)
 	if err != nil {
+		cancel()
 		return nil, nil, nil, err
 	}
 

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -133,6 +133,7 @@ func NewSplunkSpanSink(server string, token string, localHostname string, valida
 		rand:               mrand.New(mrand.NewSource(seed.Int64())),
 		maxConnLifetime:    maxConnLifetime,
 		connLifetimeJitter: connLifetimeJitter,
+		workers:            workers,
 	}, nil
 }
 

--- a/sinks/splunk/splunk_internal_test.go
+++ b/sinks/splunk/splunk_internal_test.go
@@ -1,0 +1,44 @@
+package splunk
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerCount(t *testing.T) {
+	counts := map[int]int{
+		0:   1,
+		1:   1,
+		5:   5,
+		100: 100,
+	}
+
+	for in, out := range counts {
+		nWorkers := in
+		workerProcs := out
+		t.Run(strconv.Itoa(nWorkers), func(t *testing.T) {
+			t.Parallel()
+			logger := logrus.StandardLogger()
+			sink, err := NewSplunkSpanSink("http://example.com", "00000000-0000-0000-0000-000000000000",
+				"test-host", "", logger, time.Duration(0), time.Duration(0), 100, nWorkers, 10, 10*time.Millisecond, 0)
+			sss := sink.(*splunkSpanSink)
+			defer sss.Stop()
+			require.NoError(t, err)
+
+			// this number should correspond to the input:
+			assert.Equal(t, nWorkers, sss.workers)
+
+			err = sss.Start(nil)
+			require.NoError(t, err)
+
+			// use the number of channels for synchronization as a proxy
+			// for the number of workers:
+			assert.Len(t, sss.sync, workerProcs)
+		})
+	}
+}

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -28,7 +28,7 @@ func jsonEndpoint(t testing.TB, ch chan<- splunk.Event) http.Handler {
 		failed := false
 		j := json.NewDecoder(r.Body)
 		defer func() {
-			ioutil.ReadAll(r.Body)
+			_, _ = ioutil.ReadAll(r.Body)
 			r.Body.Close()
 		}()
 
@@ -118,7 +118,7 @@ func TestSpanIngestBatch(t *testing.T) {
 		require.NoError(t, err)
 		output := splunk.SerializedSSF{}
 		err = json.Unmarshal(spanB, &output)
-
+		require.NoError(t, err)
 		assert.Equal(t, float64(span.StartTimestamp)/float64(time.Second), output.StartTimestamp)
 		assert.Equal(t, float64(span.EndTimestamp)/float64(time.Second), output.EndTimestamp)
 
@@ -290,7 +290,7 @@ func TestSampling(t *testing.T) {
 
 	// check how many events we got:
 	events := 0
-	for _ = range ch {
+	for range ch {
 		events++
 		// Don't close the receiving end until the first
 		// span, to avoid failing the test by racing the
@@ -351,7 +351,7 @@ func TestSamplingIndicators(t *testing.T) {
 
 	// check how many events we got:
 	events := 0
-	for _ = range ch {
+	for range ch {
 		events++
 		// Don't close the receiving end until the first
 		// span, to avoid failing the test by racing the
@@ -371,8 +371,7 @@ func TestClosedIngestionEndpoint(t *testing.T) {
 	logger := logrus.StandardLogger()
 
 	ch := make(chan splunk.Event, nToFlush)
-	var ts *httptest.Server
-	ts = httptest.NewServer(jsonEndpoint(t, ch))
+	ts := httptest.NewServer(jsonEndpoint(t, ch))
 	defer func() {
 		ts.Close()
 	}()
@@ -415,7 +414,7 @@ func TestClosedIngestionEndpoint(t *testing.T) {
 	sink.Sync()
 	sink.Stop()
 	events := 0
-	for _ = range ch {
+	for range ch {
 		events++
 		// Don't close the receiving end until the first
 		// span, to avoid failing the test by racing the

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -183,13 +183,14 @@ func TestTimeout(t *testing.T) {
 	}
 
 	sink.Sync()
-	ms := <-spans
-	require.NotNil(t, ms)
 	var found *ssf.SSFSample
-	for _, sample := range ms.Metrics {
-		if strings.HasSuffix(sample.Name, "splunk.hec_submission_failed_total") {
-			found = sample
-			break
+readMetrics:
+	for ms := range spans {
+		for _, sample := range ms.Metrics {
+			if strings.HasSuffix(sample.Name, "splunk.hec_submission_failed_total") {
+				found = sample
+				break readMetrics
+			}
 		}
 	}
 	require.NotNil(t, found, "Expected a timeout metric to be reported")


### PR DESCRIPTION
#### Summary
This PR fixes a few linty problems and one pretty grave bug in the splunk span sink: It didn't actually spawn the number of workers configured.

#### Motivation
This PR brought to you by me enabling `golangci-lint` in veneur and chasing down the problems highlighted in a package. Turns out one was actually meaningful!

#### Test plan

I wrote a new test for the behavior (it fails without the change). That's only the theoretical half of the story though:

We should stage a rollout of this, as we actually do configure the number of workers on some high-traffic machines. Those will likely see greater resource utilization, and we'll *definitely* see the number of connections on splunk HEC ingestion endpoints rise.

#### Rollout/monitoring/revert plan

See Test Plan - we should be careful rolling this out, and potentially decrease the number of workers in our config.