### PR TITLE
Add the option to drop Datatod metric by name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * New config option `count_unique_timeseries` which is used to emit metric `veneur.flush.unique_timeseries_total`, the HyperLogLog cardinality estimate of the unique timeseries in a flush interval. Thanks, [randallm](https://github.com/randallm)!
 * veneur-emit now allows you to mark SSF spans as having errored. Thanks, [randallm](https://github.com/randallm)!
 * The Splunk span sink supports tag exclusion, to better manage Splunk indexing volume. If a span contains a tag that's in the excluded set, the Splunk sink will skip sending that span to Splunk. Thanks, [aditya](https://github.com/chimeracoder)!
+* The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`.
 
 ## Updated
 

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`
 	DatadogSpanBufferSize                     int       `yaml:"datadog_span_buffer_size"`
 	DatadogTraceAPIAddress                    string    `yaml:"datadog_trace_api_address"`
+	DatadogMetricNamePrefixDrops              []string  `yaml:"datadog_metric_name_prefix_drops"`
 	Debug                                     bool      `yaml:"debug"`
 	DebugFlushedMetrics                       bool      `yaml:"debug_flushed_metrics"`
 	DebugIngestedSpans                        bool      `yaml:"debug_ingested_spans"`

--- a/config.go
+++ b/config.go
@@ -11,9 +11,9 @@ type Config struct {
 	DatadogAPIHostname                        string    `yaml:"datadog_api_hostname"`
 	DatadogAPIKey                             string    `yaml:"datadog_api_key"`
 	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`
+	DatadogMetricNamePrefixDrops              []string  `yaml:"datadog_metric_name_prefix_drops"`
 	DatadogSpanBufferSize                     int       `yaml:"datadog_span_buffer_size"`
 	DatadogTraceAPIAddress                    string    `yaml:"datadog_trace_api_address"`
-	DatadogMetricNamePrefixDrops              []string  `yaml:"datadog_metric_name_prefix_drops"`
 	Debug                                     bool      `yaml:"debug"`
 	DebugFlushedMetrics                       bool      `yaml:"debug_flushed_metrics"`
 	DebugIngestedSpans                        bool      `yaml:"debug_ingested_spans"`

--- a/example.yaml
+++ b/example.yaml
@@ -279,6 +279,12 @@ datadog_flush_max_per_body: 25000
 # Hostname to send Datadog trace data to.
 datadog_trace_api_address: ""
 
+# A list of metric *prefixes* to drop. Note that this is not the whole string
+# and not a regexp. Just a prefix. Any metrics that have this prefix as a name
+# will be dropped before sending to Datadog.
+datadog_metric_name_prefix_drops:
+  - ""
+
 # The size of the ring buffer used for retaining spans during a flush interval.
 datadog_span_buffer_size: 16384
 

--- a/example.yaml
+++ b/example.yaml
@@ -283,7 +283,7 @@ datadog_trace_api_address: ""
 # and not a regexp. Just a prefix. Any metrics that have this prefix as a name
 # will be dropped before sending to Datadog.
 datadog_metric_name_prefix_drops:
-  - ""
+  - "an_ignorable_metric."
 
 # The size of the ring buffer used for retaining spans during a flush interval.
 datadog_span_buffer_size: 16384

--- a/server.go
+++ b/server.go
@@ -497,7 +497,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	if conf.DatadogAPIKey != "" && conf.DatadogAPIHostname != "" {
 		ddSink, err := datadog.NewDatadogMetricSink(
 			ret.interval.Seconds(), conf.DatadogFlushMaxPerBody, conf.Hostname, ret.Tags,
-			conf.DatadogAPIHostname, conf.DatadogAPIKey, ret.HTTPClient, log,
+			conf.DatadogAPIHostname, conf.DatadogAPIKey, ret.HTTPClient, log, conf.DatadogMetricNamePrefixDrops,
 		)
 		if err != nil {
 			return ret, err

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -32,16 +32,17 @@ const datadogSpanType = "web"
 const datadogSpanBufferSize = 1 << 14
 
 type DatadogMetricSink struct {
-	HTTPClient      *http.Client
-	APIKey          string
-	DDHostname      string
-	hostname        string
-	flushMaxPerBody int
-	tags            []string
-	interval        float64
-	traceClient     *trace.Client
-	log             *logrus.Logger
-	excludedTags    []string
+	HTTPClient            *http.Client
+	APIKey                string
+	DDHostname            string
+	hostname              string
+	flushMaxPerBody       int
+	tags                  []string
+	interval              float64
+	traceClient           *trace.Client
+	log                   *logrus.Logger
+	metricNamePrefixDrops []string
+	excludedTags          []string
 }
 
 // DDEvent represents the structure of datadog's undocumented /intake endpoint
@@ -80,16 +81,17 @@ type DDServiceCheck struct {
 }
 
 // NewDatadogMetricSink creates a new Datadog sink for trace spans.
-func NewDatadogMetricSink(interval float64, flushMaxPerBody int, hostname string, tags []string, ddHostname string, apiKey string, httpClient *http.Client, log *logrus.Logger) (*DatadogMetricSink, error) {
+func NewDatadogMetricSink(interval float64, flushMaxPerBody int, hostname string, tags []string, ddHostname string, apiKey string, httpClient *http.Client, log *logrus.Logger, metricNamePrefixDrops []string) (*DatadogMetricSink, error) {
 	return &DatadogMetricSink{
-		HTTPClient:      httpClient,
-		APIKey:          apiKey,
-		DDHostname:      ddHostname,
-		interval:        interval,
-		flushMaxPerBody: flushMaxPerBody,
-		hostname:        hostname,
-		tags:            tags,
-		log:             log,
+		HTTPClient:            httpClient,
+		APIKey:                apiKey,
+		DDHostname:            ddHostname,
+		interval:              interval,
+		flushMaxPerBody:       flushMaxPerBody,
+		hostname:              hostname,
+		tags:                  tags,
+		metricNamePrefixDrops: metricNamePrefixDrops,
+		log:                   log,
 	}, nil
 }
 
@@ -253,10 +255,18 @@ func (dd *DatadogMetricSink) finalizeMetrics(metrics []samplers.InterMetric) ([]
 	ddMetrics := make([]DDMetric, 0, len(metrics))
 	checks := []DDServiceCheck{}
 
+METRICLOOP: // Convenience label so that inner nested loops and `continue` easily
 	for _, m := range metrics {
 		if !sinks.IsAcceptableMetric(m, dd) {
 			continue
 		}
+
+		for _, dropMetricPrefix := range dd.metricNamePrefixDrops {
+			if strings.HasPrefix(m.Name, dropMetricPrefix) {
+				continue METRICLOOP
+			}
+		}
+
 		// Defensively copy tags since we're gonna mutate it
 		tags := make([]string, 0, len(dd.tags))
 

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -255,7 +255,7 @@ func (dd *DatadogMetricSink) finalizeMetrics(metrics []samplers.InterMetric) ([]
 	ddMetrics := make([]DDMetric, 0, len(metrics))
 	checks := []DDServiceCheck{}
 
-METRICLOOP: // Convenience label so that inner nested loops and `continue` easily
+METRICLOOP:
 	for _, m := range metrics {
 		if !sinks.IsAcceptableMetric(m, dd) {
 			continue


### PR DESCRIPTION
#### Summary
Add the ability to drops Datadog metric by name prefix

#### Motivation
 
We want to decrease the number of metrics that sent to Datadog. 


#### Test plan
I have added tests cases that check the count of metric that send after the dropping  

