### PR TITLE
Exclude specific tags by prefix metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 14.0.0, in progress
 
+## Added
+* The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
+* The Datadog sink can now filter tags by metric names prefix with `datadog_exclude_tags_prefix_by_prefix_metric`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
+
 # 13.0.0, 2020-01-03
 
 ## Added

--- a/config.go
+++ b/config.go
@@ -1,15 +1,19 @@
 package veneur
 
 type Config struct {
-	Aggregates                                []string  `yaml:"aggregates"`
-	AwsAccessKeyID                            string    `yaml:"aws_access_key_id"`
-	AwsRegion                                 string    `yaml:"aws_region"`
-	AwsS3Bucket                               string    `yaml:"aws_s3_bucket"`
-	AwsSecretAccessKey                        string    `yaml:"aws_secret_access_key"`
-	BlockProfileRate                          int       `yaml:"block_profile_rate"`
-	CountUniqueTimeseries                     bool      `yaml:"count_unique_timeseries"`
-	DatadogAPIHostname                        string    `yaml:"datadog_api_hostname"`
-	DatadogAPIKey                             string    `yaml:"datadog_api_key"`
+	Aggregates                             []string `yaml:"aggregates"`
+	AwsAccessKeyID                         string   `yaml:"aws_access_key_id"`
+	AwsRegion                              string   `yaml:"aws_region"`
+	AwsS3Bucket                            string   `yaml:"aws_s3_bucket"`
+	AwsSecretAccessKey                     string   `yaml:"aws_secret_access_key"`
+	BlockProfileRate                       int      `yaml:"block_profile_rate"`
+	CountUniqueTimeseries                  bool     `yaml:"count_unique_timeseries"`
+	DatadogAPIHostname                     string   `yaml:"datadog_api_hostname"`
+	DatadogAPIKey                          string   `yaml:"datadog_api_key"`
+	DatadogExcludeTagsPrefixByPrefixMetric []struct {
+		MetricPrefix string   `yaml:"metric_prefix"`
+		Tags         []string `yaml:"tags"`
+	} `yaml:"datadog_exclude_tags_prefix_by_prefix_metric"`
 	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`
 	DatadogMetricNamePrefixDrops              []string  `yaml:"datadog_metric_name_prefix_drops"`
 	DatadogSpanBufferSize                     int       `yaml:"datadog_span_buffer_size"`

--- a/example.yaml
+++ b/example.yaml
@@ -285,6 +285,13 @@ datadog_trace_api_address: ""
 datadog_metric_name_prefix_drops:
   - "an_ignorable_metric."
 
+# Excluded tags *prefixes* from specific metric *prefixes*
+# Any metrics that have tags *prefixes* will be dropped before sending to Datadog.
+datadog_exclude_tags_prefix_by_prefix_metric:
+  - metric_prefix: "metric_prefix"
+    tags: 
+      - an_ignorable_tag_prefix"
+
 # The size of the ring buffer used for retaining spans during a flush interval.
 datadog_span_buffer_size: 16384
 

--- a/server.go
+++ b/server.go
@@ -495,9 +495,16 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		ret.metricSinks = append(ret.metricSinks, sfxSink)
 	}
 	if conf.DatadogAPIKey != "" && conf.DatadogAPIHostname != "" {
+
+		excludeTagsPrefixByPrefixMetric := map[string][]string{}
+		for _, m := range conf.DatadogExcludeTagsPrefixByPrefixMetric {
+			excludeTagsPrefixByPrefixMetric[m.MetricPrefix] = m.Tags
+		}
+
 		ddSink, err := datadog.NewDatadogMetricSink(
 			ret.interval.Seconds(), conf.DatadogFlushMaxPerBody, conf.Hostname, ret.Tags,
 			conf.DatadogAPIHostname, conf.DatadogAPIKey, ret.HTTPClient, log, conf.DatadogMetricNamePrefixDrops,
+			excludeTagsPrefixByPrefixMetric,
 		)
 		if err != nil {
 			return ret, err


### PR DESCRIPTION
#### Summary
We have a lot of systems sending telemetry data to Datadog that we can't really control which metrics and tags are sent to Datadog.
We'd like to have the ability to control which metrics are sent to Datadog by their metric name (preferably prefix) and their tag name (prefix again).
This way we'll be able to reduce the number of custom metrics we're sending and have better control over what we send.

#### Motivation
- Reduce the number of custom metrics we send to Datadog (cost).
- Preserve only the metrics we want to have.
- Remove repeatable data (two metrics representing the same value, for example: region, datacenter)
- Have better control on what we send using prefixes and not a full name


#### Test plan
Added test that checks drop tags by prefix metric name `TestDataDogDropTagsByMetricPrefix`

