### PR TITLE
Remove experimental context package import

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -905,7 +905,6 @@
     "github.com/zenazn/goji/graceful",
     "goji.io",
     "goji.io/pat",
-    "golang.org/x/net/context",
     "golang.org/x/sys/unix",
     "google.golang.org/grpc",
     "google.golang.org/grpc/connectivity",

--- a/http.go
+++ b/http.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stripe/veneur/trace"
 	"github.com/stripe/veneur/trace/metrics"
 
+	"context"
 	"github.com/segmentio/fasthash/fnv1a"
 	"goji.io"
 	"goji.io/pat"
-	"golang.org/x/net/context"
 )
 
 // Handler returns the Handler responsible for routing request processing.

--- a/importsrv/server.go
+++ b/importsrv/server.go
@@ -10,9 +10,10 @@ import (
 	"net"
 	"time"
 
+	"context"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/segmentio/fasthash/fnv1a"
-	"golang.org/x/net/context" // This can be replace with "context" after Go 1.8 support is dropped
 	"google.golang.org/grpc"
 
 	"github.com/stripe/veneur/forwardrpc"

--- a/internal/forwardtest/server.go
+++ b/internal/forwardtest/server.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"testing"
 
+	"context"
+
 	"github.com/golang/protobuf/ptypes/empty"
-	"golang.org/x/net/context" // This can be replace with "context" after Go 1.8 support is dropped
 	"google.golang.org/grpc"
 
 	"github.com/stripe/veneur/forwardrpc"

--- a/proxy.go
+++ b/proxy.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/DataDog/datadog-go/statsd"
 	raven "github.com/getsentry/raven-go"

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -15,9 +15,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context" // This can be replace with "context" after Go 1.8 support is dropped
 	"google.golang.org/grpc"
 	"stathat.com/c/consistent"
 

--- a/sinks/grpsink/convert_context_18.go
+++ b/sinks/grpsink/convert_context_18.go
@@ -5,7 +5,7 @@ package grpsink
 import (
 	"context"
 
-	ocontext "golang.org/x/net/context"
+	ocontext "context"
 )
 
 func convertContext(ctx context.Context) ocontext.Context {

--- a/sinks/grpsink/convert_context_19.go
+++ b/sinks/grpsink/convert_context_19.go
@@ -5,7 +5,7 @@ package grpsink
 import (
 	"context"
 
-	ocontext "golang.org/x/net/context"
+	ocontext "context"
 )
 
 func convertContext(ctx context.Context) ocontext.Context {

--- a/sinks/grpsink/grpsink.go
+++ b/sinks/grpsink/grpsink.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	ocontext "golang.org/x/net/context"
+	ocontext "context"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"

--- a/sinks/grpsink/grpsink_test.go
+++ b/sinks/grpsink/grpsink_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	ocontext "golang.org/x/net/context"
+	ocontext "context"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This patch does a path rewrite of the context package since it has been
supported for a few major releases now.

#### Summary
I removed the old `context` import via a `gofmt` rewrite rule:

```sh
gofmt -w -r '"golang.org/x/net/context" -> "context"' .
```

#### Motivation
It helps remove a stale import.

#### Test plan
I am relying on existing unit tests.

#### Rollout/monitoring/revert plan
Revert the path rewrite.