### PR TITLE
Add timeout for TestSignalFxClientByTagUpdater

### DIFF
--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -732,7 +732,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 
 	mindex := atomic.LoadInt64(&m.index)
 	assert.True(t, mindex >= 3, "m.index should be at least 3, not %d", mindex)
-	assert.Equal(t, len(sink.clientsByTagValue), len(expectedPerTagClients), "Sink should have %d clients", len(expectedPerTagClients))
+	assert.Equal(t, len(expectedPerTagClients), len(sink.clientsByTagValue), "Sink should have %d clients", len(expectedPerTagClients))
 	for tag, client := range sink.clientsByTagValue {
 		actualPerTagClients = append(actualPerTagClients, tag)
 		require.NotNil(t, client)

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -667,7 +667,8 @@ type mockHandler struct {
 
 func (m *mockHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
-	resp.Write([]byte(m.responses[atomic.LoadInt64(&m.index)%int64(len(m.responses))]))
+	response := m.responses[atomic.LoadInt64(&m.index)%int64(len(m.responses))]
+	resp.Write([]byte(response))
 	atomic.AddInt64(&m.index, 1)
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -719,6 +719,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	time.Sleep(10 * dynamicKeyRefreshPeriod)
 
 	sink.clientsByTagValueMu.Lock()
+	defer sink.clientsByTagValueMu.Unlock()
 
 	expectedPerTagClients := []string{
 		"service",
@@ -741,4 +742,5 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	// three responses
 	assert.Subset(t, expectedPerTagClients, actualPerTagClients, "The actual values should be a subset of the expected values")
 	assert.Subset(t, actualPerTagClients, expectedPerTagClients, "The expected values should be a subset of the actual values")
+	assert.GreaterOrEqual(t, m.index, 3)
 }

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -694,7 +694,7 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 }
 
 func TestSignalFxClientByTagUpdater(t *testing.T) {
-	const dynamicKeyRefreshPeriod = 5 * time.Millisecond
+	const dynamicKeyRefreshPeriod = 1 * time.Millisecond
 	m := &mockHandler{
 		responses: []string{
 			response1,
@@ -717,7 +717,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	require.NoError(t, err)
 
 	// TODO better synchronization here than time.Sleep
-	time.Sleep(10 * dynamicKeyRefreshPeriod)
+	time.Sleep(100 * dynamicKeyRefreshPeriod)
 
 	sink.clientsByTagValueMu.Lock()
 	defer sink.clientsByTagValueMu.Unlock()


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Follow up from https://github.com/stripe/veneur/pull/741. This timeout ensures that the sink hits the (test) server at least four times, which should mean that all three client keys in the test have been processed at least once.

In the process, we discovered another unrelated race condition in one of the Splunk sink tests, though it's rarer, so I've created a ticket for that to tackle another time.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 