### PR TITLE
Add forward_only config: Forward all metrics to a global veneur

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	FlushMaxPerBody                           int       `yaml:"flush_max_per_body"`
 	FlushWatchdogMissedFlushes                int       `yaml:"flush_watchdog_missed_flushes"`
 	ForwardAddress                            string    `yaml:"forward_address"`
+	ForwardOnly                               bool      `yaml:"forward_only"`
 	ForwardUseGrpc                            bool      `yaml:"forward_use_grpc"`
 	GrpcAddress                               string    `yaml:"grpc_address"`
 	Hostname                                  string    `yaml:"hostname"`

--- a/example.yaml
+++ b/example.yaml
@@ -41,6 +41,11 @@ tls_authority_certificate: ""
 #forward_address: "veneur.example.com"
 forward_address: ""
 
+# If true: Forward all metrics to the global veneur for aggregation. This is useful
+# when wanting to aggregate a large volume of metrics that all should be global, without
+# needing to explicitly tag them.
+forward_only: false
+
 # Whether or not to forward to an upstream Veneur over gRPC.  If this is false
 # or unset, HTTP will be used.
 forward_use_grpc: false

--- a/server.go
+++ b/server.go
@@ -386,9 +386,17 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	// slight performance hit to workers.
 	ret.CountUniqueTimeseries = conf.CountUniqueTimeseries
 
