### PR TITLE
[veneur-prometheus] now supports Prometheus untyped metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * New config option `count_unique_timeseries` which is used to emit metric `veneur.flush.unique_timeseries_total`, the HyperLogLog cardinality estimate of the unique timeseries in a flush interval. Thanks, [randallm](https://github.com/randallm)!
 * veneur-emit now allows you to mark SSF spans as having errored. Thanks, [randallm](https://github.com/randallm)!
 * The Splunk span sink supports tag exclusion, to better manage Splunk indexing volume. If a span contains a tag that's in the excluded set, the Splunk sink will skip sending that span to Splunk. Thanks, [aditya](https://github.com/chimeracoder)!
+* veneur-prometheus now supports Prometheus Untyped metrics. Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
 
 ## Updated
 

--- a/cmd/veneur-prometheus/translate.go
+++ b/cmd/veneur-prometheus/translate.go
@@ -54,6 +54,8 @@ func sendTranslated(prometheus <-chan prometheusResults, translate translator, s
 			stats = translate.PrometheusSummary(mf)
 		case dto.MetricType_HISTOGRAM:
 			stats = translate.PrometheusHistogram(mf)
+		case dto.MetricType_UNTYPED:
+			stats = translate.PrometheusUntyped(mf)
 		default:
 			unknown++
 		}
@@ -111,6 +113,15 @@ func (t translator) PrometheusGauge(mf dto.MetricFamily) []inMemoryStat {
 	for _, gauge := range mf.GetMetric() {
 		tags := t.Tags(gauge.GetLabel())
 		stats = append(stats, newGauge(mf.GetName(), tags, float64(gauge.GetGauge().GetValue())))
+	}
+	return stats
+}
+
+func (t translator) PrometheusUntyped(mf dto.MetricFamily) []inMemoryStat {
+	var stats []inMemoryStat
+	for _, untyped := range mf.GetMetric() {
+		tags := t.Tags(untyped.GetLabel())
+		stats = append(stats, newGauge(mf.GetName(), tags, float64(untyped.GetUntyped().GetValue())))
 	}
 	return stats
 }


### PR DESCRIPTION
#### Summary
Prometheus has a concept called 'Untyped' metrics.  These can be treated like [gauges](https://godoc.org/github.com/prometheus/client_golang/prometheus#hdr-Metrics).  

#### Motivation
Prometheus recording rules create metrics that are untyped.  If you use veneur-prometheus to gather those (for instance via the federate endpoint) they would have been ignored.

#### Test plan
Automated tests

#### Rollout/monitoring/revert plan
No special rollout plan needed.