### PR TITLE
Run a watchdog that ensures flushing doesn't get stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 * The Kafka sink now includes metrics for skipped and dropped spans, as well as a debug log line for flushes. Thanks, [franklinhu](https://github.com/franklinhu)
+* A flush "watchdog" controlled by the config setting `flush_watchdog_missed_flushes`. If veneur has not started this many flushes, the watchdog panics and terminates veneur (so it can be restarted by process supervision). Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Updated
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -88,6 +88,7 @@ func main() {
 		}
 		trace.DefaultClient = server.TraceClient
 	}
+	go server.FlushWatchdog()
 	server.Start()
 
 	if conf.HTTPAddress != "" || conf.GrpcAddress != "" {

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	FalconerAddress               string    `yaml:"falconer_address"`
 	FlushFile                     string    `yaml:"flush_file"`
 	FlushMaxPerBody               int       `yaml:"flush_max_per_body"`
+	FlushWatchdogMissedFlushes    int       `yaml:"flush_watchdog_missed_flushes"`
 	ForwardAddress                string    `yaml:"forward_address"`
 	ForwardUseGrpc                bool      `yaml:"forward_use_grpc"`
 	GrpcAddress                   string    `yaml:"grpc_address"`

--- a/example.yaml
+++ b/example.yaml
@@ -50,6 +50,11 @@ forward_use_grpc: false
 # series data.
 interval: "10s"
 
+# How many flushes veneur may miss before it considers itself buggy
+# and terminates. Leaving this at the default of 0 disables the
+# watchdog.
+flush_watchdog_missed_flushes: 0
+
 # Veneur can "sychronize" it's flushes with the system clock, flushing at even
 # intervals i.e. 0, 10, 20… to align with the `interval`. This is disabled by
 # default for now, as it can cause thundering herds in large installations.

--- a/flusher.go
+++ b/flusher.go
@@ -31,11 +31,15 @@ func (s *Server) Flush(ctx context.Context) {
 	mem := &runtime.MemStats{}
 	runtime.ReadMemStats(mem)
 
+	flushTime := time.Now().UnixNano()
+	atomic.StoreInt64(&s.lastFlushUnix, flushTime)
+
 	s.Statsd.Gauge("worker.span_chan.total_elements", float64(len(s.SpanChan)), nil, 1.0)
 	s.Statsd.Gauge("worker.span_chan.total_capacity", float64(cap(s.SpanChan)), nil, 1.0)
 	s.Statsd.Gauge("gc.number", float64(mem.NumGC), nil, 1.0)
 	s.Statsd.Gauge("gc.pause_total_ns", float64(mem.PauseTotalNs), nil, 1.0)
 	s.Statsd.Gauge("mem.heap_alloc_bytes", float64(mem.HeapAlloc), nil, 1.0)
+	s.Statsd.Gauge("flush.flush_timestamp_ns", float64(flushTime), nil, 1.0)
 
 	samples := s.EventWorker.Flush()
 

--- a/internal/forwardtest/server.go
+++ b/internal/forwardtest/server.go
@@ -51,7 +51,7 @@ func (s *Server) Start(t testing.TB) {
 	}
 
 	go func() {
-		if err := s.Serve(s.lis); err != nil {
+		if err := s.Serve(s.lis); err != nil && err != grpc.ErrServerStopped {
 			t.Logf("failed to stop the test forwarding gRPC server: %v", err)
 		}
 	}()

--- a/server.go
+++ b/server.go
@@ -716,6 +716,10 @@ func (s *Server) Start() {
 
 	// Be a watchdog forever!
 	go func() {
+		defer func() {
+			ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
+		}()
+
 		if s.stuckIntervals == 0 {
 			// No watchdog needed:
 			return

--- a/server.go
+++ b/server.go
@@ -733,7 +733,7 @@ func (s *Server) Start() {
 				return
 			case <-ticker.C:
 				last := time.Unix(0, atomic.LoadInt64(&s.lastFlushUnix))
-				if time.Since(last) > 3*s.interval {
+				if time.Since(last) > time.Duration(s.stuckIntervals)*s.interval {
 					s.Statsd.Count("flush_watchdog.fired", 1, nil, 1.0)
 					log.WithField("last_flush", last).
 						Panic("Flushing seems to be stuck. Terminating.")


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary

This PR adds a sidecar goroutine to the flush one, which wakes up every interval and checks veneur is making progress in flushing (ensuring that at least one flush in `flush_watchdog_missed_flushes` has happened).


#### Motivation

We're still seeing veneur get stuck on flushing, and that's just not great as it's paging people.

#### Test plan

- [x] write a test to ensure this panics as planned.

#### Rollout/monitoring/revert plan

1. merge
2. adjust the config to set the `flush_watchdog_missed_flushes` setting to something like 3? (30s of no flushes) 6 (60s)?
3. roll it out.