### PR TITLE
Add a socket based roundtripper to veneur-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 * veneur-emit now allows you to mark SSF spans as having errored. Thanks, [randallm](https://github.com/randallm)!
 * The Splunk span sink supports tag exclusion, to better manage Splunk indexing volume. If a span contains a tag that's in the excluded set, the Splunk sink will skip sending that span to Splunk. Thanks, [aditya](https://github.com/chimeracoder)!
 * veneur-prometheus now supports Prometheus Untyped metrics. Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
-* The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`.
+* veneur-prometheus now accepts a socket parameter for proxied requests. Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
+* The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 
 ## Updated
 

--- a/cmd/veneur-prometheus/config.go
+++ b/cmd/veneur-prometheus/config.go
@@ -63,7 +63,7 @@ func httpTransport(certPath, keyPath, caCertPath string) (http.RoundTripper, err
 	if certPath != "" {
 		clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading client cert and key: %w", err)
+			return nil, fmt.Errorf("error reading client cert and key: %s", err)
 		}
 		clientCerts = append(clientCerts, clientCert)
 	}
@@ -72,7 +72,7 @@ func httpTransport(certPath, keyPath, caCertPath string) (http.RoundTripper, err
 		caCertPool = x509.NewCertPool()
 		caCert, err := ioutil.ReadFile(caCertPath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading ca cert: %w", err)
+			return nil, fmt.Errorf("error reading ca cert: %s", err)
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 	}

--- a/cmd/veneur-prometheus/config_test.go
+++ b/cmd/veneur-prometheus/config_test.go
@@ -9,10 +9,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHTTPClientHTTP(t *testing.T) {
-	client := newHTTPClient("", "", "")
+	client, err := newHTTPClient("", "", "", "")
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -25,7 +27,8 @@ func TestGetHTTPClientHTTP(t *testing.T) {
 }
 
 func TestGetHTTPClientHTTPS(t *testing.T) {
-	client := newHTTPClient("./testdata/client.pem", "./testdata/client.key", "./testdata/root.pem")
+	client, err := newHTTPClient("", "./testdata/client.pem", "./testdata/client.key", "./testdata/root.pem")
+	require.NoError(t, err)
 
 	caCertPool := x509.NewCertPool()
 	caCert, err := ioutil.ReadFile("./testdata/root.pem")

--- a/cmd/veneur-prometheus/unixtripper.go
+++ b/cmd/veneur-prometheus/unixtripper.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport, like http.Transport, implements http.RoundTripper. Set an object
+// of type Transport as the Transport field on an http.Client to send requests
+// via the proxy.
+type Transport struct {
+	shadow http.Transport
+}
+
+// New returns a Transport that uses the UNIX domain socket at the given path.
+// Set the Transport field of an http.Client to send requests via the proxy.
+// checkResponse is a function that will be called on each response and can
+// be used for filtering or additional processing.
+func NewUnixTransport(path string) *Transport {
+	dial := func(network, addr string) (net.Conn, error) {
+		return net.Dial("unix", path)
+	}
+	shadow := http.Transport{
+		Dial:                  dial,
+		DialTLS:               dial,
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 10 * time.Second,
+	}
+	return &Transport{shadow}
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := *req
+	url2 := *req.URL
+	req2.URL = &url2
+	req2.URL.Opaque = fmt.Sprintf("//%s%s", req.URL.Host, req.URL.EscapedPath())
+	resp, err := t.shadow.RoundTrip(&req2)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
#### Summary
Added a --socket parameter to veneur-prometheus.  When provided the process will use a unix socket at the provided location to route prometheus queries to.

~~**Note**: This makes use of the go 1.13 wrapped errors concept.  I assumed this was safe as we updated to that version in our builds.~~

**Note**: I upgraded our CI builds to go 1.13 as the Docker image build had been updated to that.

#### Motivation
Certain types of proxies work via unix sockets.

#### Test plan
Tested locally against a unix socket.

#### Rollout/monitoring/revert plan
Backwards compatible.