### PR TITLE
Add metric measuring unique timeseries per host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New SSF `sample` field: `scope`. This field lets clients tell Veneur what to do with the sample - it corresponds exactly to the `veneurglobalonly` and `veneurlocalonly` tags that metrics can hold. Thanks, [antifuchs](https://github.com/antifuchs)!
 * veneur-prometheus now allows you to specify mTLS configuration for the polling HTTP client. Thanks, [choo-stripe](https://github.com/choo-stripe)!
 * The `http_quit` config option enables the `/quitquitquit` endpoint, which can be used to trigger a graceful shutdown using an HTTP POST request. Thanks, [aditya](https://github.com/chimeracoder)!
+* New config option `count_unique_timeseries` which is used to emit metric `veneur.flush.unique_timeseries_total`, the HyperLogLog cardinality estimate of the unique timeseries in a flush interval. Thanks, [randallm](https://github.com/randallm)!
 
 ## Updated
 

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	AwsS3Bucket                               string    `yaml:"aws_s3_bucket"`
 	AwsSecretAccessKey                        string    `yaml:"aws_secret_access_key"`
 	BlockProfileRate                          int       `yaml:"block_profile_rate"`
+	CountUniqueTimeseries                     bool      `yaml:"count_unique_timeseries`
 	DatadogAPIHostname                        string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey                             string    `yaml:"datadog_api_key"`
 	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`

--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	AwsS3Bucket                               string    `yaml:"aws_s3_bucket"`
 	AwsSecretAccessKey                        string    `yaml:"aws_secret_access_key"`
 	BlockProfileRate                          int       `yaml:"block_profile_rate"`
-	CountUniqueTimeseries                     bool      `yaml:"count_unique_timeseries`
+	CountUniqueTimeseries                     bool      `yaml:"count_unique_timeseries"`
 	DatadogAPIHostname                        string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey                             string    `yaml:"datadog_api_key"`
 	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`

--- a/example.yaml
+++ b/example.yaml
@@ -163,6 +163,8 @@ veneur_metrics_scopes:
 veneur_metrics_additional_tags:
   - "veneur_internal_metric:true"
 
+count_unique_timeseries: false
+
 # == DEPRECATED ==
 
 # This configuration has been replaced by datadog_flush_max_per_body.

--- a/flusher.go
+++ b/flusher.go
@@ -25,7 +25,6 @@ import (
 
 // Flush collects sampler's metrics and passes them to sinks.
 func (s *Server) Flush(ctx context.Context) {
-	// TODO: combine and reset the sets
 	span := tracer.StartSpan("flush").(*trace.Span)
 	defer span.ClientFinish(s.TraceClient)
 
@@ -329,7 +328,6 @@ func (s *Server) reportMetricsFlushCounts(ms metricsSummary) {
 // globalCounters, globalGauges, totalHistograms, totalSets, and totalTimers,
 // which are the three metrics reported *only* by the global
 // veneur instance.
-// TODO: update this because it's no longer just 3 metrics
 func (s *Server) reportGlobalMetricsFlushCounts(ms metricsSummary) {
 	// we only report these lengths in FlushGlobal
 	// since if we're the global veneur instance responsible for flushing them

--- a/flusher.go
+++ b/flusher.go
@@ -42,7 +42,9 @@ func (s *Server) Flush(ctx context.Context) {
 	s.Statsd.Gauge("mem.heap_alloc_bytes", float64(mem.HeapAlloc), nil, 1.0)
 	s.Statsd.Gauge("flush.flush_timestamp_ns", float64(flushTime), nil, 1.0)
 
-	s.Statsd.Count("flush.unique_timeseries_total", s.tallyTimeseries(), []string{fmt.Sprintf("global_veneur:%t", !s.IsLocal())}, 1.0)
+	if s.CountUniqueTimeseries {
+		s.Statsd.Count("flush.unique_timeseries_total", s.tallyTimeseries(), []string{fmt.Sprintf("global_veneur:%t", !s.IsLocal())}, 1.0)
+	}
 
 	samples := s.EventWorker.Flush()
 

--- a/flusher.go
+++ b/flusher.go
@@ -42,7 +42,7 @@ func (s *Server) Flush(ctx context.Context) {
 	s.Statsd.Gauge("flush.flush_timestamp_ns", float64(flushTime), nil, 1.0)
 
 	mts := s.tallyTimeseries()
-	s.Statsd.Count("worker.unique_timeseries_total", mts.count, mts.tags, 1.0)
+	s.Statsd.Count("flush.unique_timeseries_total", mts.count, mts.tags, 1.0)
 
 	samples := s.EventWorker.Flush()
 

--- a/flusher.go
+++ b/flusher.go
@@ -25,6 +25,7 @@ import (
 
 // Flush collects sampler's metrics and passes them to sinks.
 func (s *Server) Flush(ctx context.Context) {
+	// TODO: combine and reset the sets
 	span := tracer.StartSpan("flush").(*trace.Span)
 	defer span.ClientFinish(s.TraceClient)
 

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -181,6 +181,7 @@ func TestGlobalAcceptsHistogramsOverUDP(t *testing.T) {
 
 func TestFlushResetsWorkerUniqueMTS(t *testing.T) {
 	config := localConfig()
+	config.CountUniqueTimeseries = true
 	config.NumWorkers = 2
 	config.Interval = "60s"
 	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}
@@ -211,6 +212,7 @@ func TestFlushResetsWorkerUniqueMTS(t *testing.T) {
 
 func TestTallyTimeseries(t *testing.T) {
 	config := localConfig()
+	config.CountUniqueTimeseries = true
 	config.NumWorkers = 10
 	config.Interval = "60s"
 	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -209,7 +209,7 @@ func TestFlushResetsWorkerUniqueMTS(t *testing.T) {
 	}
 }
 
-func TestTimeseriesSummary(t *testing.T) {
+func TestTallyTimeseries(t *testing.T) {
 	config := localConfig()
 	config.NumWorkers = 10
 	config.Interval = "60s"
@@ -242,8 +242,5 @@ func TestTimeseriesSummary(t *testing.T) {
 	f.server.Workers[0].SampleTimeseries(&m2)
 
 	summary := f.server.tallyTimeseries()
-	assert.Equal(t, timeseriesSummary{
-		tags:  []string{"global_veneur:false"},
-		count: 2,
-	}, summary)
+	assert.Equal(t, int64(2), summary)
 }

--- a/networking.go
+++ b/networking.go
@@ -29,23 +29,11 @@ func StartStatsd(s *Server, a net.Addr, packetPool *sync.Pool) net.Addr {
 	}
 }
 
-// udpProcessor is a wrapper for the udpSSFProcessor and
-// udpStatsdProcessor types.
-type udpProcessor struct {
-	SsfProc    udpSSFProcessor
-	StatsdProc udpStatsdProcessor
-}
+// udpProcessor is a function that reads packets from a socket, using
+// the pool provided.
+type udpProcessor func(net.PacketConn, *sync.Pool)
 
-// udpSSFProcessor is a function that reads SSF packets from a
-// socket, using the pool provided.
-type udpSSFProcessor func(net.PacketConn, *sync.Pool)
-
-// udpStatsdProcessor is a function that reads Statsd packets from a
-// socket, using the pool provided.
-// TODO: document aggregation
-type udpStatsdProcessor func(net.PacketConn, *sync.Pool, ReaderTimeseries)
-
-// startProcessingOnUDP starts network numReaders listeners on the
+// startProcessingOnUDP starts network num_readers listeners on the
 // given address in one goroutine each, using the passed pool. When
 // the listener is established, it starts the udpProcessor with the
 // listener.
@@ -66,7 +54,6 @@ func startProcessingOnUDP(s *Server, protocol string, addr *net.UDPAddr, pool *s
 	addrChan := make(chan net.Addr, 1)
 	once := sync.Once{}
 	for i := 0; i < s.numReaders; i++ {
-		readerTimeseries := s.NewReaderTimeseries()
 		go func() {
 			defer func() {
 				ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
@@ -96,21 +83,14 @@ func startProcessingOnUDP(s *Server, protocol string, addr *net.UDPAddr, pool *s
 				close(addrChan)
 			})
 
-			if protocol == "ssf" {
-				proc.SsfProc(sock, pool)
-			} else if protocol == "statsd" {
-				proc.StatsdProc(sock, pool, readerTimeseries)
-			}
+			proc(sock, pool)
 		}()
 	}
 	return <-addrChan
 }
 
 func startStatsdUDP(s *Server, addr *net.UDPAddr, packetPool *sync.Pool) net.Addr {
-	proc := udpProcessor{
-		StatsdProc: s.ReadMetricSocket,
-	}
-	return startProcessingOnUDP(s, "statsd", addr, packetPool, proc)
+	return startProcessingOnUDP(s, "statsd", addr, packetPool, s.ReadMetricSocket)
 }
 
 func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) net.Addr {
@@ -147,15 +127,11 @@ func startStatsdTCP(s *Server, addr *net.TCPAddr, packetPool *sync.Pool) net.Add
 		"address": addr, "mode": mode,
 	}).Info("Listening for statsd metrics on TCP socket")
 
-	// TODO: figure out name
-	// TODO: figure out tags
-	readerTimeseries := s.NewReaderTimeseries()
-
 	go func() {
 		defer func() {
 			ConsumePanic(s.Sentry, s.TraceClient, s.Hostname, recover())
 		}()
-		s.ReadTCPSocket(listener, readerTimeseries)
+		s.ReadTCPSocket(listener)
 	}()
 	return listener.Addr()
 }
@@ -201,7 +177,7 @@ func startStatsdUnix(s *Server, addr *net.UnixAddr, packetPool *sync.Pool) (<-ch
 		}
 	}()
 	for i := 0; i < s.numReaders; i++ {
-		go s.ReadStatsdDatagramSocket(conn, packetPool, s.readerTimeseries[i])
+		go s.ReadStatsdDatagramSocket(conn, packetPool)
 	}
 	return done, addr
 }
@@ -225,10 +201,7 @@ func StartSSF(s *Server, a net.Addr, tracePool *sync.Pool) net.Addr {
 }
 
 func startSSFUDP(s *Server, addr *net.UDPAddr, tracePool *sync.Pool) net.Addr {
-	proc := udpProcessor{
-		SsfProc: s.ReadSSFPacketSocket,
-	}
-	return startProcessingOnUDP(s, "ssf", addr, tracePool, proc)
+	return startProcessingOnUDP(s, "ssf", addr, tracePool, s.ReadSSFPacketSocket)
 }
 
 // startSSFUnix starts listening for connections that send framed SSF

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -372,6 +372,7 @@ type Set struct {
 
 // Sample checks if the supplied value has is already in the filter. If not, it increments
 // the counter!
+// TODO: actually use sampleRate
 func (s *Set) Sample(sample string, sampleRate float32) {
 	s.Hll.Insert([]byte(sample))
 }

--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -372,8 +372,7 @@ type Set struct {
 
 // Sample checks if the supplied value has is already in the filter. If not, it increments
 // the counter!
-// TODO: actually use sampleRate
-func (s *Set) Sample(sample string, sampleRate float32) {
+func (s *Set) Sample(sample string) {
 	s.Hll.Insert([]byte(sample))
 }
 

--- a/samplers/samplers_test.go
+++ b/samplers/samplers_test.go
@@ -193,14 +193,14 @@ func TestSet(t *testing.T) {
 	assert.Len(t, s.Tags, 1, "Tag count")
 	assert.Equal(t, "a:b", s.Tags[0], "First tag")
 
-	s.Sample("5", 1.0)
+	s.Sample("5")
 
-	s.Sample("5", 1.0)
+	s.Sample("5")
 
-	s.Sample("123", 1.0)
+	s.Sample("123")
 
-	s.Sample("2147483647", 1.0)
-	s.Sample("-2147483648", 1.0)
+	s.Sample("2147483647")
+	s.Sample("-2147483648")
 
 	metrics := s.Flush()
 	assert.Len(t, metrics, 1, "Flush")
@@ -217,7 +217,7 @@ func TestSetMerge(t *testing.T) {
 
 	s := NewSet("a.b.c", []string{"a:b"})
 	for i := 0; i < 100; i++ {
-		s.Sample(strconv.Itoa(rand.Int()), 1.0)
+		s.Sample(strconv.Itoa(rand.Int()))
 	}
 	assert.Equal(t, uint64(100), s.Hll.Estimate(), "counts did not match")
 
@@ -240,7 +240,7 @@ func TestSetMergeMetric(t *testing.T) {
 
 	s := NewSet("a.b.c", []string{"a:b"})
 	for i := 0; i < 100; i++ {
-		s.Sample(strconv.Itoa(rand.Int()), 1.0)
+		s.Sample(strconv.Itoa(rand.Int()))
 	}
 	assert.Equal(t, uint64(100), s.Hll.Estimate(), "counts did not match")
 

--- a/server_test.go
+++ b/server_test.go
@@ -1000,7 +1000,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Simulate a metrics worker:
-	w := NewWorker(0, false, nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 	go func() {
 	}()
@@ -1073,7 +1073,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	require.NoError(b, err)
 
 	// Simulate a metrics worker:
-	w := NewWorker(0, false, nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 
 	go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -697,7 +697,7 @@ func TestUDPMetricsSSF(t *testing.T) {
 	assert.Equal(t, "test.metric", metrics[0].Name, "worker processed the metric")
 }
 
-func TestAsdf(t *testing.T) {
+func TestTotalMTS(t *testing.T) {
 	config := localConfig()
 	config.NumWorkers = 1
 	config.Interval = "5m"
@@ -712,16 +712,13 @@ func TestAsdf(t *testing.T) {
 	defer conn.Close()
 
 	packet := []byte("foo.bar:1|c|#baz:gorch")
-	readerTimeseries := f.server.NewReaderTimeseries()
-	fmt.Println(len(f.server.readerTimeseries))
-	assert.Equal(t, 1, 1)
-	f.server.HandleMetricPacket(packet, readerTimeseries)
-	assert.Equal(t, 1, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
-	f.server.HandleMetricPacket(packet, readerTimeseries)
-	assert.Equal(t, 1, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet)
+	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet)
+	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
 	packet2 := []byte("foo.bar:1|c|#boom:bap")
-	f.server.HandleMetricPacket(packet2, readerTimeseries)
-	assert.Equal(t, 2, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet2)
+	assert.Equal(t, 2, int(f.server.totalMTS.Hll.Estimate()))
 }
 
 func connectToAddress(t *testing.T, network string, addr string, timeout time.Duration) net.Conn {
@@ -970,7 +967,7 @@ func TestHandleTCPGoroutineTimeout(t *testing.T) {
 
 	// handleTCPGoroutine should not block forever: it will time outTest
 	log.Printf("handling goroutine")
-	s.handleTCPGoroutine(conn, s.NewReaderTimeseries())
+	s.handleTCPGoroutine(conn)
 	<-acceptorDone
 
 	// we should have received one metric

--- a/server_test.go
+++ b/server_test.go
@@ -1000,7 +1000,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Simulate a metrics worker:
-	w := NewWorker(0, s.IsLocal(), nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 	go func() {
 	}()
@@ -1073,7 +1073,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	require.NoError(b, err)
 
 	// Simulate a metrics worker:
-	w := NewWorker(0, s.IsLocal(), nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd)
 	s.Workers = []*Worker{w}
 
 	go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -215,7 +215,9 @@ func newFixture(t testing.TB, config Config, mSink sinks.MetricSink, sSink sinks
 	// (e.g. Datadog)
 	f := &fixture{nil, &Server{}, interval, config.DatadogFlushMaxPerBody}
 
-	config.NumWorkers = 1
+	if config.NumWorkers == 0 {
+		config.NumWorkers = 1
+	}
 	f.server = setupVeneurServer(t, config, nil, mSink, sSink, nil)
 	return f
 }

--- a/server_test.go
+++ b/server_test.go
@@ -697,7 +697,7 @@ func TestUDPMetricsSSF(t *testing.T) {
 	assert.Equal(t, "test.metric", metrics[0].Name, "worker processed the metric")
 }
 
-func TestTotalMTS(t *testing.T) {
+func TestAsdf(t *testing.T) {
 	config := localConfig()
 	config.NumWorkers = 1
 	config.Interval = "5m"
@@ -712,13 +712,16 @@ func TestTotalMTS(t *testing.T) {
 	defer conn.Close()
 
 	packet := []byte("foo.bar:1|c|#baz:gorch")
-	f.server.HandleMetricPacket(packet)
-	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
-	f.server.HandleMetricPacket(packet)
-	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
+	readerTimeseries := f.server.NewReaderTimeseries()
+	fmt.Println(len(f.server.readerTimeseries))
+	assert.Equal(t, 1, 1)
+	f.server.HandleMetricPacket(packet, readerTimeseries)
+	assert.Equal(t, 1, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet, readerTimeseries)
+	assert.Equal(t, 1, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
 	packet2 := []byte("foo.bar:1|c|#boom:bap")
-	f.server.HandleMetricPacket(packet2)
-	assert.Equal(t, 2, int(f.server.totalMTS.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet2, readerTimeseries)
+	assert.Equal(t, 2, int(f.server.readerTimeseries[2].Set.Hll.Estimate()))
 }
 
 func connectToAddress(t *testing.T, network string, addr string, timeout time.Duration) net.Conn {
@@ -967,7 +970,7 @@ func TestHandleTCPGoroutineTimeout(t *testing.T) {
 
 	// handleTCPGoroutine should not block forever: it will time outTest
 	log.Printf("handling goroutine")
-	s.handleTCPGoroutine(conn)
+	s.handleTCPGoroutine(conn, s.NewReaderTimeseries())
 	<-acceptorDone
 
 	// we should have received one metric

--- a/server_test.go
+++ b/server_test.go
@@ -697,6 +697,30 @@ func TestUDPMetricsSSF(t *testing.T) {
 	assert.Equal(t, "test.metric", metrics[0].Name, "worker processed the metric")
 }
 
+func TestTotalMTS(t *testing.T) {
+	config := localConfig()
+	config.NumWorkers = 1
+	config.Interval = "5m"
+	config.SsfListenAddresses = []string{"udp://127.0.0.1:0"}
+	ch := make(chan []samplers.InterMetric, 20)
+	sink, _ := NewChannelMetricSink(ch)
+	f := newFixture(t, config, sink, nil)
+	defer f.Close()
+
+	addr := f.server.SSFListenAddrs[0]
+	conn := connectToAddress(t, "udp", addr.String(), 20*time.Millisecond)
+	defer conn.Close()
+
+	packet := []byte("foo.bar:1|c|#baz:gorch")
+	f.server.HandleMetricPacket(packet)
+	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
+	f.server.HandleMetricPacket(packet)
+	assert.Equal(t, 1, int(f.server.totalMTS.Hll.Estimate()))
+	packet2 := []byte("foo.bar:1|c|#boom:bap")
+	f.server.HandleMetricPacket(packet2)
+	assert.Equal(t, 2, int(f.server.totalMTS.Hll.Estimate()))
+}
+
 func connectToAddress(t *testing.T, network string, addr string, timeout time.Duration) net.Conn {
 	ch := make(chan net.Conn)
 	go func() {

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger, nil)
+	worker := veneur.NewWorker(0, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestMetricExtractor(t *testing.T) {
 
 func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger, nil)
+	worker := veneur.NewWorker(0, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	if err != nil {
@@ -109,7 +109,7 @@ func BenchmarkParallelMetricExtractor(b *testing.B) {
 
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, nil, logger, nil)
+	worker := veneur.NewWorker(0, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "bar", nil, logger)
 	require.NoError(t, err)

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestMetricExtractor(t *testing.T) {
 
 func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	if err != nil {
@@ -109,7 +109,7 @@ func BenchmarkParallelMetricExtractor(b *testing.B) {
 
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "bar", nil, logger)
 	require.NoError(t, err)

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestMetricExtractor(t *testing.T) {
 
 func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	if err != nil {
@@ -109,7 +109,7 @@ func BenchmarkParallelMetricExtractor(b *testing.B) {
 
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "bar", nil, logger)
 	require.NoError(t, err)

--- a/worker.go
+++ b/worker.go
@@ -29,21 +29,21 @@ const statusTypeName = "status"
 
 // Worker is the doodad that does work.
 type Worker struct {
-	id                    int
-	runningInGlobalVeneur bool
-	uniqueMTS             *hyperloglog.Sketch
-	uniqueMTSMtx          *sync.RWMutex
-	PacketChan            chan samplers.UDPMetric
-	ImportChan            chan []samplers.JSONMetric
-	ImportMetricChan      chan []*metricpb.Metric
-	QuitChan              chan struct{}
-	processed             int64
-	imported              int64
-	mutex                 *sync.Mutex
-	traceClient           *trace.Client
-	logger                *logrus.Logger
-	wm                    WorkerMetrics
-	stats                 scopedstatsd.Client
+	id               int
+	isLocal          bool
+	uniqueMTS        *hyperloglog.Sketch
+	uniqueMTSMtx     *sync.RWMutex
+	PacketChan       chan samplers.UDPMetric
+	ImportChan       chan []samplers.JSONMetric
+	ImportMetricChan chan []*metricpb.Metric
+	QuitChan         chan struct{}
+	processed        int64
+	imported         int64
+	mutex            *sync.Mutex
+	traceClient      *trace.Client
+	logger           *logrus.Logger
+	wm               WorkerMetrics
+	stats            scopedstatsd.Client
 }
 
 // IngestUDP on a Worker feeds the metric into the worker's PacketChan.
@@ -238,23 +238,23 @@ func (wm WorkerMetrics) appendExportedMetric(res []*metricpb.Metric, exp metricE
 }
 
 // NewWorker creates, and returns a new Worker object.
-func NewWorker(id int, runningInGlobalVeneur bool, cl *trace.Client, logger *logrus.Logger, stats scopedstatsd.Client) *Worker {
+func NewWorker(id int, isLocal bool, cl *trace.Client, logger *logrus.Logger, stats scopedstatsd.Client) *Worker {
 	return &Worker{
-		id:                    id,
-		runningInGlobalVeneur: runningInGlobalVeneur,
-		uniqueMTS:             hyperloglog.New(),
-		uniqueMTSMtx:          &sync.RWMutex{},
-		PacketChan:            make(chan samplers.UDPMetric, 32),
-		ImportChan:            make(chan []samplers.JSONMetric, 32),
-		ImportMetricChan:      make(chan []*metricpb.Metric, 32),
-		QuitChan:              make(chan struct{}),
-		processed:             0,
-		imported:              0,
-		mutex:                 &sync.Mutex{},
-		traceClient:           cl,
-		logger:                logger,
-		wm:                    NewWorkerMetrics(),
-		stats:                 scopedstatsd.Ensure(stats),
+		id:               id,
+		isLocal:          isLocal,
+		uniqueMTS:        hyperloglog.New(),
+		uniqueMTSMtx:     &sync.RWMutex{},
+		PacketChan:       make(chan samplers.UDPMetric, 32),
+		ImportChan:       make(chan []samplers.JSONMetric, 32),
+		ImportMetricChan: make(chan []*metricpb.Metric, 32),
+		QuitChan:         make(chan struct{}),
+		processed:        0,
+		imported:         0,
+		mutex:            &sync.Mutex{},
+		traceClient:      cl,
+		logger:           logger,
+		wm:               NewWorkerMetrics(),
+		stats:            scopedstatsd.Ensure(stats),
 	}
 }
 
@@ -302,7 +302,7 @@ func (w *Worker) SampleTimeseries(m *samplers.UDPMetric) {
 
 	// Always sample if worker is running in global Veneur instance,
 	// as there is nowhere the metric can be forwarded to.
-	if w.runningInGlobalVeneur {
+	if !w.isLocal {
 		w.uniqueMTS.Insert(digest)
 		return
 	}

--- a/worker.go
+++ b/worker.go
@@ -366,9 +366,9 @@ func (w *Worker) ProcessMetric(m *samplers.UDPMetric) {
 		}
 	case setTypeName:
 		if m.Scope == samplers.LocalOnly {
-			w.wm.localSets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
+			w.wm.localSets[m.MetricKey].Sample(m.Value.(string))
 		} else {
-			w.wm.sets[m.MetricKey].Sample(m.Value.(string), m.SampleRate)
+			w.wm.sets[m.MetricKey].Sample(m.Value.(string))
 		}
 	case timerTypeName:
 		if m.Scope == samplers.LocalOnly {

--- a/worker.go
+++ b/worker.go
@@ -290,7 +290,8 @@ func (w *Worker) MetricsProcessedCount() int64 {
 	return w.processed
 }
 
-// TODO: document
+// SampleTimeseries takes a metric and counts whether the timeseries
+// has already been seen by the worker in this flush interval.
 func (w *Worker) SampleTimeseries(m *samplers.UDPMetric) {
 	digestStr := strconv.FormatUint(uint64(m.Digest), 10)
 	w.totalMTSMtx.RLock()

--- a/worker_test.go
+++ b/worker_test.go
@@ -502,3 +502,43 @@ func TestGlobalWorkerSampleTimeseries(t *testing.T) {
 	w.SampleTimeseries(&m2)
 	assert.Equal(t, uint64(2), w.uniqueMTS.Estimate())
 }
+
+func BenchmarkPacketChanWork(b *testing.B) {
+	w := NewWorker(1, true, nil, logrus.New(), nil)
+	m := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "counter",
+			Type: counterTypeName,
+		},
+		Value:      20.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.MixedScope,
+	}
+
+	go w.Work()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.PacketChan <- m
+	}
+	w.Stop()
+}
+
+func BenchmarkSampleTimeseries(b *testing.B) {
+	w := NewWorker(1, true, nil, logrus.New(), nil)
+	m := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "counter",
+			Type: counterTypeName,
+		},
+		Value:      20.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.MixedScope,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.SampleTimeseries(&m)
+	}
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -40,7 +40,7 @@ func TestWorker(t *testing.T) {
 }
 
 func TestWorkerLocal(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -93,7 +93,7 @@ func TestWorkerGlobal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo", 1.0)
 	testset.Sample("bar", 1.0)
@@ -108,7 +108,7 @@ func TestWorkerImportSet(t *testing.T) {
 }
 
 func TestWorkerImportHistogram(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 	testhisto := samplers.NewHist("a.b.c", nil)
 	testhisto.Sample(1.0, 1.0)
 	testhisto.Sample(2.0, 1.0)
@@ -123,7 +123,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerStatusMetric(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -264,7 +264,7 @@ type testMetricExporter interface {
 }
 
 func exportMetricAndFlush(t testing.TB, exp testMetricExporter) WorkerMetrics {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 	m, err := exp.Metric()
 	assert.NoErrorf(t, err, "exporting the metric '%s' shouldn't have failed",
 		exp.GetName())
@@ -301,7 +301,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 	})
 	t.Run("timer", func(t *testing.T) {
 		t.Parallel()
-		w := NewWorker(1, false, nil, logrus.New(), nil)
+		w := NewWorker(1, true, nil, logrus.New(), nil)
 		h := samplers.NewHist("test.timer", nil)
 		h.Sample(1.0, 1.0)
 
@@ -327,7 +327,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 func TestWorkerImportMetricGRPCNilValue(t *testing.T) {
 	t.Parallel()
 
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 	metric := &metricpb.Metric{
 		Name:  "test",
 		Type:  metricpb.Type_Histogram,
@@ -429,7 +429,7 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 }
 
 func TestLocalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -456,7 +456,7 @@ func TestLocalWorkerSampleTimeseries(t *testing.T) {
 }
 
 func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -480,7 +480,7 @@ func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
 }
 
 func TestGlobalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{

--- a/worker_test.go
+++ b/worker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -40,7 +40,7 @@ func TestWorker(t *testing.T) {
 }
 
 func TestWorkerLocal(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -60,7 +60,7 @@ func TestWorkerLocal(t *testing.T) {
 }
 
 func TestWorkerGlobal(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, false, false, nil, logrus.New(), nil)
 
 	gc := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -93,7 +93,7 @@ func TestWorkerGlobal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo")
 	testset.Sample("bar")
@@ -108,7 +108,7 @@ func TestWorkerImportSet(t *testing.T) {
 }
 
 func TestWorkerImportHistogram(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 	testhisto := samplers.NewHist("a.b.c", nil)
 	testhisto.Sample(1.0, 1.0)
 	testhisto.Sample(2.0, 1.0)
@@ -123,7 +123,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerStatusMetric(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -264,7 +264,7 @@ type testMetricExporter interface {
 }
 
 func exportMetricAndFlush(t testing.TB, exp testMetricExporter) WorkerMetrics {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 	m, err := exp.Metric()
 	assert.NoErrorf(t, err, "exporting the metric '%s' shouldn't have failed",
 		exp.GetName())
@@ -301,7 +301,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 	})
 	t.Run("timer", func(t *testing.T) {
 		t.Parallel()
-		w := NewWorker(1, true, nil, logrus.New(), nil)
+		w := NewWorker(1, true, false, nil, logrus.New(), nil)
 		h := samplers.NewHist("test.timer", nil)
 		h.Sample(1.0, 1.0)
 
@@ -327,7 +327,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 func TestWorkerImportMetricGRPCNilValue(t *testing.T) {
 	t.Parallel()
 
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil)
 	metric := &metricpb.Metric{
 		Name:  "test",
 		Type:  metricpb.Type_Histogram,
@@ -429,7 +429,7 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 }
 
 func TestLocalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -456,7 +456,7 @@ func TestLocalWorkerSampleTimeseries(t *testing.T) {
 }
 
 func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -480,7 +480,7 @@ func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
 }
 
 func TestGlobalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, false, nil, logrus.New(), nil)
+	w := NewWorker(1, false, true, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -504,7 +504,7 @@ func TestGlobalWorkerSampleTimeseries(t *testing.T) {
 }
 
 func BenchmarkPacketChanWork(b *testing.B) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil)
 
 	const Len = 1000
 	input := make([]*samplers.UDPMetric, Len)
@@ -546,7 +546,7 @@ func BenchmarkPacketChanWork(b *testing.B) {
 }
 
 func BenchmarkSampleTimeseries(b *testing.B) {
-	w := NewWorker(1, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil)
 	const Len = 1000
 	input := make([]*samplers.UDPMetric, Len)
 	for i, _ := range input {

--- a/worker_test.go
+++ b/worker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -40,7 +40,7 @@ func TestWorker(t *testing.T) {
 }
 
 func TestWorkerLocal(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -60,7 +60,7 @@ func TestWorkerLocal(t *testing.T) {
 }
 
 func TestWorkerGlobal(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 
 	gc := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -93,7 +93,7 @@ func TestWorkerGlobal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo", 1.0)
 	testset.Sample("bar", 1.0)
@@ -108,7 +108,7 @@ func TestWorkerImportSet(t *testing.T) {
 }
 
 func TestWorkerImportHistogram(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 	testhisto := samplers.NewHist("a.b.c", nil)
 	testhisto.Sample(1.0, 1.0)
 	testhisto.Sample(2.0, 1.0)
@@ -123,7 +123,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerStatusMetric(t *testing.T) {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -264,7 +264,7 @@ type testMetricExporter interface {
 }
 
 func exportMetricAndFlush(t testing.TB, exp testMetricExporter) WorkerMetrics {
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 	m, err := exp.Metric()
 	assert.NoErrorf(t, err, "exporting the metric '%s' shouldn't have failed",
 		exp.GetName())
@@ -301,7 +301,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 	})
 	t.Run("timer", func(t *testing.T) {
 		t.Parallel()
-		w := NewWorker(1, nil, logrus.New(), nil)
+		w := NewWorker(1, false, nil, logrus.New(), nil)
 		h := samplers.NewHist("test.timer", nil)
 		h.Sample(1.0, 1.0)
 
@@ -327,7 +327,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 func TestWorkerImportMetricGRPCNilValue(t *testing.T) {
 	t.Parallel()
 
-	w := NewWorker(1, nil, logrus.New(), nil)
+	w := NewWorker(1, false, nil, logrus.New(), nil)
 	metric := &metricpb.Metric{
 		Name:  "test",
 		Type:  metricpb.Type_Histogram,
@@ -426,4 +426,79 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 				"The output of ForwardableMetrics doesn't have the right metrics")
 		})
 	}
+}
+
+func TestLocalWorkerSampleTimeseries(t *testing.T) {
+	w := NewWorker(1, false, nil, logrus.New(), nil)
+
+	m := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "histogram",
+		},
+		Digest: 1,
+		Scope:  samplers.LocalOnly,
+	}
+	m2 := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "counter",
+		},
+		Digest: 2,
+		Scope:  samplers.MixedScope,
+	}
+	w.SampleTimeseries(&m)
+	assert.Equal(t, uint64(1), w.totalMTS.Hll.Estimate())
+	w.SampleTimeseries(&m)
+	assert.Equal(t, uint64(1), w.totalMTS.Hll.Estimate())
+	w.SampleTimeseries(&m2)
+	assert.Equal(t, uint64(2), w.totalMTS.Hll.Estimate())
+}
+
+func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
+	w := NewWorker(1, false, nil, logrus.New(), nil)
+
+	m := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "histogram",
+		},
+		Digest: 1,
+		Scope:  samplers.MixedScope,
+	}
+	m2 := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "counter",
+		},
+		Digest: 2,
+		Scope:  samplers.GlobalOnly,
+	}
+	w.SampleTimeseries(&m)
+	w.SampleTimeseries(&m2)
+	assert.Equal(t, uint64(0), w.totalMTS.Hll.Estimate())
+}
+
+func TestGlobalWorkerSampleTimeseries(t *testing.T) {
+	w := NewWorker(1, true, nil, logrus.New(), nil)
+
+	m := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "histogram",
+		},
+		Digest: 1,
+		Scope:  samplers.LocalOnly,
+	}
+	m2 := samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name: "a.b.c",
+			Type: "counter",
+		},
+		Digest: 2,
+		Scope:  samplers.GlobalOnly,
+	}
+	w.SampleTimeseries(&m)
+	w.SampleTimeseries(&m2)
+	assert.Equal(t, uint64(2), w.totalMTS.Hll.Estimate())
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -95,8 +95,8 @@ func TestWorkerGlobal(t *testing.T) {
 func TestWorkerImportSet(t *testing.T) {
 	w := NewWorker(1, true, nil, logrus.New(), nil)
 	testset := samplers.NewSet("a.b.c", nil)
-	testset.Sample("foo", 1.0)
-	testset.Sample("bar", 1.0)
+	testset.Sample("foo")
+	testset.Sample("bar")
 
 	jsonMetric, err := testset.Export()
 	assert.NoError(t, err, "should have exported successfully")
@@ -317,7 +317,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
 		t.Parallel()
 		s := samplers.NewSet("test.set", nil)
-		s.Sample("value", 1.0)
+		s.Sample("value")
 
 		assert.Len(t, exportMetricAndFlush(t, s).sets, 1,
 			"The number of flushed sets is not correct")

--- a/worker_test.go
+++ b/worker_test.go
@@ -448,11 +448,11 @@ func TestLocalWorkerSampleTimeseries(t *testing.T) {
 		Scope:  samplers.MixedScope,
 	}
 	w.SampleTimeseries(&m)
-	assert.Equal(t, uint64(1), w.totalMTS.Hll.Estimate())
+	assert.Equal(t, uint64(1), w.uniqueMTS.Estimate())
 	w.SampleTimeseries(&m)
-	assert.Equal(t, uint64(1), w.totalMTS.Hll.Estimate())
+	assert.Equal(t, uint64(1), w.uniqueMTS.Estimate())
 	w.SampleTimeseries(&m2)
-	assert.Equal(t, uint64(2), w.totalMTS.Hll.Estimate())
+	assert.Equal(t, uint64(2), w.uniqueMTS.Estimate())
 }
 
 func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
@@ -476,7 +476,7 @@ func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
 	}
 	w.SampleTimeseries(&m)
 	w.SampleTimeseries(&m2)
-	assert.Equal(t, uint64(0), w.totalMTS.Hll.Estimate())
+	assert.Equal(t, uint64(0), w.uniqueMTS.Estimate())
 }
 
 func TestGlobalWorkerSampleTimeseries(t *testing.T) {
@@ -500,5 +500,5 @@ func TestGlobalWorkerSampleTimeseries(t *testing.T) {
 	}
 	w.SampleTimeseries(&m)
 	w.SampleTimeseries(&m2)
-	assert.Equal(t, uint64(2), w.totalMTS.Hll.Estimate())
+	assert.Equal(t, uint64(2), w.uniqueMTS.Estimate())
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Emit new metric "flush.unique_timeseries_total", which counts the number of unique timeseries flushed on every flush interval.

#### Benchmarks

`func (w *Worker) Work` on master (b735ec9)
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkPacketChanWork-12    	time="2019-08-01T13:22:19-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:19-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:19-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:19-07:00" level=error msg=Stopping worker=1
 3000000	       408 ns/op
PASS
time="2019-08-01T13:22:20-07:00" level=error msg=Stopping worker=1
ok  	github.com/stripe/veneur	1.900s
```

`func (w *Worker) Work` on this branch
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkPacketChanWork-12    	time="2019-08-01T13:22:52-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:52-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:52-07:00" level=error msg=Stopping worker=1
time="2019-08-01T13:22:53-07:00" level=error msg=Stopping worker=1
 3000000	       559 ns/op
PASS
time="2019-08-01T13:22:55-07:00" level=error msg=Stopping worker=1
ok  	github.com/stripe/veneur	2.456s
```

`func (w *Worker) SampleTimeseries` on this branch
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/veneur
BenchmarkSampleTimeseries-12    	20000000	        68.9 ns/op
PASS
ok  	github.com/stripe/veneur	1.680s
```

r? @stripe/observability