### PR TITLE
Don't consider it a bug if we exceed the flush deadline

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -489,7 +489,11 @@ func (s *Server) forwardGRPC(ctx context.Context, wms []WorkerMetrics) {
 	grpcStart := time.Now()
 	_, err := c.SendMetrics(ctx, &forwardrpc.MetricList{Metrics: metrics})
 	if err != nil {
-		if statErr, ok := status.FromError(err); ok && (statErr.Message() == "all SubConns are in TransientFailure" || statErr.Message() == "transport is closing") {
+		if ctx.Err() != nil {
+			// We exceeded the deadline of the flush context.
+			span.Add(ssf.Count("forward.error_total", 1, map[string]string{"cause": "deadline_exceeded"}))
+		} else if statErr, ok := status.FromError(err); ok &&
+			(statErr.Message() == "all SubConns are in TransientFailure" || statErr.Message() == "transport is closing") {
 			// We could check statErr.Code() == codes.Unavailable, but we don't know all of the cases that
 			// could return that code. These two particular cases are fairly safe and usually associated
 			// with connection rebalancing or host replacement, so we don't want them going to sentry.

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +31,7 @@ func TestServerFlushGRPC(t *testing.T) {
 	localCfg.DebugFlushedMetrics = true
 	localCfg.ForwardAddress = testServer.Addr().String()
 	localCfg.ForwardUseGrpc = true
-	local := setupVeneurServer(t, localCfg, nil, nil, nil)
+	local := setupVeneurServer(t, localCfg, nil, nil, nil, nil)
 	defer local.Shutdown()
 
 	inputs := forwardGRPCTestMetrics()
@@ -59,6 +61,54 @@ func TestServerFlushGRPC(t *testing.T) {
 	}
 }
 
+func TestServerFlushGRPCTimeout(t *testing.T) {
+	testServer := forwardtest.NewServer(func(ms []*metricpb.Metric) {
+		time.Sleep(500 * time.Millisecond)
+	})
+	testServer.Start(t)
+	defer testServer.Stop()
+
+	spanCh := make(chan *ssf.SSFSpan, 900)
+	cl, err := trace.NewChannelClient(spanCh)
+	require.NoError(t, err)
+	defer func() {
+		cl.Close()
+	}()
+
+	got := make(chan *ssf.SSFSample)
+	go func() {
+		for span := range spanCh {
+			for _, sample := range span.Metrics {
+				if sample.Name == "forward.error_total" && span.Tags != nil && sample.Tags["cause"] == "deadline_exceeded" {
+					got <- sample
+					return
+				}
+			}
+		}
+	}()
+
+	localCfg := localConfig()
+	localCfg.Interval = "20us"
+	localCfg.DebugFlushedMetrics = true
+	localCfg.ForwardAddress = testServer.Addr().String()
+	localCfg.ForwardUseGrpc = true
+	local := setupVeneurServer(t, localCfg, nil, nil, nil, cl)
+	defer local.Shutdown()
+
+	inputs := forwardGRPCTestMetrics()
+	for _, input := range inputs {
+		local.Workers[0].ProcessMetric(input)
+	}
+
+	// Wait until the running server has flushed out the metrics for us:
+	select {
+	case v := <-got:
+		assert.Equal(t, float32(1.0), v.Value)
+	case <-time.After(time.Second):
+		t.Fatal("The server didn't time out flushing.")
+	}
+}
+
 // Just test that a flushing to a bad address is handled without panicing
 func TestServerFlushGRPCBadAddress(t *testing.T) {
 	rcv := make(chan []samplers.InterMetric, 10)
@@ -69,7 +119,7 @@ func TestServerFlushGRPCBadAddress(t *testing.T) {
 	localCfg.ForwardAddress = "bad-address:123"
 	localCfg.ForwardUseGrpc = true
 
-	local := setupVeneurServer(t, localCfg, nil, sink, nil)
+	local := setupVeneurServer(t, localCfg, nil, sink, nil, nil)
 	defer local.Shutdown()
 
 	local.Workers[0].ProcessMetric(forwardGRPCTestMetrics()[0])
@@ -103,7 +153,7 @@ func TestGlobalAcceptsHistogramsOverUDP(t *testing.T) {
 	cfg := globalConfig()
 	cfg.Percentiles = []float64{}
 	cfg.Aggregates = []string{"min"}
-	global := setupVeneurServer(t, cfg, nil, sink, nil)
+	global := setupVeneurServer(t, cfg, nil, sink, nil, nil)
 	defer global.Shutdown()
 
 	// simulate introducing a histogram to a global veneur.

--- a/forward_grpc_test.go
+++ b/forward_grpc_test.go
@@ -31,7 +31,7 @@ func newForwardGRPCFixture(t testing.TB, localConfig Config, sink sinks.MetricSi
 	// Create a global Veneur
 	globalCfg := globalConfig()
 	globalCfg.GrpcAddress = unusedLocalTCPAddress(t)
-	global := setupVeneurServer(t, globalCfg, nil, sink, nil)
+	global := setupVeneurServer(t, globalCfg, nil, sink, nil, nil)
 	go func() {
 		global.Serve()
 	}()
@@ -51,7 +51,7 @@ func newForwardGRPCFixture(t testing.TB, localConfig Config, sink sinks.MetricSi
 
 	localConfig.ForwardAddress = proxyCfg.GrpcAddress
 	localConfig.ForwardUseGrpc = true
-	local := setupVeneurServer(t, localConfig, nil, nil, nil)
+	local := setupVeneurServer(t, localConfig, nil, nil, nil, nil)
 
 	return &forwardGRPCFixture{t: t, proxy: &proxy, global: global, local: local}
 }

--- a/forward_test.go
+++ b/forward_test.go
@@ -36,7 +36,7 @@ func newForwardingFixture(t testing.TB, localConfig Config, transport http.Round
 	ff := &forwardFixture{t: t}
 
 	// Make the global veneur:
-	ff.global = setupVeneurServer(t, globalConfig(), transport, globalSink, nil)
+	ff.global = setupVeneurServer(t, globalConfig(), transport, globalSink, nil, nil)
 	ff.globalTS = httptest.NewServer(handleImport(ff.global))
 
 	// Make the proxy that sends to the global veneur:
@@ -53,7 +53,7 @@ func newForwardingFixture(t testing.TB, localConfig Config, transport http.Round
 
 	// Now make the local server, have it forward to the proxy:
 	localConfig.ForwardAddress = ff.proxyTS.URL
-	ff.server = setupVeneurServer(t, localConfig, transport, nil, nil)
+	ff.server = setupVeneurServer(t, localConfig, transport, nil, nil, nil)
 
 	return ff
 }

--- a/http_test.go
+++ b/http_test.go
@@ -115,7 +115,7 @@ func testServerImport(t *testing.T, filename string, contentEncoding string) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	handler := handleImport(s)
@@ -156,7 +156,7 @@ func TestServerImportGzip(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	handler := handleImport(s)
@@ -181,7 +181,7 @@ func TestServerImportCompressedInvalid(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	handler := handleImport(s)
@@ -206,7 +206,7 @@ func TestServerImportUncompressedInvalid(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	handler := handleImport(s)
@@ -260,7 +260,7 @@ func TestGeneralHealthCheck(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	w := httptest.NewRecorder()
@@ -278,7 +278,7 @@ func TestOkTraceHealthCheck(t *testing.T) {
 	// We must enable tracing, as it's disabled by default, by turning on one
 	// of the tracing sinks.
 	config.LightstepAccessToken = "farts"
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	w := httptest.NewRecorder()
@@ -312,7 +312,7 @@ func TestBuildDate(t *testing.T) {
 
 	config := localConfig()
 	config.SsfListenAddresses = []string{}
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	w := httptest.NewRecorder()
@@ -344,7 +344,7 @@ func TestVersion(t *testing.T) {
 
 	config := localConfig()
 	config.SsfListenAddresses = []string{}
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	w := httptest.NewRecorder()
@@ -369,7 +369,7 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	w := httptest.NewRecorder()
 
 	config := localConfig()
-	s := setupVeneurServer(t, config, nil, nil, nil)
+	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
 	handler := handleImport(s)

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -87,7 +87,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	config.DatadogAPIKey = "secret"
 	config.DatadogTraceAPIAddress = remoteServer.URL
 
-	server := setupVeneurServer(t, config, nil, nil, nil)
+	server := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer server.Shutdown()
 
 	ddSink, err := datadog.NewDatadogSpanSink("http://example.com", 100, server.HTTPClient, logrus.New())
@@ -121,7 +121,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 
 	// this can be anything as long as it's not empty
 	config.LightstepAccessToken = "secret"
-	server := setupVeneurServer(t, config, nil, nil, nil)
+	server := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer server.Shutdown()
 
 	//collector string, reconnectPeriod string, maximumSpans int, numClients int, accessToken string

--- a/server_test.go
+++ b/server_test.go
@@ -130,7 +130,7 @@ func generateMetrics() (metricValues []float64, expectedMetrics map[string]float
 // and starts listening for requests. It returns the server for inspection.
 // If no metricSink or spanSink are provided then a `black hole` sink be used
 // so that flushes to these sinks do "nothing".
-func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink sinks.MetricSink, sSink sinks.SpanSink) *Server {
+func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink sinks.MetricSink, sSink sinks.SpanSink, traceClient *trace.Client) *Server {
 	logger := logrus.New()
 	server, err := NewFromConfig(logger, config)
 	if err != nil {
@@ -146,7 +146,7 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 
 	// Make sure we don't send internal metrics when testing:
 	trace.NeutralizeClient(server.TraceClient)
-	server.TraceClient = nil
+	server.TraceClient = traceClient
 
 	if mSink == nil {
 		// Install a blackhole sink if we have no other sinks
@@ -215,7 +215,7 @@ func newFixture(t testing.TB, config Config, mSink sinks.MetricSink, sSink sinks
 	f := &fixture{nil, &Server{}, interval, config.DatadogFlushMaxPerBody}
 
 	config.NumWorkers = 1
-	f.server = setupVeneurServer(t, config, nil, mSink, sSink)
+	f.server = setupVeneurServer(t, config, nil, mSink, sSink, nil)
 	return f
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This change makes flushGRPC not report an exception to sentry when it encounters a deadline excession. These are not bugs, but are interesting in aggregate; so we increment a metric.

#### Motivation

We got semi-paged by sentry because network conditions aligned.

#### Test plan

Didn't, not really.

#### Rollout/monitoring/revert plan

Merge & deploy!
