### PR TITLE
Splunk sink data improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * The Kafka sink now includes metrics for skipped and dropped spans, as well as a debug log line for flushes. Thanks, [franklinhu](https://github.com/franklinhu)
 * A flush "watchdog" controlled by the config setting `flush_watchdog_missed_flushes`. If veneur has not started this many flushes, the watchdog panics and terminates veneur (so it can be restarted by process supervision). Thanks, [antifuchs](https://github.com/antifuchs)!
+* Splunk sink: Trace-related IDs are now represented in hexadecimal for cross-tool compatibility and a small byte savings. Thanks, [myndzi](https://github.com/myndzi)
+* Splunk sink: Indicator spans are now tagged with `"partial":true` when they would otherwise have been sampled, distinguishing between partial and full traces. Thanks, [myndzi](https://github.com/myndzi)
 
 ## Updated
 

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -437,11 +437,11 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 
 	// wouldDrop indicates whether this span would be dropped
 	// according to the sample rate. (1/spanSampleRate) spans
-	// will be kept.
+	// will be kept. `wouldDrop` is marked on Splunk events
+	// below when it's true
 	wouldDrop := ssfSpan.TraceId%sss.spanSampleRate != 0
 
-	// skip this span if the sample rate says so, UNLESS it
-	// is also an indicator span.
+	// indicator spans are never sampled
 	if wouldDrop && !ssfSpan.Indicator {
 		atomic.AddUint32(&sss.skippedSpans, 1)
 		return nil
@@ -468,7 +468,7 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		Name:           ssfSpan.Name,
 	}
 
-	if ssfSpan.Indicator {
+	if wouldDrop {
 		// if we would have dropped this span, the trace is marked as "partial"
 		// this lets us readily search for indicator spans that have full traces
 		// we only mark indicator spans this way

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -456,9 +456,9 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 	}
 
 	serialized := SerializedSSF{
-		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 10),
-		Id:             strconv.FormatInt(ssfSpan.Id, 10),
-		ParentId:       strconv.FormatInt(ssfSpan.ParentId, 10),
+		TraceId:        strconv.FormatInt(ssfSpan.TraceId, 16),
+		Id:             strconv.FormatInt(ssfSpan.Id, 16),
+		ParentId:       strconv.FormatInt(ssfSpan.ParentId, 16),
 		StartTimestamp: float64(ssfSpan.StartTimestamp) / float64(time.Second),
 		EndTimestamp:   float64(ssfSpan.EndTimestamp) / float64(time.Second),
 		Duration:       ssfSpan.EndTimestamp - ssfSpan.StartTimestamp,

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -467,9 +467,13 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 		Tags:           ssfSpan.Tags,
 		Indicator:      ssfSpan.Indicator,
 		Name:           ssfSpan.Name,
+	}
+
+	if ssfSpan.Indicator {
 		// if we would have dropped this span, the trace is marked as "partial"
 		// this lets us readily search for indicator spans that have full traces
-		Partial: wouldDrop,
+		// we only mark indicator spans this way
+		serialized.Partial = &wouldDrop
 	}
 
 	event := &Event{
@@ -505,5 +509,5 @@ type SerializedSSF struct {
 	Tags           map[string]string `json:"tags"`
 	Indicator      bool              `json:"indicator"`
 	Name           string            `json:"name"`
-	Partial        bool              `json:"partial"`
+	Partial        *bool             `json:"partial,omitempty"`
 }

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -437,8 +437,7 @@ func (sss *splunkSpanSink) Ingest(ssfSpan *ssf.SSFSpan) error {
 
 	// wouldDrop indicates whether this span would be dropped
 	// according to the sample rate. (1/spanSampleRate) spans
-	// will be kept. spans with a traceID of 0 will always be
-	// kept.
+	// will be kept.
 	wouldDrop := ssfSpan.TraceId%sss.spanSampleRate != 0
 
 	// skip this span if the sample rate says so, UNLESS it

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -311,7 +311,7 @@ func TestSampling(t *testing.T) {
 	assert.True(t, events > 0, "Should have sent around 1/10 of spans, but received zero")
 	assert.True(t, events < nToFlush/2, "Should have sent less than half the spans, but received %d of %d", events, nToFlush)
 	assert.Equal(t, 0, markedPartial, "Expected `partial` to be omitted from non-indicator spans, but it was there")
-	t.Logf("Received %d of %d events", events, nToFlush)
+	t.Logf("Received %d of %d events (%d marked partial)", events, nToFlush, markedPartial)
 }
 
 func TestSamplingIndicators(t *testing.T) {
@@ -379,7 +379,7 @@ func TestSamplingIndicators(t *testing.T) {
 	assert.Equal(t, events, nToFlush, "Should have sent all the spans, but received %d of %d", events, nToFlush)
 	assert.True(t, markedPartial > 0, "Should marked around 1/10 of spans as partial, but received zero")
 	assert.True(t, (nToFlush-markedPartial) < nToFlush/2, "Should have marked less than half the spans as partial, but received %d of %d", markedPartial, nToFlush)
-	t.Logf("Received %d of %d events", events, nToFlush)
+	t.Logf("Received %d of %d events (%d marked partial)", events, nToFlush, markedPartial)
 }
 
 func TestClosedIngestionEndpoint(t *testing.T) {


### PR DESCRIPTION
#### Summary
Two Splunk-related improvements:
1) Mark indicator spans with `partial: {true|false}` to represent whether they would have been kept or dropped by sampling rules
2) Format ids as hex for a slight byte savings + compatibility with other tools

#### Motivation
Improve searchability and cross-tool referencing of data


#### Test plan
Automated tests

#### Rollout/monitoring/revert plan
Trial in QA, bake, roll to prod

r? @asf-stripe 
