### PR TITLE
Setting the UDS recv buffer size based on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Updated the vendored version of github.com/gogo/protobuf which fixes Gopkg.toml conflicts for users of veneur. Thanks, [dtbartle](http://github.com/dtbartle)!
 
 ## Bugfixes
-
+* Veneur listening on UDS for statsd metrics will respect the `read_buffer_size_bytes` config. Thanks, [prudhvi](https://github.com/prudhvi)!
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Veneur now sets a deadline for its flushes: No flush may take longer than the configured server flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/networking.go
+++ b/networking.go
@@ -150,6 +150,12 @@ func startStatsdUnix(s *Server, addr *net.UnixAddr, packetPool *sync.Pool) (<-ch
 		panic(fmt.Sprintf("Couldn't listen on UNIX socket %v: %v", addr, err))
 	}
 
+	if rcvbufsize := s.RcvbufBytes; rcvbufsize != 0 {
+		if err := conn.SetReadBuffer(rcvbufsize); err != nil {
+			panic(fmt.Sprintf("Couldn't set buffer size for UNIX socket %v: %v", addr, err))
+		}
+	}
+
 	// Make the socket connectable by everyone with access to the socket pathname:
 	err = os.Chmod(addr.String(), 0666)
 	if err != nil {


### PR DESCRIPTION
#### Summary
Forgot to make sure that the UDS listener respect the read buffer size config param for setting the recv buffer size of socket. If we don't set this it will use the host defaults.

#### Motivation
We have very low host defaults for socket buffer sizes, but as long as host max is higher than that's configured in veneur config it works

Defaults and max for host can be found at
 /proc/sys/net/core/wmem_default
/proc/sys/net/core/wmem_max
