### PR TITLE
Make TestSignalFxFetchAPITokens deterministic

### DIFF
--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -660,19 +660,19 @@ func TestSignalFxExtractTokensFromResponse(t *testing.T) {
 
 // mockHandler cycles through a slice of predefined HTTP responses
 type mockHandler struct {
-	returns []string
-	index   int
+	responses []string
+	index     int
 }
 
 func (m *mockHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
-	resp.Write([]byte(m.returns[m.index%len(m.returns)]))
+	resp.Write([]byte(m.responses[m.index%len(m.responses)]))
 	m.index++
 }
 
 func TestSignalFxFetchAPITokens(t *testing.T) {
 	m := &mockHandler{
-		returns: []string{
+		responses: []string{
 			response1,
 			response3,
 			response2,
@@ -695,7 +695,7 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 func TestSignalFxClientByTagUpdater(t *testing.T) {
 	const dynamicKeyRefreshPeriod = 5 * time.Millisecond
 	m := &mockHandler{
-		returns: []string{
+		responses: []string{
 			response1,
 			response3,
 			response2,

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -658,20 +658,15 @@ func TestSignalFxExtractTokensFromResponse(t *testing.T) {
 	}
 }
 
+// mockHandler cycles through a slice of predefined HTTP responses
 type mockHandler struct {
 	returns []string
 	index   int
 }
 
 func (m *mockHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	if m.index >= len(m.returns) {
-		resp.WriteHeader(http.StatusBadRequest)
-		resp.Write([]byte("not enough responses specified"))
-		return
-	}
-
 	resp.WriteHeader(http.StatusOK)
-	resp.Write([]byte(m.returns[m.index]))
+	resp.Write([]byte(m.returns[m.index%len(m.returns)]))
 	m.index++
 }
 
@@ -698,6 +693,7 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 }
 
 func TestSignalFxClientByTagUpdater(t *testing.T) {
+	const dynamicKeyRefreshPeriod = 5 * time.Millisecond
 	m := &mockHandler{
 		returns: []string{
 			response1,
@@ -713,13 +709,14 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	derived := newDerivedProcessor()
 	perBatch := 1
 
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", true, 5*time.Millisecond, "", server.URL, server.Client())
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", true, dynamicKeyRefreshPeriod, "", server.URL, server.Client())
 	require.NoError(t, err)
 
 	err = sink.Start(nil)
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
+	// TODO better synchronization here than time.Sleep
+	time.Sleep(10 * dynamicKeyRefreshPeriod)
 
 	sink.clientsByTagValueMu.Lock()
 
@@ -739,5 +736,9 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	sort.Strings(expectedPerTagClients)
 	sort.Strings(actualPerTagClients)
 
-	require.Equal(t, expectedPerTagClients, actualPerTagClients)
+	// Check that both sets are equal (subsets of each other)
+	// The order might be different due to modular division, but we should always receive the same
+	// three responses
+	assert.Subset(t, expectedPerTagClients, actualPerTagClients, "The actual values should be a subset of the expected values")
+	assert.Subset(t, actualPerTagClients, expectedPerTagClients, "The expected values should be a subset of the actual values")
 }


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

TestSignalFxFetchAPITokens, introduced in #738 / #706, included a race condition which causes flaky builds in resource-constrained environments (CircleCI, but not developer laptops). This PR fixes that race condition and also cleans up some harmless errors that caused extraneous logs.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 