### PR TITLE
Fix signalfx submission hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Veneur now sets a deadline for its flushes: No flush may take longer than the configured server flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!
+* The signalfx sink no longer deadlocks the flush process if it receives more than one error per submission. Thanks, [antifuchs](https://github.com/antifuchs)!
 
 ## Removed
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -2,6 +2,7 @@ package signalfx
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"strconv"
@@ -50,6 +51,16 @@ func (fs *FakeSink) AddEvents(ctx context.Context, events []*event.Event) (err e
 	fs.events = append(fs.events, events...)
 	fs.eventAdds += 1
 	return nil
+}
+
+type failSink struct{}
+
+func (fs failSink) AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) (err error) {
+	return errors.New("simulated failure to send")
+}
+
+func (fs failSink) AddEvents(ctx context.Context, events []*event.Event) (err error) {
+	return errors.New("simulated failure to send")
 }
 
 type testDerivedSink struct {
@@ -538,6 +549,45 @@ func TestSignalFxFlushBatches(t *testing.T) {
 	}
 	assert.True(t, found["first"])
 	assert.True(t, found["second"])
+}
+
+func TestSignalFxFlushBatchHang(t *testing.T) {
+	fallback := failSink{}
+
+	derived := newDerivedProcessor()
+	perBatch := 1
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch)
+
+	assert.NoError(t, err)
+
+	interMetrics := []samplers.InterMetric{
+		samplers.InterMetric{
+			Name:      "a.b.c",
+			Timestamp: 1476119058,
+			Value:     float64(100),
+			Tags: []string{
+				"foo:bar",
+				"baz:quz",
+				"test_by:first",
+			},
+			Type: samplers.GaugeMetric,
+		},
+		samplers.InterMetric{
+			Name:      "a.b.c.d",
+			Timestamp: 1476119058,
+			Value:     float64(100),
+			Tags: []string{
+				"foo:bar",
+				"baz:quz",
+				"test_by:first",
+			},
+			Type: samplers.GaugeMetric,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	require.Error(t, sink.Flush(ctx, interMetrics))
 }
 
 func TestNewSinkDoubleSlashes(t *testing.T) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Now *THIS* was a fun bug. This PR adjusts the per-api-key submission function in the signalfx sink to be a bit easier to read, and also removes a deadlock that occurred when a submission to an API key was broken into multiple batches and *more than one batch* failed - so that the total number of HTTP submission failures exceeded the number of API keys + 1.

This kind of thing happened preferentially on the boxes that submit large numbers of datapoints every time, namely our global veneurs. Oops.

This was found with the previous change adding the flush watchdog!

#### Motivation

Hangs are bad.

#### Test plan

I wrote a test that hangs on master & succeeds here!

#### Rollout/monitoring/revert plan

merge & deploy!
