### PR TITLE
[veneur-prometheus] refactor to pull apart responsibilities.

### DIFF
--- a/cmd/veneur-prometheus/config.go
+++ b/cmd/veneur-prometheus/config.go
@@ -8,31 +8,21 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 )
 
-type config struct {
+type prometheusConfig struct {
 	metricsHost    string
-	statsHost      string
 	httpClient     *http.Client
-	statsClient    statsC
 	ignoredLabels  []*regexp.Regexp
 	ignoredMetrics []*regexp.Regexp
 }
 
-func configFromArgs() config {
-	statsClient, _ := statsd.New(*statsHost)
+func prometheusConfigFromArguments() prometheusConfig {
 
-	if *prefix != "" {
-		statsClient.Namespace = *prefix
-	}
-
-	return config{
+	return prometheusConfig{
 		metricsHost:    *metricsHost,
-		statsHost:      *statsHost,
 		httpClient:     newHTTPClient(*cert, *key, *caCert),
-		statsClient:    statsClient,
 		ignoredLabels:  getIgnoredFromArg(*ignoredLabelsStr),
 		ignoredMetrics: getIgnoredFromArg(*ignoredMetricsStr),
 	}

--- a/cmd/veneur-prometheus/config_test.go
+++ b/cmd/veneur-prometheus/config_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHTTPClientHTTP(t *testing.T) {
+	client := newHTTPClient("", "", "")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	res, err := client.Get(ts.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+}
+
+func TestGetHTTPClientHTTPS(t *testing.T) {
+	client := newHTTPClient("./testdata/client.pem", "./testdata/client.key", "./testdata/root.pem")
+
+	caCertPool := x509.NewCertPool()
+	caCert, err := ioutil.ReadFile("./testdata/root.pem")
+	assert.NoError(t, err)
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	serverCert, err := tls.LoadX509KeyPair("./testdata/server.pem", "./testdata/server.key")
+	assert.NoError(t, err)
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	ts.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caCertPool,
+	}
+	ts.StartTLS()
+	defer ts.Close()
+
+	res, err := client.Get(ts.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+}

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -2,14 +2,9 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"io"
-	"math"
-	"regexp"
 	"time"
 
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,138 +35,44 @@ func main() {
 		logrus.WithError(err).Fatalf("Failed to parse interval '%s'", *interval)
 	}
 
-	cfg := configFromArgs()
+	statsClient, _ := statsd.New(*statsHost)
+
+	if *prefix != "" {
+		statsClient.Namespace = *prefix
+	}
+
+	cfg := prometheusConfigFromArguments()
 	ticker := time.NewTicker(i)
 	for _ = range ticker.C {
-		collect(cfg)
+		inMemory := collect(cfg)
+		sendToStatsd(statsClient, *statsHost, inMemory)
 	}
 }
 
-type statsC interface {
-	Count(string, int64, []string, float64) error
-	Gauge(string, float64, []string, float64) error
-}
-
-func collect(cfg config) {
+func collect(cfg prometheusConfig) <-chan []inMemoryStat {
 	logrus.WithFields(logrus.Fields{
-		"stats_host":      cfg.statsHost,
 		"metrics_host":    cfg.metricsHost,
 		"ignored_labels":  cfg.ignoredLabels,
 		"ignored_metrics": cfg.ignoredMetrics,
-	}).Debug("Beginning collection")
+	}).Debug("beginning collection")
 
-	resp, err := cfg.httpClient.Get(cfg.metricsHost)
-	if err != nil {
-		logrus.
-			WithError(err).
-			WithField("metrics_host", cfg.metricsHost).
-			Warn(fmt.Sprintf("Failed to collect metrics"))
-		return
-	}
-
-	d := expfmt.NewDecoder(resp.Body, expfmt.FmtText)
-	var mf dto.MetricFamily
-	for {
-		err := d.Decode(&mf)
-		if err == io.EOF {
-			// We've hit the end, break out!
-			break
-		} else if err != nil {
-			cfg.statsClient.Count("veneur.prometheus.decode_errors_total", 1, nil, 1.0)
-			logrus.WithError(err).Warn("Failed to decode a metric")
-			break
-		}
-
-		if !shouldExportMetric(mf, cfg.ignoredMetrics) {
-			continue
-		}
-
-		var metricCount int64
-		switch mf.GetType() {
-		case dto.MetricType_COUNTER:
-			for _, counter := range mf.GetMetric() {
-				tags := getTags(counter.GetLabel(), cfg.ignoredLabels)
-				cfg.statsClient.Count(mf.GetName(), int64(counter.GetCounter().GetValue()), tags, 1.0)
-				metricCount++
-			}
-		case dto.MetricType_GAUGE:
-			for _, gauge := range mf.GetMetric() {
-				tags := getTags(gauge.GetLabel(), cfg.ignoredLabels)
-				cfg.statsClient.Gauge(mf.GetName(), float64(gauge.GetGauge().GetValue()), tags, 1.0)
-				metricCount++
-			}
-		case dto.MetricType_SUMMARY:
-			for _, summary := range mf.GetMetric() {
-				tags := getTags(summary.GetLabel(), cfg.ignoredLabels)
-				name := mf.GetName()
-				data := summary.GetSummary()
-				cfg.statsClient.Gauge(fmt.Sprintf("%s.sum", name), data.GetSampleSum(), tags, 1.0)
-				cfg.statsClient.Count(fmt.Sprintf("%s.count", name), int64(data.GetSampleCount()), tags, 1.0)
-				metricCount += 2 // One for sum, one for count, one for each percentile bucket
-
-				for _, quantile := range data.GetQuantile() {
-					v := quantile.GetValue()
-					if !math.IsNaN(v) {
-						cfg.statsClient.Gauge(fmt.Sprintf("%s.%dpercentile", name, int(quantile.GetQuantile()*100)), v, tags, 1.0)
-						metricCount++
-					}
-				}
-			}
-		case dto.MetricType_HISTOGRAM:
-			for _, histo := range mf.GetMetric() {
-				tags := getTags(histo.GetLabel(), cfg.ignoredLabels)
-				name := mf.GetName()
-				data := histo.GetHistogram()
-				cfg.statsClient.Gauge(fmt.Sprintf("%s.sum", name), data.GetSampleSum(), tags, 1.0)
-				cfg.statsClient.Count(fmt.Sprintf("%s.count", name), int64(data.GetSampleCount()), tags, 1.0)
-				metricCount += 2 // One for sum, one for count, one for each histo bucket
-
-				for _, bucket := range data.GetBucket() {
-					b := bucket.GetUpperBound()
-					if !math.IsNaN(b) {
-						cfg.statsClient.Count(fmt.Sprintf("%s.le%f", name, b), int64(bucket.GetCumulativeCount()), tags, 1.0)
-						metricCount++
-					}
-				}
-			}
-		default:
-			cfg.statsClient.Count("veneur.prometheus.unknown_metric_type_total", 1, nil, 1.0)
-		}
-		cfg.statsClient.Count("veneur.prometheus.metrics_flushed_total", metricCount, nil, 1.0)
-	}
+	prometheus := queryPrometheus(cfg.httpClient, cfg.metricsHost, cfg.ignoredMetrics)
+	return translatePrometheus(cfg.ignoredLabels, prometheus)
 }
 
-func getTags(labels []*dto.LabelPair, ignoredLabels []*regexp.Regexp) []string {
-	var tags []string
+func sendToStatsd(client *statsd.Client, host string, stats <-chan []inMemoryStat) {
+	logrus.WithField("stats_host", host).Debug("beginning stats send")
 
-	for _, pair := range labels {
-		labelName := pair.GetName()
-		labelValue := pair.GetValue()
-		include := true
+	for batch := range stats {
+		for _, s := range batch {
+			err := s.Send(client)
 
-		for _, ignoredLabel := range ignoredLabels {
-			if ignoredLabel.MatchString(labelName) {
-				include = false
-				break
+			if err != nil {
+				logrus.
+					WithError(err).
+					WithField("stats_host", host).
+					Warn("failed sending stats")
 			}
 		}
-
-		if include {
-			tags = append(tags, fmt.Sprintf("%s:%s", labelName, labelValue))
-		}
 	}
-
-	return tags
-}
-
-func shouldExportMetric(mf dto.MetricFamily, ignoredMetrics []*regexp.Regexp) bool {
-	for _, ignoredMetric := range ignoredMetrics {
-		metricName := mf.GetName()
-
-		if ignoredMetric.MatchString(metricName) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/cmd/veneur-prometheus/main_test.go
+++ b/cmd/veneur-prometheus/main_test.go
@@ -1,17 +1,10 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"regexp"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,8 +17,7 @@ func TestCollectGetsAllMetricsItShould(t *testing.T) {
 
 	counterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "counter_vec",
-		Help: "A typical counter vec with labels that will be added and some that won't.",
-	},
+		Help: "A typical counter vec with labels that will be added and some that won't."},
 		[]string{"a", "b", "ignore_me"},
 	)
 
@@ -125,85 +117,78 @@ func TestCollectGetsAllMetricsItShould(t *testing.T) {
 	histogramVec.WithLabelValues("G1", "H1", "Ignored4").Observe(45)
 	histogramIgnored.Observe(45)
 
-	statsC := &memoryStatsC{}
-
-	cfg := config{
+	cfg := prometheusConfig{
 		metricsHost:    ts.URL,
-		statsHost:      "unit-test-no-host",
 		httpClient:     newHTTPClient("", "", ""),
-		statsClient:    statsC,
 		ignoredLabels:  getIgnoredFromArg("ignore"),
 		ignoredMetrics: getIgnoredFromArg("(.*)_ignore,promhttp_(.*)"),
 	}
 
-	collect(cfg)
+	counts, gauges := splitStats(collect(cfg))
 
-	assert.True(t, statsC.Contains(stat{Name: "counter"}))
-	assert.True(t, statsC.Contains(stat{Name: "counter_vec", Tags: []string{"a:A1", "b:B1"}}))
-	assert.False(t, statsC.Contains(stat{Name: "counter_ignored"}))
+	assert.True(t, countReceived(counts, "counter"))
+	assert.True(t, countReceived(counts, "counter_vec", "a:A1", "b:B1"))
+	assert.False(t, countReceived(counts, "counter_ignored"))
 
-	assert.True(t, statsC.Contains(stat{Name: "gauge"}))
-	assert.True(t, statsC.Contains(stat{Name: "gauge_vec", Tags: []string{"c:C1", "d:D1"}}))
-	assert.False(t, statsC.Contains(stat{Name: "gauge_ignored"}))
+	assert.True(t, gaugeReceived(gauges, "gauge"))
+	assert.True(t, gaugeReceived(gauges, "gauge_vec", "c:C1", "d:D1"))
+	assert.False(t, gaugeReceived(gauges, "gauge_ignored"))
 
-	assert.True(t, statsC.Contains(stat{Name: "summary.sum"}))
-	assert.True(t, statsC.Contains(stat{Name: "summary.count"}))
-	assert.True(t, statsC.Contains(stat{Name: "summary.50percentile"}))
-	assert.True(t, statsC.Contains(stat{Name: "summary.90percentile"}))
-	assert.True(t, statsC.Contains(stat{Name: "summary.99percentile"}))
+	assert.True(t, gaugeReceived(gauges, "summary.sum"))
+	assert.True(t, countReceived(counts, "summary.count"))
+	assert.True(t, gaugeReceived(gauges, "summary.50percentile"))
+	assert.True(t, gaugeReceived(gauges, "summary.90percentile"))
+	assert.True(t, gaugeReceived(gauges, "summary.99percentile"))
 
-	assert.True(t, statsC.Contains(stat{Name: "summary_vec.sum", Tags: []string{"e:E1", "f:F1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "summary_vec.count", Tags: []string{"e:E1", "f:F1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "summary_vec.50percentile", Tags: []string{"e:E1", "f:F1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "summary_vec.90percentile", Tags: []string{"e:E1", "f:F1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "summary_vec.99percentile", Tags: []string{"e:E1", "f:F1"}}))
+	assert.True(t, gaugeReceived(gauges, "summary_vec.sum", "e:E1", "f:F1"))
+	assert.True(t, countReceived(counts, "summary_vec.count", "e:E1", "f:F1"))
+	assert.True(t, gaugeReceived(gauges, "summary_vec.50percentile", "e:E1", "f:F1"))
+	assert.True(t, gaugeReceived(gauges, "summary_vec.90percentile", "e:E1", "f:F1"))
+	assert.True(t, gaugeReceived(gauges, "summary_vec.99percentile", "e:E1", "f:F1"))
 
-	assert.False(t, statsC.Contains(stat{Name: "summary_ignored.sum"}))
+	assert.False(t, gaugeReceived(gauges, "summary_ignored.sum"))
 
-	assert.True(t, statsC.Contains(stat{Name: "histogram.sum"}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram.count"}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram.le1.000000"}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram.le2.000000"}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram.le5.000000"}))
+	assert.True(t, gaugeReceived(gauges, "histogram.sum"))
+	assert.True(t, countReceived(counts, "histogram.count"))
+	assert.True(t, countReceived(counts, "histogram.le1.000000"))
+	assert.True(t, countReceived(counts, "histogram.le2.000000"))
+	assert.True(t, countReceived(counts, "histogram.le5.000000"))
 
-	assert.True(t, statsC.Contains(stat{Name: "histogram_vec.sum", Tags: []string{"g:G1", "h:H1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram_vec.count", Tags: []string{"g:G1", "h:H1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram_vec.le1.000000", Tags: []string{"g:G1", "h:H1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram_vec.le2.000000", Tags: []string{"g:G1", "h:H1"}}))
-	assert.True(t, statsC.Contains(stat{Name: "histogram_vec.le5.000000", Tags: []string{"g:G1", "h:H1"}}))
+	assert.True(t, gaugeReceived(gauges, "histogram_vec.sum", "g:G1", "h:H1"))
+	assert.True(t, countReceived(counts, "histogram_vec.count", "g:G1", "h:H1"))
+	assert.True(t, countReceived(counts, "histogram_vec.le1.000000", "g:G1", "h:H1"))
+	assert.True(t, countReceived(counts, "histogram_vec.le2.000000", "g:G1", "h:H1"))
+	assert.True(t, countReceived(counts, "histogram_vec.le5.000000", "g:G1", "h:H1"))
 
-	assert.False(t, statsC.Contains(stat{Name: "histogram_ignored.sum"}))
+	assert.False(t, gaugeReceived(gauges, "histogram_ignored.sum"))
 
-	assert.True(t, statsC.Contains(stat{Name: "veneur.prometheus.metrics_flushed_total"}))
+	assert.True(t, countReceived(counts, "veneur.prometheus.metrics_flushed_total"))
 }
 
-type memoryStatsC struct {
-	stats []interface{}
-}
+func splitStats(stats <-chan []inMemoryStat) ([]count, []gauge) {
+	var c []count
+	var g []gauge
+	for batch := range stats {
+		for _, s := range batch {
+			switch i := s.(type) {
+			case count:
+				c = append(c, i)
+			case gauge:
+				g = append(g, i)
 
-func (m *memoryStatsC) Count(name string, value int64, tags []string, scale float64) error {
-	m.stats = append(m.stats, count{stat{name, tags}, value})
-	return nil
-}
-
-func (m *memoryStatsC) Gauge(name string, value float64, tags []string, scale float64) error {
-	m.stats = append(m.stats, gauge{stat{name, tags}, value})
-	return nil
-}
-
-func (m *memoryStatsC) Contains(s stat) bool {
-	for _, t := range m.stats {
-		var o stat
-		switch v := t.(type) {
-		case count:
-			o = v.stat
-		case gauge:
-			o = v.stat
-		default:
-			panic(fmt.Sprintf("unknown stat type %T", v))
+			default:
+				panic(fmt.Sprintf("unknown inmemory stat type: %T", s))
+			}
 		}
+	}
 
-		if s.Same(o) {
+	return c, g
+}
+
+func gaugeReceived(gauges []gauge, name string, tags ...string) bool {
+	b := statID{name, tags}
+	for _, a := range gauges {
+		if same(a.statID, b) {
 			return true
 		}
 	}
@@ -211,98 +196,13 @@ func (m *memoryStatsC) Contains(s stat) bool {
 	return false
 }
 
-func TestGetTags(t *testing.T) {
-	label1Name := "label1Name"
-	label1Value := "label1Value"
-	label1Pair := &dto.LabelPair{
-		Name:  &label1Name,
-		Value: &label1Value,
+func countReceived(counts []count, name string, tags ...string) bool {
+	b := statID{name, tags}
+	for _, a := range counts {
+		if same(a.statID, b) {
+			return true
+		}
 	}
 
-	label2Name := "label2Name"
-	label2Value := "label2Value"
-	label2Pair := &dto.LabelPair{
-		Name:  &label2Name,
-		Value: &label2Value,
-	}
-
-	label3Name := "label3Name"
-	label3Value := "label3Value"
-	label3Pair := &dto.LabelPair{
-		Name:  &label3Name,
-		Value: &label3Value,
-	}
-
-	labels := []*dto.LabelPair{
-		label1Pair, label2Pair, label3Pair,
-	}
-
-	ignoredLabels := []*regexp.Regexp{
-		regexp.MustCompile(".*5.*"),
-		regexp.MustCompile(".*abel1.*"),
-	}
-
-	tags := getTags(labels, ignoredLabels)
-	expectedTags := []string{
-		"label2Name:label2Value",
-		"label3Name:label3Value",
-	}
-
-	assert.Equal(t, expectedTags, tags)
-}
-
-func TestShouldExportMetric(t *testing.T) {
-	metric1Name := "metric1Name"
-
-	mf := dto.MetricFamily{
-		Name: &metric1Name,
-	}
-
-	ignoredMetrics1 := []*regexp.Regexp{
-		regexp.MustCompile(".*0.*"),
-		regexp.MustCompile(".*1.*"),
-	}
-	ignoredMetrics2 := []*regexp.Regexp{regexp.MustCompile(".*2.*")}
-
-	assert.False(t, shouldExportMetric(mf, ignoredMetrics1))
-	assert.True(t, shouldExportMetric(mf, ignoredMetrics2))
-}
-
-func TestGetHTTPClientHTTP(t *testing.T) {
-	client := newHTTPClient("", "", "")
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	res, err := client.Get(ts.URL)
-	assert.NoError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusOK)
-}
-
-func TestGetHTTPClientHTTPS(t *testing.T) {
-	client := newHTTPClient("./testdata/client.pem", "./testdata/client.key", "./testdata/root.pem")
-
-	caCertPool := x509.NewCertPool()
-	caCert, err := ioutil.ReadFile("./testdata/root.pem")
-	assert.NoError(t, err)
-	caCertPool.AppendCertsFromPEM(caCert)
-
-	serverCert, err := tls.LoadX509KeyPair("./testdata/server.pem", "./testdata/server.key")
-	assert.NoError(t, err)
-
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	ts.TLS = &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		ClientCAs:    caCertPool,
-	}
-	ts.StartTLS()
-	defer ts.Close()
-
-	res, err := client.Get(ts.URL)
-	assert.NoError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusOK)
+	return false
 }

--- a/cmd/veneur-prometheus/prometheus.go
+++ b/cmd/veneur-prometheus/prometheus.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"regexp"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/sirupsen/logrus"
+)
+
+type prometheusResults struct {
+	mf          dto.MetricFamily
+	decodeError error
+	clientError error
+}
+
+func queryPrometheus(httpClient *http.Client, host string, ignoredMetrics []*regexp.Regexp) <-chan prometheusResults {
+	metrics := make(chan prometheusResults)
+
+	go func() {
+		defer close(metrics)
+
+		resp, err := httpClient.Get(host)
+		if err != nil {
+			metrics <- prometheusResults{clientError: err}
+			logrus.
+				WithError(err).
+				WithField("prometheus_host", host).
+				Warn("unable to connect with prometheus host")
+
+			return
+		}
+
+		d := expfmt.NewDecoder(resp.Body, expfmt.FmtText)
+		for {
+			var mf dto.MetricFamily
+			err := d.Decode(&mf)
+			if err == io.EOF {
+				// We've hit the end, break out!
+				return
+			} else if err != nil {
+				metrics <- prometheusResults{decodeError: err}
+				logrus.
+					WithError(err).
+					WithField("prometheus_host", host).
+					Warn("decode error")
+				return
+			}
+
+			if !shouldExportMetric(mf, ignoredMetrics) {
+				continue
+			}
+
+			metrics <- prometheusResults{mf: mf}
+		}
+	}()
+
+	return metrics
+}
+
+func shouldExportMetric(mf dto.MetricFamily, ignoredMetrics []*regexp.Regexp) bool {
+	for _, ignoredMetric := range ignoredMetrics {
+		metricName := mf.GetName()
+
+		if ignoredMetric.MatchString(metricName) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/veneur-prometheus/prometheus_test.go
+++ b/cmd/veneur-prometheus/prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,6 +15,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestShouldExportMetric(t *testing.T) {
+	metric1Name := "metric1Name"
+
+	mf := dto.MetricFamily{
+		Name: &metric1Name,
+	}
+
+	ignoredMetrics1 := []*regexp.Regexp{
+		regexp.MustCompile(".*0.*"),
+		regexp.MustCompile(".*1.*"),
+	}
+	ignoredMetrics2 := []*regexp.Regexp{regexp.MustCompile(".*2.*")}
+
+	assert.False(t, shouldExportMetric(mf, ignoredMetrics1))
+	assert.True(t, shouldExportMetric(mf, ignoredMetrics2))
+}
 
 func TestPrometheusCounterIsEverIncreasing(t *testing.T) {
 

--- a/cmd/veneur-prometheus/translate.go
+++ b/cmd/veneur-prometheus/translate.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func translatePrometheus(ignoredLabels []*regexp.Regexp, prometheus <-chan prometheusResults) <-chan []inMemoryStat {
+	inmemory := make(chan []inMemoryStat)
+	go sendTranslated(prometheus, ignoredLabels, inmemory)
+
+	return inmemory
+}
+
+func sendTranslated(prometheus <-chan prometheusResults, translate translator, s sendor) {
+
+	count := int64(0)
+	unknown := int64(0)
+
+	for result := range prometheus {
+		var stats []inMemoryStat
+
+		if result.clientError != nil {
+			count++
+			s.send(newCount("veneur.prometheus.connect_errors_total", nil, 1))
+			continue
+		}
+
+		if result.decodeError != nil {
+			count++
+			s.send(newCount("veneur.prometheus.decode_errors_total", nil, 1))
+			continue
+		}
+
+		mf := result.mf
+		switch mf.GetType() {
+		case dto.MetricType_COUNTER:
+			stats = translate.PrometheusCounter(mf)
+		case dto.MetricType_GAUGE:
+			stats = translate.PrometheusGauge(mf)
+		case dto.MetricType_SUMMARY:
+			stats = translate.PrometheusSummary(mf)
+		case dto.MetricType_HISTOGRAM:
+			stats = translate.PrometheusHistogram(mf)
+		default:
+			unknown++
+		}
+
+		count += int64(len(stats))
+		if stats != nil {
+			s.send(stats...)
+		}
+	}
+
+	s.send(
+		newCount("veneur.prometheus.unknown_metric_type_total", nil, unknown),
+		newCount("veneur.prometheus.metrics_flushed_total", nil, count+2),
+	)
+
+	s.Close()
+}
+
+type sendor chan<- []inMemoryStat
+
+func (s sendor) send(stats ...inMemoryStat) {
+	s <- stats
+}
+
+func (s sendor) Close() {
+	close(s)
+}
+
+type translator []*regexp.Regexp
+
+func (t translator) PrometheusCounter(mf dto.MetricFamily) []inMemoryStat {
+	var stats []inMemoryStat
+	for _, counter := range mf.GetMetric() {
+		tags := t.Tags(counter.GetLabel())
+		stats = append(stats, newCount(mf.GetName(), tags, int64(counter.GetCounter().GetValue())))
+	}
+	return stats
+}
+
+func (t translator) PrometheusGauge(mf dto.MetricFamily) []inMemoryStat {
+	var stats []inMemoryStat
+	for _, gauge := range mf.GetMetric() {
+		tags := t.Tags(gauge.GetLabel())
+		stats = append(stats, newGauge(mf.GetName(), tags, float64(gauge.GetGauge().GetValue())))
+	}
+	return stats
+}
+
+func (t translator) PrometheusSummary(mf dto.MetricFamily) []inMemoryStat {
+	var stats []inMemoryStat
+	for _, summary := range mf.GetMetric() {
+		tags := t.Tags(summary.GetLabel())
+		name := mf.GetName()
+		data := summary.GetSummary()
+
+		stats = append(stats, newGauge(fmt.Sprintf("%s.sum", name), tags, data.GetSampleSum()))
+		stats = append(stats, newCount(fmt.Sprintf("%s.count", name), tags, int64(data.GetSampleCount())))
+
+		for _, quantile := range data.GetQuantile() {
+			v := quantile.GetValue()
+			if !math.IsNaN(v) {
+				stats = append(stats,
+					newGauge(
+						fmt.Sprintf("%s.%dpercentile", name, int(quantile.GetQuantile()*100)),
+						tags,
+						v))
+			}
+		}
+	}
+
+	return stats
+}
+
+func (t translator) PrometheusHistogram(mf dto.MetricFamily) []inMemoryStat {
+	var stats []inMemoryStat
+	for _, histo := range mf.GetMetric() {
+		tags := t.Tags(histo.GetLabel())
+		name := mf.GetName()
+		data := histo.GetHistogram()
+
+		stats = append(stats, newGauge(fmt.Sprintf("%s.sum", name), tags, data.GetSampleSum()))
+		stats = append(stats, newCount(fmt.Sprintf("%s.count", name), tags, int64(data.GetSampleCount())))
+
+		for _, bucket := range data.GetBucket() {
+			b := bucket.GetUpperBound()
+			if !math.IsNaN(b) {
+				stats = append(stats,
+					newCount(
+						fmt.Sprintf("%s.le%f", name, b),
+						tags,
+						int64(bucket.GetCumulativeCount())))
+			}
+		}
+	}
+
+	return stats
+}
+
+func (t translator) Tags(labels []*dto.LabelPair) []string {
+	var tags []string
+
+	for _, pair := range labels {
+		labelName := pair.GetName()
+		labelValue := pair.GetValue()
+		include := true
+
+		for _, ignoredLabel := range t {
+			if ignoredLabel.MatchString(labelName) {
+				include = false
+				break
+			}
+		}
+
+		if include {
+			tags = append(tags, fmt.Sprintf("%s:%s", labelName, labelValue))
+		}
+	}
+
+	return tags
+}

--- a/cmd/veneur-prometheus/translate_test.go
+++ b/cmd/veneur-prometheus/translate_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateTags(t *testing.T) {
+	label1Name := "label1Name"
+	label1Value := "label1Value"
+	label1Pair := &dto.LabelPair{
+		Name:  &label1Name,
+		Value: &label1Value,
+	}
+
+	label2Name := "label2Name"
+	label2Value := "label2Value"
+	label2Pair := &dto.LabelPair{
+		Name:  &label2Name,
+		Value: &label2Value,
+	}
+
+	label3Name := "label3Name"
+	label3Value := "label3Value"
+	label3Pair := &dto.LabelPair{
+		Name:  &label3Name,
+		Value: &label3Value,
+	}
+
+	labels := []*dto.LabelPair{
+		label1Pair, label2Pair, label3Pair,
+	}
+
+	ignoredLabels := []*regexp.Regexp{
+		regexp.MustCompile(".*5.*"),
+		regexp.MustCompile(".*abel1.*"),
+	}
+
+	tags := translator(ignoredLabels).Tags(labels)
+	expectedTags := []string{
+		"label2Name:label2Value",
+		"label3Name:label3Value",
+	}
+
+	assert.Equal(t, expectedTags, tags)
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
This is the second of 3 PR to fix #753.  It builds on #754 and should be merged afterwards.  This PR does not change any behavior or data coming out of the command but it is a more major refactor.  

The refactor here is to pull apart the responsibilities of the various components in veneur-prometheus.  This now has 3 parts a) querying prometheus b) turning the prometheus stats into an inmemory representation that can be translated to statsd and c) sending those stats to statsd.

Note that this uses concurrency for this not because concurrent access is particularly necessary but the channel abstraction makes for a good api between the various components.

#### Motivation
This will enable us to more easily write the more complicated diff code that will be necessary to fix the actual bug in the next PR.

#### Test plan
This relies on the tests introduced in #754 

#### Rollout/monitoring/revert plan
This does not change any behavior or data and can be reverted trivially.