### PR TITLE
Make metric-provided SFX token precedence over host token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 * The Datadog sink can now filter tags by metric names prefix with `datadog_exclude_tags_prefix_by_prefix_metric`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
+* When specifying the SignalFx key with `signalfx_vary_key_by`, if both the host and the metric provide a value, the metric-provided value will take precedence over the host-provided value. This allows more granular forms of metric organization and attribution. Thanks, [aditya](https://github.com/chimeracoder)!
 
 # 13.0.0, 2020-01-03
 

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -433,9 +433,12 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 
 		// metric-specified API key, if present, should override the common dimension
 		metricKey := ""
+		overridePresent := false
+
 		if sfx.varyBy != "" {
 			if val, ok := dims[sfx.varyBy]; ok {
 				metricKey = val
+				overridePresent = true
 			} else {
 				if val, ok := sfx.commonDimensions[sfx.varyBy]; ok {
 					metricKey = val
@@ -446,6 +449,11 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 		// Copy common dimensions
 		for k, v := range sfx.commonDimensions {
 			dims[k] = v
+		}
+
+		// re-copy metric-specified API key, if present
+		if overridePresent && sfx.varyBy != "" {
+			dims[sfx.varyBy] = metricKey
 		}
 
 		for k := range sfx.excludedTags {

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -433,16 +433,12 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 
 		// metric-specified API key, if present, should override the common dimension
 		metricKey := ""
-		overridePresent := false
+		metricVaryByOverride := false
 
 		if sfx.varyBy != "" {
 			if val, ok := dims[sfx.varyBy]; ok {
 				metricKey = val
-				overridePresent = true
-			} else {
-				if val, ok := sfx.commonDimensions[sfx.varyBy]; ok {
-					metricKey = val
-				}
+				metricVaryByOverride = true
 			}
 		}
 
@@ -452,7 +448,7 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 		}
 
 		// re-copy metric-specified API key, if present
-		if overridePresent && sfx.varyBy != "" {
+		if metricVaryByOverride {
 			dims[sfx.varyBy] = metricKey
 		}
 

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -430,15 +430,22 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 				dims[key] = kv[1]
 			}
 		}
-		// Copy common dimensions
-		for k, v := range sfx.commonDimensions {
-			dims[k] = v
-		}
+
+		// metric-specified API key, if present, should override the common dimension
 		metricKey := ""
 		if sfx.varyBy != "" {
 			if val, ok := dims[sfx.varyBy]; ok {
 				metricKey = val
+			} else {
+				if val, ok := sfx.commonDimensions[sfx.varyBy]; ok {
+					metricKey = val
+				}
 			}
+		}
+
+		// Copy common dimensions
+		for k, v := range sfx.commonDimensions {
+			dims[k] = v
 		}
 
 		for k := range sfx.excludedTags {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Veneur already supports two features:
* The SignalFx sink supports using multiple access tokens, using a user-provided tag to signal which key to use for a particular metric (configured with `signalfx_vary_key_by`). 
* If the `tags` array value is specified in the Veneur configuration on startup, all tags in the array will be applied to all metrics ingested. (This includes the user-provided tag that is configured in `signalfx_vary_key_by`).

However, if a metric provides its own value for the `signalfx_vary_key_by`-specified tag, this will be overridden by the host, which is generally *not* the desired behavior. This PR updates Veneur to use the host-wide value as a fallback, and allow the metric-provided value (if specified) to take precedence.

One open question: should this overridden value be passed through in how the metric is reported, or should it simply be used when determining the access token for submission (and report the metric with the host-wide value anyway)? This is the question of whether to revert the second commit in this PR: https://github.com/stripe/veneur/pull/776/commits/05fb618d2f29e385248a01c2f6ac4aa7d21b3e12.

**Reasons to revert**:
* It's a special case
* It looks a little hacky

**Reasons not to revert**:
* Easier debugging
* Could be confusing to have the `host_operator` as viewed in SignalFx not match the access token that was used to submit the metric

I originally intended on reverting it, but now I'm leaning towards keeping it, after seeing how it made debugging easier.


### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Tested on QA, and metrics were attributed correctly 


r? @annab-stripe || @rma-stripe 
cc @stripe/observability 