### PR TITLE
[veneur-prometheus] Report incremental counters from Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 * Updated the vendored version of github.com/gogo/protobuf which fixes Gopkg.toml conflicts for users of veneur. Thanks, [dtbartle](http://github.com/dtbartle)!
 
 ## Bugfixes
-* veneur-prometheus no longer sends the cumulative count that is reported from a Prometheus endpoint.  Instead it diffs the numbers to get difference based statistics that a statsd protocol expects. **This can cause dramatic differences in the statistics reported by veneur-prometheus.**  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
+* veneur-prometheus now reports incremental counters instead of cumulative counters. This may cause dramatic differences in the statistics reported by veneur-prometheus.  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
+
+## Bugfixes
 * Veneur listening on UDS for statsd metrics will respect the `read_buffer_size_bytes` config. Thanks, [prudhvi](https://github.com/prudhvi)!
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Updated the vendored version of github.com/gogo/protobuf which fixes Gopkg.toml conflicts for users of veneur. Thanks, [dtbartle](http://github.com/dtbartle)!
 
 ## Bugfixes
+* veneur-prometheus no longer sends the cumulative count that is reported from a Prometheus endpoint.  Instead it diffs the numbers to get difference based statistics that a statsd protocol expects. **This can cause dramatic differences in the statistics reported by veneur-prometheus.**  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
 * Veneur listening on UDS for statsd metrics will respect the `read_buffer_size_bytes` config. Thanks, [prudhvi](https://github.com/prudhvi)!
 * The splunk HEC span sink didn't correctly spawn the number of submission workers configured with `splunk_hec_submission_workers`, only spawning one. Now it spawns the number configured. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink now correctly constructs ingestion endpoint URLs when given URLs that end in slashes. Thanks, [antifuchs](https://github.com/antifuchs)!

--- a/cmd/veneur-prometheus/README.md
+++ b/cmd/veneur-prometheus/README.md
@@ -6,6 +6,28 @@ and passing those metrics along to an instance of Veneur.
 
 At present these metrics are emitting as DogStatsD style metrics. We will add SSF at a later date.
 
+## Prometheus Counters vs Statsd Counters
+
+Prometheus counters continue to increase over the life time of the monitored service.  Conversely, statsd counters are only the counts of events that have happened since the last time they were reported.  Therefore it is incorrect to naively read from a Prometheus endpoint and just pass the values returned for counters to statsd.  Instead you need to send the difference between the last observation point and the current one to get an accurate mapping.
+
+This leads to the following conditions:
+- we've made no observations to cache and compare against.  We won't report any metrics to statsd until a second observation allows us to diff.
+- we have some observations in our cache, but a particular metric does not exist there (common for vector types to appear over time). In this case, we can implicitly compare that metric to 0.
+- our cache version is smaller than the Prometheus metric count.  This is the normal case and indicates that there have ben events on that metric.  We report the difference.
+- our cache version is bigger than the Prometheus metric count.  This indicates a restart on the monitored service.  The best we can do is report the events since that restart.
+
+This leads to the following cases where we will miss metrics:
+- `veneur-prometheus` is restarted.  All counts while `veneur-prometheus` is down, plus those that happen between the first and second observation, are missed.
+- the monitored service is restarted.  Any events that happen after the `veneur-prometheus` observation and before the monitored service restart are missed.
+
+### Prometheus Histograms are (mostly) Counters
+
+Prometheus implements its histograms as additive counters.  That is if you have a set of buckets like 1 second, 2 seconds, 5 seconds, when an event that is 1.8 seconds long is observed the count on the 2 second bucket, the 5 second bucket and the infinity bucket are incremented.  These buckets are just Prometheus counters so all of the cases above apply to each of them.  Further the histogram keeps a count as well which is impacted.
+
+Our rules above get particularly problematic when dealing with histogram metrics where the buckets have changed on a monitored service restart.  That is if it previously had 1, 2, 5 second buckets and after a restart has 1, 2, 6 second buckets.  The end result is that our translation of Prometheus histograms around monitored restarts are likely not ever going to provide extremely accurate information.
+
+*Note* Prometheus Summaries also have a count sub-component that is a counter and impacted by the above.  The majority of information in Summaries are gauges though.
+
 # Usage
 
 ```

--- a/cmd/veneur-prometheus/cache.go
+++ b/cmd/veneur-prometheus/cache.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type countCache struct {
+	last map[string]prometheusCount
+	next map[string]prometheusCount
+}
+
+//GetAndSwap will return the previous count for this metric and add the passed in one for future use
+//bool indicates if Get was successful
+func (c *countCache) GetAndSwap(n prometheusCount) (prev prometheusCount, ok bool) {
+	if c == nil {
+		c = &countCache{}
+	}
+
+	if c.next == nil {
+		c.next = make(map[string]prometheusCount)
+	}
+
+	key := cacheKey(n)
+	c.next[key] = n
+
+	if c.FirstObservation() {
+		return
+	}
+
+	prev, ok = c.last[key]
+	return
+}
+
+func (c *countCache) FirstObservation() bool {
+	return c == nil || c.last == nil
+}
+
+//indicates that a single observations sweep is done.
+//this is important for determining if 'we' are new or if 'they' are
+func (c *countCache) Done() {
+	if c == nil {
+		return
+	}
+
+	//double map approach allows us to distinquish between no observations
+	//and new metric and keep memory from growing in the face of metrics
+	//coming and going so seems worth the complication
+	c.last = c.next
+	c.next = make(map[string]prometheusCount)
+}
+
+func cacheKey(n prometheusCount) string {
+	return fmt.Sprintf("%s-%s", n.Name, strings.Join(n.Tags, "-"))
+}

--- a/cmd/veneur-prometheus/cache_test.go
+++ b/cmd/veneur-prometheus/cache_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGaugesDontCacheTranslate(t *testing.T) {
+	in := newGauge("foo", nil, 10.2)
+	out := in.Translate(new(countCache))
+	diffed, is := out.(gauge)
+	require.True(t, is)
+	assert.True(t, same(in.statID, diffed.statID))
+	assert.Equal(t, in.Value, diffed.Value)
+}
+
+func TestCountCacheTranslate(t *testing.T) {
+	name := "foo"
+	var tags []string
+
+	base := newPrometheusCount(name, tags, 10)
+	less := newPrometheusCount(name, tags, 8)
+	more := newPrometheusCount(name, tags, 12)
+
+	zero := newStatsdCount(name, tags, 0)
+	equal := newStatsdCount(name, tags, 10)
+	diff := newStatsdCount(name, tags, 2)
+
+	key := cacheKey(base)
+
+	for _, difftest := range []struct {
+		name     string
+		cache    *countCache
+		expected statsdCount
+	}{
+		{"no-previous", new(countCache), zero},
+		{"less", newCache(map[string]prometheusCount{key: less}), diff},
+		{"same", newCache(map[string]prometheusCount{key: base}), zero},
+		{"more", newCache(map[string]prometheusCount{key: more}), equal},
+	} {
+		t.Run(difftest.name, func(t *testing.T) {
+			out := base.Translate(difftest.cache)
+			c, is := out.(statsdCount)
+			require.True(t, is)
+			assert.True(t, same(difftest.expected.statID, c.statID))
+			assert.Equal(t, difftest.expected.Value, c.Value)
+
+			cached, ok := difftest.cache.next[key]
+			assert.True(t, ok)
+			assert.Equal(t, base.Value, cached.Value)
+		})
+	}
+}
+
+func TestDiffIsDifferentForEmptyCacheVsNewMetrics(t *testing.T) {
+	//if this is the first observations set of the cache then all metrics
+	//must be considered no traffic as we have no way of determining if they are old or not
+	//so we output zero traffic for those
+	//
+	//conversely if we've made observations before and the metric itself is new
+	//we can presume that it's previous observation was a zero.
+	//new metrics can appear either because labels get observed or a restart
+	//of the monitoring service
+	a := newPrometheusCount("a", nil, 3)
+	b := newPrometheusCount("b", nil, 3)
+	c := newPrometheusCount("c", nil, 4)
+
+	cache := new(countCache)
+
+	//empty cache, no idea where those counts came from time wise
+	assert.Equal(t, int64(0), a.diff(cache))
+	assert.Equal(t, int64(0), b.diff(cache))
+
+	cache.Done()
+
+	a.Value = 6
+
+	//3 since last observation period we can trust those 3 to send along
+	assert.Equal(t, int64(3), a.diff(cache), fmt.Sprintf("%v", cache))
+	//this is a new metric since last observation, that means we can assume its count is from this time period
+	assert.Equal(t, int64(4), c.diff(cache), fmt.Sprintf("%v", cache))
+
+	cache.Done()
+
+	//b came, left, came again thats weird behavior but effectively the same as new metric we've observed
+	assert.Equal(t, int64(3), b.diff(cache))
+}
+
+func newCache(startingWith map[string]prometheusCount) *countCache {
+	return &countCache{last: startingWith}
+}

--- a/cmd/veneur-prometheus/stats.go
+++ b/cmd/veneur-prometheus/stats.go
@@ -73,17 +73,18 @@ func (c prometheusCount) Translate(cache *countCache) statsdStat {
 }
 
 func (c prometheusCount) diff(cache *countCache) int64 {
-	cached, has := cache.GetAndSwap(c)
-	if !has {
-		//if this is the first observation cycle the cache has been through
-		//then we have _no_ basis for calculations for any metrics dont count
-		//the values you see
-		if cache.FirstObservation() {
-			return 0
-		}
+	cached, has, first := cache.GetAndSwap(c)
 
-		//if we don't have this particular metric, but we do have other it means
-		//this metric is new.  you can assume those are part of this sample cycle
+	//if this is the first observation cycle the cache has been through
+	//then we have _no_ basis for calculations for any metrics dont count
+	//the values you see
+	if first {
+		return 0
+	}
+
+	//if we don't have this particular metric, but we do have other it means
+	//this metric is new.  you can assume those are part of this sample cycle
+	if !has {
 		return c.Value
 	}
 

--- a/cmd/veneur-prometheus/stats.go
+++ b/cmd/veneur-prometheus/stats.go
@@ -7,6 +7,10 @@ import (
 )
 
 type inMemoryStat interface {
+	Translate(*countCache) statsdStat
+}
+
+type statsdStat interface {
 	Send(*statsd.Client) error
 }
 
@@ -36,17 +40,64 @@ func same(a statID, b statID) bool {
 	return true
 }
 
-func newCount(name string, tags []string, value int64) count {
-	return count{statID{name, tags}, value}
+func newStatsdCount(name string, tags []string, value int64) statsdCount {
+	return statsdCount{statID{name, tags}, value}
 }
 
-type count struct {
+type statsdCount struct {
 	statID
 	Value int64
 }
 
-func (c count) Send(client *statsd.Client) error {
+func (c statsdCount) Send(client *statsd.Client) error {
+	//can skip 0 statsd counters
+	if c.Value == 0 {
+		return nil
+	}
+
 	return client.Count(c.Name, c.Value, c.Tags, 1.0)
+}
+
+func newPrometheusCount(name string, tags []string, value int64) prometheusCount {
+	return prometheusCount{statID{name, tags}, value}
+}
+
+type prometheusCount struct {
+	statID
+	Value int64
+}
+
+func (c prometheusCount) Translate(cache *countCache) statsdStat {
+	diffed := c.diff(cache)
+	return newStatsdCount(c.Name, c.Tags, diffed)
+}
+
+func (c prometheusCount) diff(cache *countCache) int64 {
+	cached, has := cache.GetAndSwap(c)
+	if !has {
+		//if this is the first observation cycle the cache has been through
+		//then we have _no_ basis for calculations for any metrics dont count
+		//the values you see
+		if cache.FirstObservation() {
+			return 0
+		}
+
+		//if we don't have this particular metric, but we do have other it means
+		//this metric is new.  you can assume those are part of this sample cycle
+		return c.Value
+	}
+
+	//if what we have is cached is larger than what we received it means there was a restart
+	//on the monitored service,  we know _at least_ the ones it reporting have happened
+	//though we may have missed some post our last observation and prior to restart
+	if cached.Value > c.Value {
+		return c.Value
+	}
+
+	//the normal case is we had some last observation cyle, then they grew so we report the diff
+	//note that there is an edge case here, that is we saw some, there was a restart and it grew to
+	//the value we had before.  in that case we are under counting but we cant determine any difference
+	return c.Value - cached.Value
 }
 
 func newGauge(name string, tags []string, value float64) gauge {
@@ -60,4 +111,8 @@ type gauge struct {
 
 func (g gauge) Send(client *statsd.Client) error {
 	return client.Gauge(g.Name, g.Value, g.Tags, 1.0)
+}
+
+func (g gauge) Translate(_ *countCache) statsdStat {
+	return g
 }


### PR DESCRIPTION
#### Summary
This is the third and final PR to fix #753.  It builds on #755 and should be merged after that PR.  This PR actually implements the code to make the translation of Prometheus stats to statsd stats happen via diffing 2 sample points.  It also adds a considerable number of tests around this behavior.

See the README in this change for a discussion on the edge cases that are introduced by this fix.

#### Motivation
#753 

#### Test plan
There are a wide variety of automated tests with this change.

#### Rollout/monitoring/revert plan
Rolling this out will likely cause a significant drop in the values reported for counters in veneur-prometheus; this is expected and a corrective action (since the values are no longer cumulative).  It is a stateless change between deploys though so can be trivially rolled back.