### PR TITLE
Correctly construct signalfx endpoint URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bugfixes
 
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
+* The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 12.0.0, 2019-03-06
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -539,3 +539,9 @@ func TestSignalFxFlushBatches(t *testing.T) {
 	assert.True(t, found["first"])
 	assert.True(t, found["second"])
 }
+
+func TestNewSinkDoubleSlashes(t *testing.T) {
+	cl := NewClient("http://example.com/", "foo", nil).(*sfxclient.HTTPSink)
+	assert.Equal(t, "http://example.com/v2/datapoint", cl.DatapointEndpoint)
+	assert.Equal(t, "http://example.com/v2/event", cl.EventEndpoint)
+}


### PR DESCRIPTION

<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Since signalfx's ingestion endpoint is now less tolerant of URLs that start with two /es, we should make sure that we don't accidentally end up with those if someone should specify a base URL ending with a slash in their config.

The best way to do that is to use go's built-in URL resolution functionality. Let's just use that. This change also ensures that no invalid URLs can be set as ingestion endpoints - veneur would panic at startup if someone tried that.


#### Motivation
We noticed the hard way that signalfx had started to send 301 (then 404 on the subsequent GET).


#### Test plan
There's a test to ensure the URL is correct re. the base.


#### Rollout/monitoring/revert plan

Just merge - our config is corrected already.
