### PR TITLE
Update signalfx_endpoint_api in example config

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -285,7 +285,8 @@ signalfx_api_key: "abc123"
 signalfx_endpoint_base: "https://ingest.signalfx.com"
 
 # Where to send API calls
-signalfx_endpoint_api: "https://api.{REALM}.signalfx.com"
+# Substitute the correct SignalFX realm
+signalfx_endpoint_api: "https://api.REALM.signalfx.com"
 
 # The tag we'll add to each metric that contains the hostname we came from
 signalfx_hostname_tag: "host"


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Including `{` and `}` in the example means that Veneur can't actually start up anymore with the example config file. This fixes that - metrics will be sent to an incorrect realm, which is better than the application failing to start entirely.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 