### PR TITLE
Trigger graceful shutdown via HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * New configuration options `veneur_metrics_scopes` and `veneur_metrics_additional_tags`, which allow configuring veneur such that it aggregates its own metrics globally (rather than reporting a set of internal metrics per instance/container/etc). Thanks, [antifuchs](https://github.com/antifuchs)!
 * New SSF `sample` field: `scope`. This field lets clients tell Veneur what to do with the sample - it corresponds exactly to the `veneurglobalonly` and `veneurlocalonly` tags that metrics can hold. Thanks, [antifuchs](https://github.com/antifuchs)!
 * veneur-prometheus now allows you to specify mTLS configuration for the polling HTTP client. Thanks, [choo-stripe](https://github.com/choo-stripe)!
+* The `http_quit` config option enables the `/quitquitquit` endpoint, which can be used to trigger a graceful shutdown using an HTTP POST request. Thanks, [aditya](https://github.com/chimeracoder)!
 
 ## Updated
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	GrpcAddress                               string    `yaml:"grpc_address"`
 	Hostname                                  string    `yaml:"hostname"`
 	HTTPAddress                               string    `yaml:"http_address"`
+	HTTPQuit                                  bool      `yaml:"http_quit"`
 	IndicatorSpanTimerName                    string    `yaml:"indicator_span_timer_name"`
 	Interval                                  string    `yaml:"interval"`
 	KafkaBroker                               string    `yaml:"kafka_broker"`

--- a/example.yaml
+++ b/example.yaml
@@ -82,6 +82,12 @@ indicator_span_timer_name: "indicator_span.duration_ns"
 # report an additional timer metric for indicator spans.
 objective_span_timer_name: "objective_span.duration_ns"
 
+# If enabled, issuing an unathenticated HTTP POST request to /quitquitquit
+# will gracefully shut down the server.
+# This is intended to be used in environments where network access is already
+# restricted, such as inside containerized deployments.
+http_quit: false
+
 # == METRICS CONFIGURATION ==
 
 # Defaults to the os.Hostname()!

--- a/http.go
+++ b/http.go
@@ -33,6 +33,14 @@ func (s *Server) Handler() http.Handler {
 		w.Write([]byte(VERSION))
 	})
 
+	if s.httpQuit {
+		mux.HandleFuncC(pat.Post(httpQuitEndpoint), func(c context.Context, w http.ResponseWriter, r *http.Request) {
+			log.WithField("endpoint", httpQuitEndpoint).Info("Received shutdown request on HTTP quit endpoint")
+			w.Write([]byte("Beginning graceful shutdown....\n"))
+			s.Shutdown()
+		})
+	}
+
 	// TODO3.0: Maybe remove this endpoint as it is kinda useless now that tracing is always on.
 	mux.HandleFuncC(pat.Get("/healthcheck/tracing"), func(c context.Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))

--- a/server.go
+++ b/server.go
@@ -77,6 +77,8 @@ var tracer = trace.GlobalTracer
 
 const defaultTCPReadTimeout = 10 * time.Minute
 
+const httpQuitEndpoint = "/quitquitquit"
+
 // A Server is the actual veneur instance that will be run.
 type Server struct {
 	Workers              []*Worker
@@ -115,6 +117,7 @@ type Server struct {
 
 	// closed when the server is shutting down gracefully
 	shutdown chan struct{}
+	httpQuit bool
 
 	HistogramPercentiles []float64
 
@@ -709,6 +712,10 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 
 	// closed in Shutdown; Same approach and http.Shutdown
 	ret.shutdown = make(chan struct{})
+	if conf.HTTPQuit {
+		logger.WithField("endpoint", httpQuitEndpoint).Info("Enabling graceful shutdown endpoint (via HTTP POST request)")
+		ret.httpQuit = true
+	}
 
 	// Don't emit keys into logs now that we're done with them.
 	conf.SentryDsn = REDACTED


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Per popular request, an HTTP POST request to `/quitquitquit` will trigger a graceful shutdown of the server. This is useful when running Veneur inside containerized environments and is enabled by a config (default: disabled).

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Tested at the command-line with curl

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 