### PR TITLE
Add config for building on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,15 @@ commands:
       stringer_rev:
         type: string
         default: "25101aadb97aa42907eee6a238d6d26a6cb3c756"
+      gojson_tag:
+        type: string
+        default: "v1.0.0"
       cachebust:
         type: string
         default: "1"
     steps:
-      - restore_cache:
-          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_<<parameters.cachebust>>"
+      - restore_cache: &prereq_cache_key
+          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_gojson-<<parameters.gojson_tag>>_<<parameters.cachebust>>"
       - run:
           name: protoc
           command: |
@@ -53,7 +56,11 @@ commands:
           name: gojson
           command: |
             if ! [ -x $GOPATH/bin/gojson ] ; then
-              go get -u github.com/ChimeraCoder/gojson/gojson
+              go get -d -u github.com/ChimeraCoder/gojson/gojson
+              cd $GOPATH/src/github.com/ChimeraCoder/gojson
+              git fetch
+              git reset --hard <<parameters.gojson_tag>>
+              go install github.com/ChimeraCoder/gojson/gojson
             fi
       - run:
           name: dep
@@ -71,7 +78,7 @@ commands:
               go install
             fi
       - save_cache:
-          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_<<parameters.cachebust>>"
+          <<: *prereq_cache_key
           paths:
             - /opt/protoc
             - /go/bin/protoc-gen-gogofaster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: go generate
           command: |
             export PATH=$PATH:/opt/protoc/bin
-            go generate
+            go generate -v
       - run: "dep check"
       - run:
           name: "gofmt"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,12 +135,6 @@ commands:
           path: /tmp/test-results/go
 
 jobs:
-  success:
-    docker:
-      - image: alpine:latest
-    steps:
-      - run: echo yay
-
   code_hygiene:
     executor:
       name: gofmt
@@ -202,12 +196,6 @@ workflows:
       - test_stable
       - test_previous
       - test_tip
-      - success:
-          requires:
-          - code_hygiene
-          - test_stable
-          - test_previous
-          - test_tip
   scheduled_tests:
     jobs:
       - test_stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
               go get -d -v github.com/gogo/protobuf/protoc-gen-gogofaster
               cd $GOPATH/src/github.com/gogo/protobuf
               git fetch
-              git reset --hard v0.5
+              git reset --hard <<parameters.protoc_gen_gogofaster_tag>>
               go install github.com/gogo/protobuf/protoc-gen-gogofaster
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ workflows:
       - test_tip
     triggers:
       - schedule:
