### PR TITLE
Remove an impossible log statement from the trace client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Veneur now sets a deadline for its flushes: No flush may take longer than the configured server flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 
+## Removed
+
+* A dependency on `github.com/Sirupsen/logrus` from the trace client package `github.com/stripe/veneur/trace`. Thanks, [antifuchs](https://github.com/antifuchs) and [samczsun](https://github.com/samczsun)!
+
 # 12.0.0, 2019-03-06
 
 ## Added

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/sirupsen/logrus"
 )
 
 // Experimental
@@ -245,10 +244,7 @@ func (t *Trace) Attach(c context.Context) context.Context {
 // allocates a new span with a parent ID set to that of the span
 // stored on the context.
 func SpanFromContext(c context.Context) *Trace {
-	parent, ok := c.Value(traceKey).(*Trace)
-	if !ok {
-		logrus.WithField("type", reflect.TypeOf(c.Value(traceKey))).Error("expected *Trace from context")
-	}
+	parent := c.Value(traceKey).(*Trace)
 	return StartChildSpan(parent)
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This change removes a log statement from the trace client implementation, which removes a transitive dependency on `logrus` for users of the trace client (:

#### Motivation

Less dependencies, less dependencies _on cgo_ and less log-debugging!

#### Test plan

Tests still pass, but I didn't add tests.

#### Rollout/monitoring/revert plan

Merge & pull this into client users!