### PR TITLE
Set a top-level deadline for flushing the server each tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!
+* Veneur now sets a deadline for its flushes: No flush may take longer than the configured server flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 # 12.0.0, 2019-03-06
 

--- a/server_test.go
+++ b/server_test.go
@@ -1405,6 +1405,57 @@ func TestServeStopHTTP(t *testing.T) {
 	}
 }
 
+type blockySink struct {
+	blocker chan struct{}
+}
+
+func (s *blockySink) Name() string {
+	return "blocky_sink"
+}
+
+func (s *blockySink) Start(traceClient *trace.Client) error {
+	return nil
+}
+
+func (s *blockySink) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		close(s.blocker)
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (s *blockySink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {}
+
+func TestFlushDeadline(t *testing.T) {
+	config := localConfig()
+	config.Interval = "1us"
+
+	ch := make(chan struct{})
+	sink := &blockySink{blocker: ch}
+	f := newFixture(t, config, sink, nil)
+	defer f.Close()
+
+	f.server.Workers[0].ProcessMetric(&samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "histogram",
+		},
+		Value:      20.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.LocalOnly,
+	})
+
+	_, ok := <-ch
+	assert.False(t, ok)
+}
+
 func BenchmarkHandleTracePacket(b *testing.B) {
 	const LEN = 1000
 	input := generateSSFPackets(b, LEN)

--- a/server_test.go
+++ b/server_test.go
@@ -1422,12 +1422,9 @@ func (s *blockySink) Flush(ctx context.Context, metrics []samplers.InterMetric) 
 		return nil
 	}
 
-	select {
-	case <-ctx.Done():
-		close(s.blocker)
-		return ctx.Err()
-	}
-	return nil
+	<-ctx.Done()
+	close(s.blocker)
+	return ctx.Err()
 }
 
 func (s *blockySink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {}


### PR DESCRIPTION
#### Summary

This PR replaces `context.TODO()` with a context that has a deadline, so that a single misbehaved sink (that uses contexts correctly, mind) can't take down veneur.

#### Motivation

We had a case where veneur got wedged because some upstream service blocked.

#### Test plan

- [x] write a test for flushing

#### Rollout/monitoring/revert plan

1. merge
2. roll it out.