-          cron: 0 0 * * 0
+          cron: 0 16 * * 1-5
           filters:
             branches:
               only: ["master"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 executors:
-  "gofmt":
-    docker:
-      - image: golang:1.11
   "previous":
     docker:
       - image: golang:1.11
@@ -31,7 +28,7 @@ commands:
         default: "1"
     steps:
       - restore_cache: &prereq_cache_key
-          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_gojson-<<parameters.gojson_tag>>_<<parameters.cachebust>>"
+          key: 'protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_gojson-<<parameters.gojson_tag>>_{{checksum "/usr/local/go/bin/go" }}_<<parameters.cachebust>>'
       - run:
           name: protoc
           command: |
@@ -137,7 +134,7 @@ commands:
 jobs:
   code_hygiene:
     executor:
-      name: gofmt
+      name: stable
     working_directory: /go/src/github.com/stripe/veneur
     steps:
       - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
         default: "3.1.0"
       protoc_gen_gogofaster_tag:
         type: string
-        default: "v0.5"
+        default: "v1.2.1"
       stringer_rev:
         type: string
         default: "25101aadb97aa42907eee6a238d6d26a6cb3c756"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,214 @@
+version: 2.1
+executors:
+  "gofmt":
+    docker:
+      - image: golang:1.11
+  "previous":
+    docker:
+      - image: golang:1.11
+  "stable":
+    docker:
+      - image: golang:1.12
+
+commands:
+  install:
+    description: "Install prerequisites"
+    parameters:
+      protoc_version:
+        type: string
+        default: "3.1.0"
+      protoc_gen_gogofaster_tag:
+        type: string
+        default: "v0.5"
+      stringer_rev:
+        type: string
+        default: "25101aadb97aa42907eee6a238d6d26a6cb3c756"
+      cachebust:
+        type: string
+        default: "1"
+    steps:
+      - restore_cache:
+          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_<<parameters.cachebust>>"
+      - run:
+          name: protoc
+          command: |
+            if ! [ -d /opt/protoc ]; then
+              apt-get -q update
+              apt-get install -yq unzip
+              mkdir /opt/protoc
+              wget -O/tmp/protoc.zip https://github.com/google/protobuf/releases/download/v<<parameters.protoc_version>>/protoc-<<parameters.protoc_version>>-linux-x86_64.zip
+              unzip /tmp/protoc.zip -d /opt/protoc
+            fi
+      - run:
+          name: protoc-gen-gogofaster
+          command: |
+            if ! [ -x $GOPATH/bin/protoc-gen-gogofaster ] ; then
+              go get -d -v github.com/gogo/protobuf/protoc-gen-gogofaster
+              cd $GOPATH/src/github.com/gogo/protobuf
+              git fetch
+              git reset --hard v0.5
+              go install github.com/gogo/protobuf/protoc-gen-gogofaster
+            fi
+      - run:
+          name: gojson
+          command: |
+            if ! [ -x $GOPATH/bin/gojson ] ; then
+              go get -u github.com/ChimeraCoder/gojson/gojson
+            fi
+      - run:
+          name: dep
+          command: |
+            if ! [ -x $GOPATH/bin/dep ] ; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            fi
+      - run:
+          name: stringer
+          command: |
+            if ! [ -x $GOPATH/bin/stringer ] ; then
+              go get -u -u golang.org/x/tools/cmd/stringer
+              cd $GOPATH/src/golang.org/x/tools/cmd/stringer
+              git reset --hard <<parameters.stringer_rev>>
+              go install
+            fi
+      - save_cache:
+          key: "protoc-<<parameters.protoc_version>>_gogofaster-<<parameters.protoc_gen_gogofaster_tag>>_stringer-<<parameters.stringer_rev>>_<<parameters.cachebust>>"
+          paths:
+            - /opt/protoc
+            - /go/bin/protoc-gen-gogofaster
+            - /go/src/github.com/gogo/protobuf
+            - /go/bin/dep
+            - /go/bin/stringer
+  fetch_and_build_latest_go:
+    description: "Builds the latest version of go from source"
+    steps:
+      - run:
+          name: create datestamp
+          command: |
+            echo go-master-$(date +%Y-%m-%d) | tee /tmp/go-version
+      - run:
+          name: "Move away stable go"
+          command: |
+            if ! [ -d /usr/local/go-stable ] ; then
+              mv /usr/local/go /usr/local/go-stable
+            fi
+      - restore_cache:
+          key: |
+            {{ checksum "/tmp/go-version" }}
+      - run:
+          name: get latest master
+          command: |
+            if [ "$(cat /tmp/go-version)" = "$(cat /usr/local/go/VERSION)" ] ; then
+              exit 0
+            fi
+            wget -O/tmp/go-master.tgz https://github.com/golang/go/archive/master.tar.gz
+            tar -C /tmp -zxf /tmp/go-master.tgz
+            mv /tmp/go-master /usr/local/go
+            export GOSRC=/usr/local/go
+            export GOROOT=$GOSRC
+            export GOROOT_BOOTSTRAP=/usr/local/go-stable
+            export GOBUILD=$GOSRC/src
+            cp /tmp/go-version $GOROOT/VERSION
+            cd $GOBUILD
+            ./make.bash
+      - save_cache:
+          key: |
+            {{ checksum "/tmp/go-version" }}
+          paths:
+            - /usr/local/go
+  test:
+    description: "Run the tests"
+    steps:
+      - run:
+          name: go test
+          command: |
+            mkdir -p /tmp/test-results/go
+            trap "go get -u github.com/jstemmer/go-junit-report && go-junit-report </tmp/go-test-output.txt > /tmp/test-results/go/test-report.xml" EXIT
+            go test -race -v -timeout 60s ./... | tee /tmp/go-test-output.txt
+      - store_test_results:
+          path: /tmp/test-results/go
+
+jobs:
+  success:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run: echo yay
+
+  code_hygiene:
+    executor:
+      name: gofmt
+    working_directory: /go/src/github.com/stripe/veneur
+    steps:
+      - install
+      - checkout
+      - run:
+          name: go generate
+          command: |
+            export PATH=$PATH:/opt/protoc/bin
+            go generate
+      - run: "dep check"
+      - run:
+          name: "gofmt"
+          command: |
+            mv vendor /tmp/veneur-vendor
+            gofmt -w .
+            mv /tmp/veneur-vendor ./vendor
+      - run:
+          name: "check if any files changed"
+          command: |
+            git add .
+            env PAGER=cat git diff --cached
+            git diff-index --cached --exit-code HEAD
+
+  test_stable:
+    executor:
+      name: stable
+    working_directory: /go/src/github.com/stripe/veneur
+    steps:
+    - checkout
+    - test
+
+  test_previous:
+    executor:
+      name: previous
+    working_directory: /go/src/github.com/stripe/veneur
+    steps:
+      - checkout
+      - test
+
+  test_tip:
+    docker:
+      - image: golang:latest
+    working_directory: /go/src/github.com/stripe/veneur
+    environment:
+      GO111MODULE: auto
+    steps:
+      - fetch_and_build_latest_go
+      - checkout
+      - test
+
+workflows:
+  version: 2
+  continuous_integration:
+    jobs:
+      - code_hygiene
+      - test_stable
+      - test_previous
+      - test_tip
+      - success:
+          requires:
+          - code_hygiene
+          - test_stable
+          - test_previous
+          - test_tip
+  scheduled_tests:
+    jobs:
+      - test_stable
+      - test_previous
+      - test_tip
+    triggers:
+      - schedule:
+          cron: 0 0 * * 0
+          filters:
+            branches:
+              only: ["master"]


### PR DESCRIPTION
#### Summary
This change adds a configuration file that runs veneur's test suite on CircleCI, with a few nice bells&whistles:

* It breaks out the code-hygiene checks (go generate, gofmt, dep check) and runs them in parallel to our "real" tests. The dependencies for making that check get installed and cached with the version configured at the top of the config file.

* It installs latest "go master" from source for "tip" builds; that build gets cached once a day.

* It converts and stores the test results as junit files. If anything should fail, we'll get nice output from that.

* It runs the test suite on master against all go versions, including the daily tip (which should also prime the build cache for us!)

Result: testing veneur now takes [1 minute](https://circleci.com/workflow-run/b475c558-6d36-4180-806a-3ccdb2114533).

Also, to pre-empt any worries about travis's workers exposing errors we wouldn't otherwise see: I did see tests flake on circleci:
* [here's a timeout](https://circleci.com/gh/antifuchs/veneur/37) - that was before adding the junit conversion, sorry

#### Motivation
* I like fast builds
* travis has gotten worse /-:
* This adds a few nice features:
  * readable test failures/results
  * cron builds that validate master doesn't break against tip

#### Test plan

Uh, idk. CI?!


#### Rollout/monitoring/revert plan

* Merge
* Enable the project on circleci
* Disable travis
* Remove travis config