### PR TITLE
Support SSF span errors in veneur-emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * veneur-prometheus now allows you to specify mTLS configuration for the polling HTTP client. Thanks, [choo-stripe](https://github.com/choo-stripe)!
 * The `http_quit` config option enables the `/quitquitquit` endpoint, which can be used to trigger a graceful shutdown using an HTTP POST request. Thanks, [aditya](https://github.com/chimeracoder)!
 * New config option `count_unique_timeseries` which is used to emit metric `veneur.flush.unique_timeseries_total`, the HyperLogLog cardinality estimate of the unique timeseries in a flush interval. Thanks, [randallm](https://github.com/randallm)!
+* veneur-emit now allows you to mark SSF spans as having errored. Thanks, [randallm](https://github.com/randallm)!
 
 ## Updated
 

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -1,9 +1,10 @@
 `veneur-emit` is a command line utility for emitting metrics to [Veneur](https://github.com/stripe/veneur).
 
 Some common use cases:
-* Instrument shell scripts
-* Instrumenting shell-based tools like init scripts, startup scripts and more
-* Testing
+
+- Instrument shell scripts
+- Instrumenting shell-based tools like init scripts, startup scripts and more
+- Testing
 
 # Usage
 
@@ -47,6 +48,8 @@ Usage of veneur-emit:
         Address of destination (hostport or listening address URL).
   -indicator
         Mark the reported span as an indicator span
+  -error
+        Mark the reported span as having errored
   -mode string
         Mode for veneur-emit. Must be one of: 'metric', 'event', 'sc'. (default "metric")
   -name string
@@ -93,31 +96,31 @@ instance.
 
 Increment a counter in dogstatsd mode:
 
-``` sh
+```sh
 veneur-emit -hostport udp://127.0.0.1:8200 -name that.metric.name -tag hi:there -count 1
 ```
 
 Time a command in dogstatsd mode:
 
-``` sh
+```sh
 veneur-emit -hostport udp://127.0.0.1:8200 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```
 
 Submit a service check in dogstatsd mode (this isn't supported in SSF yet):
 
-``` sh
+```sh
 veneur-emit -hostport udp://127.0.0.1:8200 -sc_name my.service.check -sc_msg "I'm not dead" -sc_status OK
 ```
 
 Submit an event in dogstatsd mode (this isn't supported in SSF yet):
 
-``` sh
+```sh
 veneur-emit -hostport udp://127.0.0.1:8200 -e_text "Something went wrong:\\n\\nTell a lie, it's all good." -e_title "I'm just testing" -e_source_type "demonstration"
 ```
 
 Submit a "set" metric (the count of unique values across a time interval):
 
-``` sh
+```sh
 veneur-emit -hostport udp://127.0.0.1:8200 -name some.set.metric -set customer_a
 ```
 
@@ -129,13 +132,13 @@ checks.
 
 Increment a counter in SSF mode:
 
-``` sh
+```sh
 veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name that.metric.name -tag hi:there -count 1
 ```
 
 Time a command in SSF mode:
 
-``` sh
+```sh
 veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```
 
@@ -143,6 +146,6 @@ Time a command in SSF mode and submit a trace span for the process
 (the `-trace_id` and `-parent_span_id` arguments need to be be set to
 the values from the parent of whatever is calling veneur-emit):
 
-``` sh
+```sh
 veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -span_service 'testing' -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```

--- a/cmd/veneur-emit/README.md
+++ b/cmd/veneur-emit/README.md
@@ -149,3 +149,11 @@ the values from the parent of whatever is calling veneur-emit):
 ```sh
 veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -span_service 'testing' -trace_id 99 -parent_span_id 9999 -name some.command.timer -tag purpose:demonstration -command sleep 30
 ```
+
+When timing a command in SSF mode, if the command returns non-zero
+status code, the error flag will be set on the span, as if `-error`
+were passed in:
+
+```sh
+veneur-emit -ssf -hostport unix:///var/run/veneur/ssf.sock -name some.command.timer -command not_a_real_command
+```

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -495,6 +495,9 @@ func createMetric(span *ssf.SSFSpan, passedFlags map[string]flag.Value, name str
 		span.StartTimestamp = start.UnixNano()
 		span.EndTimestamp = ended.UnixNano()
 		span.Metrics = append(span.Metrics, ssf.Timing(name, ended.Sub(start), time.Millisecond, tags))
+		if status != 0 {
+			span.Error = true
+		}
 	}
 
 	sf, shas := passedFlags["span_starttime"]

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -71,6 +71,7 @@ type Flags struct {
 		EndTime   string
 		Service   string
 		Indicator bool
+		Error     bool
 		Tags      string
 	}
 }
@@ -233,7 +234,7 @@ func Main(args []string) int {
 			WithField("ID", "parent_span_id").
 			Warn("Could not infer ID from environment")
 	}
-	span, err := setupSpan(flagStruct.Span.TraceID, flagStruct.Span.ParentID, flagStruct.Name, flagStruct.Tag, flagStruct.Span.Service, flagStruct.Span.Tags, flagStruct.Span.Indicator)
+	span, err := setupSpan(flagStruct.Span.TraceID, flagStruct.Span.ParentID, flagStruct.Name, flagStruct.Tag, flagStruct.Span.Service, flagStruct.Span.Tags, flagStruct.Span.Indicator, flagStruct.Span.Error)
 	if err != nil {
 		logrus.WithError(err).
 			Error("Couldn't set up the main span")
@@ -338,6 +339,7 @@ func flags(args []string) (Flags, map[string]flag.Value, error) {
 	flagset.StringVar(&flagStruct.Span.EndTime, "span_endtime", "", "Date/time to set for the end of the span. Format is same as -span_starttime.")
 	flagset.StringVar(&flagStruct.Span.Service, "span_service", "veneur-emit", "Service name to associate with the span.")
 	flagset.BoolVar(&flagStruct.Span.Indicator, "indicator", false, "Mark the reported span as an indicator span")
+	flagset.BoolVar(&flagStruct.Span.Error, "error", false, "Mark the reported span as having errored")
 	flagset.StringVar(&flagStruct.Span.Tags, "span_tags", "", "Tag(s) for span, comma separated. Useful for avoiding high cardinality tags. Ex 'user_id:ac0b23,widget_id:284802'")
 
 	err := flagset.Parse(args[1:])
@@ -413,7 +415,7 @@ func inferTraceIDInt(existingID int64, envKey string) (id int64, err error) {
 	return
 }
 
-func setupSpan(traceID, parentID int64, name, tags, service, spanTags string, indicator bool) (*ssf.SSFSpan, error) {
+func setupSpan(traceID, parentID int64, name, tags, service, spanTags string, indicator, errFlag bool) (*ssf.SSFSpan, error) {
 	span := &ssf.SSFSpan{}
 	if traceID != 0 {
 		span.TraceId = traceID
@@ -430,6 +432,7 @@ func setupSpan(traceID, parentID int64, name, tags, service, spanTags string, in
 		}
 		span.Service = service
 		span.Indicator = indicator
+		span.Error = errFlag
 	}
 	return span, nil
 }

--- a/cmd/veneur-emit/main_test.go
+++ b/cmd/veneur-emit/main_test.go
@@ -253,7 +253,7 @@ func TestInferID(t *testing.T) {
 }
 
 func TestSetupSpanWithTracing(t *testing.T) {
-	span, err := setupSpan(1, 2, "oink", "hi:there", "oink-srv", "foo:bar", false)
+	span, err := setupSpan(1, 2, "oink", "hi:there", "oink-srv", "foo:bar", false, true)
 	if assert.NoError(t, err) {
 		assert.NotZero(t, span.Id)
 		assert.Equal(t, int64(1), span.TraceId)
@@ -263,17 +263,19 @@ func TestSetupSpanWithTracing(t *testing.T) {
 		assert.Equal(t, 2, len(span.Tags))
 		assert.Equal(t, span.Tags["hi"], "there")
 		assert.Equal(t, span.Tags["foo"], "bar")
+		assert.Equal(t, span.Error, true)
 	}
 }
 
 func TestSetupSpanWithoutTracing(t *testing.T) {
-	span, err := setupSpan(0, 0, "oink", "hi:there", "oink-srv", "", false)
+	span, err := setupSpan(0, 0, "oink", "hi:there", "oink-srv", "", false, false)
 	if assert.NoError(t, err) {
 		assert.Zero(t, span.Id)
 		assert.Zero(t, span.TraceId)
 		assert.Zero(t, span.ParentId)
 		assert.Equal(t, "", span.Name)
 		assert.Equal(t, 0, len(span.Tags))
+		assert.Equal(t, span.Indicator, false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
- adds `-error` flag to `veneur-emit`
- changes `veneur-emit -command foo` to enable error flag if `foo` exits with non-zero status

#### Motivation
<!-- Why are you making this change? -->
Feature parity between `veneur-emit` and SSF