### PR TITLE
Increase convenience of span.Error

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -204,7 +204,14 @@ func (t *Trace) ClientRecord(cl *Client, name string, tags map[string]string) er
 	return Record(cl, span, t.Sent)
 }
 
-func (t *Trace) Error(err error) {
+// Error marks the trace span as failed by setting the Error flag and
+// by attaching information about the error as tags to the span. Error
+// returns the error it was given, so users can use it like so:
+//
+//     if err != nil {
+//         return span.Error(err)
+//     }
+func (t *Trace) Error(err error) error {
 	t.Status = ssf.SSFSample_CRITICAL
 	t.error = true
 
@@ -220,6 +227,7 @@ func (t *Trace) Error(err error) {
 	t.Tags[errorMessageTag] = err.Error()
 	t.Tags[errorTypeTag] = errorType
 	t.Tags[errorStackTag] = err.Error()
+	return err
 }
 
 // Attach attaches the current trace to the context

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -225,7 +225,8 @@ func TestError(t *testing.T) {
 	err := localError{errorMessage}
 
 	root := StartTrace(resource)
-	root.Error(err)
+	errReturned := root.Error(err)
+	assert.Equal(t, err, errReturned)
 
 	assert.Equal(t, root.Status, ssf.SSFSample_CRITICAL)
 	assert.Equal(t, len(root.Tags), 3)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR changes the `Trace` method `Error` to return the error it was given, thereby enabling users to write:

``` go
if err != nil {
    return span.Error(err)
}
```

instead of the slightly more laborious

``` go
if err != nil {
    span.Error(err)
    return err
}
```

#### Motivation

I find myself doing this a lot, and it might help to have this be easier, so we get a better coverage of errors when they happen.

#### Test plan

Adjusted the span.Error test to check it does return the input error.

#### Rollout/monitoring/revert plan

merge & pull into our dependencies, then adjust the call sites.