### PR TITLE
Clear up the Server.Flush method some more

### DIFF
--- a/proxysrv/server_test.go
+++ b/proxysrv/server_test.go
@@ -75,7 +75,7 @@ func TestUnreachableDestinations(t *testing.T) {
 	ring.Add("not-a-real-host:9001")
 	ring.Add("another-bad-host:9001")
 
-	server := newServer(t, ring)
+	server := newServer(t, ring, WithForwardTimeout(500*time.Millisecond))
 	err := server.sendMetrics(context.Background(),
 		&forwardrpc.MetricList{metrictest.RandomForwardMetrics(10)})
 	assert.Error(t, err, "sendMetrics should have returned an error when all "+


### PR DESCRIPTION
#### Summary

In #715, I didn't completely follow the trail of the Flush method and decided to do something sketchy with the context. This PR fixes the flow around the Flush method and ensures that when it returns, its context can be canceled.

Additional things done in this PR:

* add a little goroutine that cancels the flush context as soon as the server shuts down.
* rework a few tests to time out less often.

#### Motivation

Mostly clarity of the code, but thinking about it, I grew concerned that the flush function would cancel some strange contexts while functions kept running and we were stashing contexts somewhere or something.

#### Test plan

tests pass, but I think a more reasonable test for this is whether it works on our infra.

#### Rollout/monitoring/revert plan

merge & deploy!