### PR TITLE
Fix BucketRegionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Veneur now sets a deadline for its flushes: No flush may take longer than the configured server flush interval. Thanks, [antifuchs](https://github.com/antifuchs)!
 * The signalfx sink no longer deadlocks the flush process if it receives more than one error per submission. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Fixed the README to link to the correct HLL implementation. Thanks, [gphat](https://github.com/gphat)!
+* Fixed the BucketRegionError while using the S3 Plugin. Thanks, [linuxdynasty](https://github.com/linuxdynasty)!
 
 ## Removed
 

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -71,9 +71,6 @@ const (
 	tsvGzFt          = "tsv.gz"
 )
 
-// S3Bucket name of S3 bucket to post to
-var S3Bucket string
-
 var S3ClientUninitializedError = errors.New("s3 client has not been initialized")
 
 func (p *S3Plugin) S3Post(hostname string, data io.ReadSeeker, ft filetype) error {
@@ -81,7 +78,7 @@ func (p *S3Plugin) S3Post(hostname string, data io.ReadSeeker, ft filetype) erro
 		return S3ClientUninitializedError
 	}
 	params := &s3.PutObjectInput{
-		Bucket: aws.String(S3Bucket),
+		Bucket: aws.String(p.S3Bucket),
 		Key:    S3Path(hostname, ft),
 		Body:   data,
 	}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Currently when you try to store data using the s3 plugin, it will
always fail with the error

```"Error posting to s3" error="BucketRegionError: incorrect region, the bucket is not in 'us-west-2' region\n\tstatus code: 301, request id: , host id: " metrics=2```

This error is misleading as the real issue is that the bucket name is never set in the code.
The code is trying to use the Global Constant S3Bucket when it should be using the method receivers struct
`p *S3Plugin` and accessing the field `p.S3Bucket` instead of the constant S3Bucket that isn't
referenced anywhere in the code.


#### Motivation
#588 


#### Test plan



#### Rollout/monitoring/revert plan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stripe/veneur/757)
<!-- Reviewable:end -->
