### PR TITLE
Fixing bug with fetching access tokens

### DIFF
--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -680,8 +680,24 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 			response2,
 		},
 	}
+	expectedParams := []string{offsetQueryParam, limitQueryParam}
+	respCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "GET" {
+			t.Errorf("Expected ‘GET’ request, got ‘%s’", r.Method)
+		}
+		q := r.URL.Query()
 
-	server := httptest.NewServer(m)
+		for _, param := range expectedParams {
+			if q.Get(param) == "" {
+				t.Errorf("Expected %s parameter to be present in the request URL", param)
+			}
+		}
+
+		w.Write([]byte(m.responses[respCount]))
+		respCount += 1
+	}))
 
 	expected := map[string]string{
 		"service":          "accessToken",


### PR DESCRIPTION
Use new request object for every fetch and pass the url params
My apologies for being overly eager and opening upstream PR without testing in our environment first. Will not repeat this again:(

#### Summary
Two issues.
1)Ever accumulating span and trace id's in request headers for every loop iteration that causes the signalfx api call to fail with error code 431 saying header too large when reusing the request object.
This got fixed when I started creating a new request object for each iteration of the loop.

2) The query params offset, limit ,name weren't actually being inserted into url as the `Add` operation earlier wasn't modifying the original url and just returning a copy of modified url. 

#### Motivation
Feature not working as expected after rollout

#### Test plan
We have been running in our staging environment and able to successfully fetch our > 1000 tokens and use different client for each service.
Fixed specs to ensure that url parameters are properly passed.