### PR TITLE
Change in Interval in the s3 plugin from int to float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * The signalfx sink no longer deadlocks the flush process if it receives more than one error per submission. Thanks, [antifuchs](https://github.com/antifuchs)!
 * Fixed the README to link to the correct HLL implementation. Thanks, [gphat](https://github.com/gphat)!
 * Fixed the BucketRegionError while using the S3 Plugin. Thanks, [linuxdynasty](https://github.com/linuxdynasty)!
+* Fixed server.go so that it passes `Interval` to the S3 Plugin and localfile plugin. Also added tests in the csv_test.go to test for `+Inf` when passing an Interval of 0. Thanks, [Linuxdynasty(https://github.com/linuxdynasty)!
 
 ## Removed
 

--- a/plugins/localfile/localfile.go
+++ b/plugins/localfile/localfile.go
@@ -22,7 +22,7 @@ type Plugin struct {
 	FilePath string
 	Logger   *logrus.Logger
 	hostname string
-	interval int
+	Interval float64
 }
 
 // Delimiter defines what kind of delimiter we'll use in the CSV format -- in this case, we want TSV
@@ -36,11 +36,11 @@ func (p *Plugin) Flush(ctx context.Context, metrics []samplers.InterMetric) erro
 	if err != nil {
 		return fmt.Errorf("couldn't open %s for appending: %s", p.FilePath, err)
 	}
-	appendToWriter(f, metrics, p.hostname, p.interval)
+	appendToWriter(f, metrics, p.hostname, p.Interval)
 	return nil
 }
 
-func appendToWriter(appender io.Writer, metrics []samplers.InterMetric, hostname string, interval int) error {
+func appendToWriter(appender io.Writer, metrics []samplers.InterMetric, hostname string, interval float64) error {
 	gzW := gzip.NewWriter(appender)
 	csvW := csv.NewWriter(gzW)
 	csvW.Comma = Delimiter

--- a/plugins/s3/csv.go
+++ b/plugins/s3/csv.go
@@ -53,7 +53,7 @@ var tsvSchema = [...]string{
 // The caller is responsible for setting w.Comma as the appropriate delimiter.
 // For performance, encodeCSV does not flush after every call; the caller is
 // expected to flush at the end of the operation cycle
-func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *time.Time, hostName string, interval int) error {
+func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *time.Time, hostName string, interval float64) error {
 	// TODO(aditya) some better error handling for this
 	// to guarantee that the result is proper JSON
 	tags := "{" + strings.Join(d.Tags, ",") + "}"
@@ -62,7 +62,7 @@ func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *
 	metricValue := d.Value
 	switch d.Type {
 	case samplers.CounterMetric:
-		metricValue = d.Value / float64(interval)
+		metricValue = d.Value / interval
 		metricType = "rate"
 
 	case samplers.GaugeMetric:
@@ -77,7 +77,7 @@ func EncodeInterMetricCSV(d samplers.InterMetric, w *csv.Writer, partitionDate *
 		TsvName:           d.Name,
 		TsvTags:           tags,
 		TsvMetricType:     metricType,
-		TsvInterval:       strconv.Itoa(interval),
+		TsvInterval:       strconv.FormatFloat(interval, 'f', -1, 64),
 		TsvVeneurHostname: hostName,
 		TsvValue:          strconv.FormatFloat(metricValue, 'f', -1, 64),
 

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -29,7 +29,7 @@ type S3Plugin struct {
 	Svc      s3iface.S3API
 	S3Bucket string
 	Hostname string
-	Interval int
+	Interval float64
 }
 
 func (p *S3Plugin) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
@@ -96,7 +96,7 @@ func S3Path(hostname string, ft filetype) *string {
 // EncodeInterMetricsCSV returns a reader containing the gzipped CSV representation of the
 // InterMetric data, one row per InterMetric.
 // the AWS sdk requires seekable input, so we return a ReadSeeker here
-func EncodeInterMetricsCSV(metrics []samplers.InterMetric, delimiter rune, includeHeaders bool, hostname string, interval int) (io.ReadSeeker, error) {
+func EncodeInterMetricsCSV(metrics []samplers.InterMetric, delimiter rune, includeHeaders bool, hostname string, interval float64) (io.ReadSeeker, error) {
 	b := &bytes.Buffer{}
 	gzw := gzip.NewWriter(b)
 	w := csv.NewWriter(gzw)

--- a/plugins/s3/s3_test.go
+++ b/plugins/s3/s3_test.go
@@ -174,3 +174,45 @@ func TestEncodeDDMetricsCSV(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeDDMetricsCSVZeroInterval(t *testing.T) {
+	const ExpectedHeader = "Name\tTags\tMetricType\tVeneurHostname\tInterval\tTimestamp\tValue\tPartition"
+	const Delimiter = '\t'
+	const VeneurHostname = "testbox-c3eac9"
+
+	testCases := ZeroIntervalCSVTestCases()
+
+	metrics := make([]samplers.InterMetric, len(testCases))
+	for i, tc := range testCases {
+		metrics[i] = tc.InterMetric
+	}
+
+	c, err := EncodeInterMetricsCSV(metrics, Delimiter, true, VeneurHostname, 0)
+	assert.NoError(t, err)
+	gzr, err := gzip.NewReader(c)
+	assert.NoError(t, err)
+	r := csv.NewReader(gzr)
+	r.FieldsPerRecord = 8
+	r.Comma = Delimiter
+
+	// first line should always contain header information
+	header, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, ExpectedHeader, strings.Join(header, "\t"))
+
+	records, err := r.ReadAll()
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(metrics), len(records), "Expected %d records and got %d", len(metrics), len(records))
+	for i, tc := range testCases {
+		record := records[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			for j, cell := range record {
+				if strings.ContainsRune(cell, Delimiter) {
+					record[j] = `"` + cell + `"`
+				}
+			}
+			AssertReadersEqual(t, testCases[i].Row, strings.NewReader(strings.Join(record, "\t")+"\n"))
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -694,6 +694,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 					Svc:      svc,
 					S3Bucket: conf.AwsS3Bucket,
 					Hostname: ret.Hostname,
+					Interval: ret.interval.Seconds(),
 				}
 				ret.registerPlugin(plugin)
 			}
@@ -714,6 +715,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		localFilePlugin := &localfilep.Plugin{
 			FilePath: conf.FlushFile,
 			Logger:   log,
+			Interval: ret.interval.Seconds(),
 		}
 		ret.registerPlugin(localFilePlugin)
 		logger.Info(fmt.Sprintf("Local file logging to %s", conf.FlushFile))


### PR DESCRIPTION
* Currently all counters return a +Inf and this is due to the fact that we are
not passing Interval in server.go. Also in s3.go, interval was set to int instead
of float64.
* Update csv_test.go to include tests when passing an Interval of 0.

#### Summary
As of right now any `samplers.CounterMetric` has a divide by 0 error which reports back as `+Inf`. This PR will fix that error for the S3 Plugin and the Localfile plugin. I also updated the tests in csv_test.go and s3_tests.go to check for `+Inf`.


#### Motivation
Counters were producing `+Inf`


#### Test plan
I updated tests in csv_test.go and s3_tests.go


#### Rollout/monitoring/revert plan

