### PR TITLE
Downgrade Splunk HEC error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Updated
 
 * Updated the vendored version of DataDog/datadog-go which adds support for sending metrics to Unix Domain socket. Thanks, [prudhvi](https://github.com/prudhvi)!
+* Splunk sink: Downgraded Splunk HEC errors to be logged at warning level, rather than error level. Added a note to clarify that Splunk cluster restarts can cause temporary errors, which are not necessarily problematic. Thanks, [aditya](https://github.com/chimeracoder)!
 * Updated the vendored version of github.com/gogo/protobuf which fixes Gopkg.toml conflicts for users of veneur. Thanks, [dtbartle](http://github.com/dtbartle)!
 
 ## Bugfixes

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -401,7 +401,7 @@ func (sss *splunkSpanSink) makeHTTPRequest(req *http.Request, cancel func()) {
 			"hec_status_code":   parsed.Code,
 			"hec_response_text": parsed.Text,
 			"event_number":      parsed.InvalidEventNumber,
-		}).Error("Error response from Splunk HEC")
+		}).Warn("Error response from Splunk HEC. (Splunk restarts may cause transient errors).")
 	}
 	samples.Add(ssf.Count(failureMetric, 1, map[string]string{
 		"cause":       cause,


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Downgrade Splunk HEC error to warning and add more detailed message.

Quick fix for https://jira.corp.stripe.com/browse/OBS-11529, while we work on a better one. Either way, this is a more informative message.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @krisreeves-stripe 
cc @stripe/observability 