+	// Default to "mixed" scope, but allow config to force metrics to be global
+	defaultMetricScope := samplers.MixedScope
+	if conf.ForwardOnly {
+		logger.WithField("scope", "global").Debug("Forwarding all metrics to global veneur")
+		defaultMetricScope = samplers.GlobalOnly
+	}
+
 	// Use the pre-allocated Workers slice to know how many to start.
 	for i := range ret.Workers {
-		ret.Workers[i] = NewWorker(i+1, ret.IsLocal(), ret.CountUniqueTimeseries, ret.TraceClient, log, ret.Statsd)
+		ret.Workers[i] = NewWorker(i+1, ret.IsLocal(), ret.CountUniqueTimeseries, ret.TraceClient,
+			log, ret.Statsd, defaultMetricScope)
 		// do not close over loop index
 		go func(w *Worker) {
 			defer func() {

--- a/server_test.go
+++ b/server_test.go
@@ -1000,7 +1000,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Simulate a metrics worker:
-	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd, samplers.MixedScope)
 	s.Workers = []*Worker{w}
 	go func() {
 	}()
@@ -1073,7 +1073,7 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	require.NoError(b, err)
 
 	// Simulate a metrics worker:
-	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd)
+	w := NewWorker(0, s.IsLocal(), s.CountUniqueTimeseries, nil, nullLogger(), s.Statsd, samplers.MixedScope)
 	s.Workers = []*Worker{w}
 
 	go func() {

--- a/sinks/ssfmetrics/metrics_test.go
+++ b/sinks/ssfmetrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/veneur"
+	"github.com/stripe/veneur/samplers"
 	"github.com/stripe/veneur/sinks"
 	"github.com/stripe/veneur/sinks/ssfmetrics"
 	"github.com/stripe/veneur/ssf"
@@ -15,7 +16,7 @@ import (
 
 func TestMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil, samplers.MixedScope)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	require.NoError(t, err)
@@ -56,7 +57,7 @@ func TestMetricExtractor(t *testing.T) {
 
 func setupBench() (*ssf.SSFSpan, sinks.SpanSink) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil, samplers.MixedScope)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "", nil, logger)
 	if err != nil {
@@ -109,7 +110,7 @@ func BenchmarkParallelMetricExtractor(b *testing.B) {
 
 func TestIndicatorMetricExtractor(t *testing.T) {
 	logger := logrus.StandardLogger()
-	worker := veneur.NewWorker(0, true, false, nil, logger, nil)
+	worker := veneur.NewWorker(0, true, false, nil, logger, nil, samplers.MixedScope)
 	workers := []ssfmetrics.Processor{worker}
 	sink, err := ssfmetrics.NewMetricExtractionSink(workers, "foo", "bar", nil, logger)
 	require.NoError(t, err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -40,7 +40,7 @@ func TestWorker(t *testing.T) {
 }
 
 func TestWorkerLocal(t *testing.T) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -60,7 +60,7 @@ func TestWorkerLocal(t *testing.T) {
 }
 
 func TestWorkerGlobal(t *testing.T) {
-	w := NewWorker(1, false, false, nil, logrus.New(), nil)
+	w := NewWorker(1, false, false, nil, logrus.New(), nil, samplers.MixedScope)
 
 	gc := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -93,7 +93,7 @@ func TestWorkerGlobal(t *testing.T) {
 }
 
 func TestWorkerImportSet(t *testing.T) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 	testset := samplers.NewSet("a.b.c", nil)
 	testset.Sample("foo")
 	testset.Sample("bar")
@@ -108,7 +108,7 @@ func TestWorkerImportSet(t *testing.T) {
 }
 
 func TestWorkerImportHistogram(t *testing.T) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 	testhisto := samplers.NewHist("a.b.c", nil)
 	testhisto.Sample(1.0, 1.0)
 	testhisto.Sample(2.0, 1.0)
@@ -123,7 +123,7 @@ func TestWorkerImportHistogram(t *testing.T) {
 }
 
 func TestWorkerStatusMetric(t *testing.T) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -264,7 +264,7 @@ type testMetricExporter interface {
 }
 
 func exportMetricAndFlush(t testing.TB, exp testMetricExporter) WorkerMetrics {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 	m, err := exp.Metric()
 	assert.NoErrorf(t, err, "exporting the metric '%s' shouldn't have failed",
 		exp.GetName())
@@ -301,7 +301,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 	})
 	t.Run("timer", func(t *testing.T) {
 		t.Parallel()
-		w := NewWorker(1, true, false, nil, logrus.New(), nil)
+		w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 		h := samplers.NewHist("test.timer", nil)
 		h.Sample(1.0, 1.0)
 
@@ -327,7 +327,7 @@ func TestWorkerImportMetricGRPC(t *testing.T) {
 func TestWorkerImportMetricGRPCNilValue(t *testing.T) {
 	t.Parallel()
 
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 	metric := &metricpb.Metric{
 		Name:  "test",
 		Type:  metricpb.Type_Histogram,
@@ -429,7 +429,7 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 }
 
 func TestLocalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, true, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -456,7 +456,7 @@ func TestLocalWorkerSampleTimeseries(t *testing.T) {
 }
 
 func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
-	w := NewWorker(1, true, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -480,7 +480,7 @@ func TestLocalWorkerSampleForwardedTimeseries(t *testing.T) {
 }
 
 func TestGlobalWorkerSampleTimeseries(t *testing.T) {
-	w := NewWorker(1, false, true, nil, logrus.New(), nil)
+	w := NewWorker(1, false, true, nil, logrus.New(), nil, samplers.MixedScope)
 
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
@@ -504,7 +504,7 @@ func TestGlobalWorkerSampleTimeseries(t *testing.T) {
 }
 
 func BenchmarkWork(b *testing.B) {
-	w := NewWorker(1, true, false, nil, logrus.New(), nil)
+	w := NewWorker(1, true, false, nil, logrus.New(), nil, samplers.MixedScope)
 
 	const Len = 1000
 	input := make([]*samplers.UDPMetric, Len)
@@ -546,7 +546,7 @@ func BenchmarkWork(b *testing.B) {
 }
 
 func BenchmarkWorkWithCountUniqueTimeseries(b *testing.B) {
-	w := NewWorker(1, true, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil, samplers.MixedScope)
 
 	const Len = 1000
 	input := make([]*samplers.UDPMetric, Len)
@@ -588,7 +588,7 @@ func BenchmarkWorkWithCountUniqueTimeseries(b *testing.B) {
 }
 
 func BenchmarkSampleTimeseries(b *testing.B) {
-	w := NewWorker(1, true, true, nil, logrus.New(), nil)
+	w := NewWorker(1, true, true, nil, logrus.New(), nil, samplers.MixedScope)
 	const Len = 1000
 	input := make([]*samplers.UDPMetric, Len)
 	for i, _ := range input {


### PR DESCRIPTION
#### Summary
Adds a configuration option to allow a veneur instance to force all
metrics to be global.

NOTE: This is a work in progress; I know I need some tests. I'm mostly posting this early to get feedback on if this is something you even want to consider merging upstream. Its yet another weird use case configuration option that probably we are the only ones who want to use. :)

(This was previously PR #746 but I accidentally closed it while rebasing to the latest master version of veneur)


#### Motivation

This is useful when you do not want any host tags on your metrics, but also don't want to tag them. See the discussion on #565


#### Test plan

We (Bluecore) have used this in production for a while. It seems So far: I have not really tested it. I've turned it on in a test environment and it seems to "work" for now!


#### Rollout/monitoring/revert plan

Don't use the configuration option if you don't need it.