### PR TITLE
Enable abstract unix domain socket addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * The Datadog sink can now filter tags by metric names prefix with `datadog_exclude_tags_prefix_by_prefix_metric`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 * When specifying the SignalFx key with `signalfx_vary_key_by`, if both the host and the metric provide a value, the metric-provided value will take precedence over the host-provided value. This allows more granular forms of metric organization and attribution. Thanks, [aditya](https://github.com/chimeracoder)!
 
+## Updated
+* Updated the vendored version of DataDog/datadog-go which fixes parsing for abstract unix domain sockets in the statsd client. Thanks, [androohan](https://github.com/androohan)!
+
 # 13.0.0, 2020-01-03
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The Datadog sink can now filter metric names by prefix with `datadog_metric_name_prefix_drops`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 * The Datadog sink can now filter tags by metric names prefix with `datadog_exclude_tags_prefix_by_prefix_metric`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 * When specifying the SignalFx key with `signalfx_vary_key_by`, if both the host and the metric provide a value, the metric-provided value will take precedence over the host-provided value. This allows more granular forms of metric organization and attribution. Thanks, [aditya](https://github.com/chimeracoder)!
+* Support for listening to abstract statsd metrics on Unix Domain Socket(Datagram type). Thanks, [androohan](https://github.com/androohan)!
 
 ## Updated
 * Updated the vendored version of DataDog/datadog-go which fixes parsing for abstract unix domain sockets in the statsd client. Thanks, [androohan](https://github.com/androohan)!

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:6d83aad9c98e13079ad8a4dbc740892edf5384bcd07f1d789bb66cd8ecfae2cd"
+  digest = "1:d81527a95da3d28e896c8b5682c1ddd4feae879f3e6b006ed343ff95d3487ccf"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
   pruneopts = "NUT"
-  revision = "e67964b4021ad3a334e748e8811eb3cd6becbc6e"
-  version = "2.1.0"
+  revision = "009ba0aea8e47ded9033b94645987ff419cba86b"
+  version = "v3.5.0"
 
 [[projects]]
   digest = "1:e30fbdce732588b475a444cbeabbcbef1c6c08b8d4f3efc142853551a1b0ab13"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/datadog-go"
-  version = "2.1.0"
+  version = "3.5.0"
 
 [[constraint]]
   name = "github.com/Shopify/sarama"

--- a/example.yaml
+++ b/example.yaml
@@ -10,6 +10,7 @@ statsd_listen_addresses:
  - udp://localhost:8126
  - tcp://localhost:8126
  - unixgram:///tmp/veneur-statsd.sock
+ - unixgram:@veneur-statsd.sock
 
 # The addresses on which to listen for SSF data. As with
 # statsd_listen_addresses, these are formatted as URLs, with schemes
@@ -21,6 +22,7 @@ statsd_listen_addresses:
 ssf_listen_addresses:
   - udp://localhost:8128
   - unix:///tmp/veneur-ssf.sock
+  - unix:@veneur-ssf.sock
 
 # TLS
 # These are only useful in conjunction with TCP listening sockets

--- a/protocol/addr.go
+++ b/protocol/addr.go
@@ -22,7 +22,14 @@ func ResolveAddr(str string) (net.Addr, error) {
 	}
 	switch u.Scheme {
 	case "unix", "unixgram", "unixpacket":
-		addr, err := net.ResolveUnixAddr(u.Scheme, u.Path)
+		var path string
+		if u.Opaque != "" {
+			path = u.Opaque
+		} else {
+			path = u.Path
+		}
+
+		addr, err := net.ResolveUnixAddr(u.Scheme, path)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/addr_test.go
+++ b/protocol/addr_test.go
@@ -16,6 +16,7 @@ func TestListenAddr(t *testing.T) {
 		{"tcp://:8200", "tcp", ":8200"},
 		{"tcp6://[::1]:8200", "tcp", "[::1]:8200"},
 		{"unix:///tmp/foo.sock", "unix", "/tmp/foo.sock"},
+		{"unix:@abstract.sock", "unix", "@abstract.sock"},
 		{"unixgram:///tmp/foo.sock", "unixgram", "/tmp/foo.sock"},
 		{"unixpacket:///tmp/foo.sock", "unixpacket", "/tmp/foo.sock"},
 	}

--- a/scopedstatsd/client_test.go
+++ b/scopedstatsd/client_test.go
@@ -1,6 +1,7 @@
 package scopedstatsd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ func TestEnsure(t *testing.T) {
 	var theNilOne Client = nil
 	ensured := Ensure(theNilOne)
 	assert.NotNil(t, ensured)
-	assert.NoError(t, ensured.Count("hi", 0, nil, 1.0))
+	assert.Error(t, errors.New("statsd client is nil"), ensured.Count("hi", 0, nil, 1.0))
 }
 
 func TestDoesSomething(t *testing.T) {
@@ -49,7 +50,7 @@ func TestDoesSomething(t *testing.T) {
 				},
 			}
 			for _, fn := range testFuncs {
-				assert.NoError(t, fn())
+				assert.Error(t, errors.New("statsd client is nil"), fn())
 			}
 		})
 	}

--- a/vendor/github.com/DataDog/datadog-go/statsd/buffer.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/buffer.go
@@ -1,0 +1,130 @@
+package statsd
+
+type bufferFullError string
+
+func (e bufferFullError) Error() string { return string(e) }
+
+const errBufferFull = bufferFullError("statsd buffer is full")
+
+const metricOverhead = 512
+
+// statsdBuffer is a buffer containing statsd messages
+// this struct methods are NOT safe for concurent use
+type statsdBuffer struct {
+	buffer       []byte
+	maxSize      int
+	maxElements  int
+	elementCount int
+}
+
+func newStatsdBuffer(maxSize, maxElements int) *statsdBuffer {
+	return &statsdBuffer{
+		buffer:      make([]byte, 0, maxSize+metricOverhead), // pre-allocate the needed size + metricOverhead to avoid having Go re-allocate on it's own if an element does not fit
+		maxSize:     maxSize,
+		maxElements: maxElements,
+	}
+}
+
+func (b *statsdBuffer) writeGauge(namespace string, globalTags []string, name string, value float64, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendGauge(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeCount(namespace string, globalTags []string, name string, value int64, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendCount(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeHistogram(namespace string, globalTags []string, name string, value float64, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendHistogram(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeDistribution(namespace string, globalTags []string, name string, value float64, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendDistribution(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeSet(namespace string, globalTags []string, name string, value string, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendSet(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeTiming(namespace string, globalTags []string, name string, value float64, tags []string, rate float64) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendTiming(b.buffer, namespace, globalTags, name, value, tags, rate)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeEvent(event Event, globalTags []string) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendEvent(b.buffer, event, globalTags)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) writeServiceCheck(serviceCheck ServiceCheck, globalTags []string) error {
+	if b.elementCount >= b.maxElements {
+		return errBufferFull
+	}
+	originalBuffer := b.buffer
+	b.writeSeparator()
+	b.buffer = appendServiceCheck(b.buffer, serviceCheck, globalTags)
+	return b.validateNewElement(originalBuffer)
+}
+
+func (b *statsdBuffer) validateNewElement(originalBuffer []byte) error {
+	if len(b.buffer) > b.maxSize {
+		b.buffer = originalBuffer
+		return errBufferFull
+	}
+	b.elementCount++
+	return nil
+}
+
+func (b *statsdBuffer) writeSeparator() {
+	if b.elementCount != 0 {
+		b.buffer = appendSeparator(b.buffer)
+	}
+}
+
+func (b *statsdBuffer) reset() {
+	b.buffer = b.buffer[:0]
+	b.elementCount = 0
+}
+
+func (b *statsdBuffer) bytes() []byte {
+	return b.buffer
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/buffer_pool.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/buffer_pool.go
@@ -1,0 +1,40 @@
+package statsd
+
+type bufferPool struct {
+	pool              chan *statsdBuffer
+	bufferMaxSize     int
+	bufferMaxElements int
+}
+
+func newBufferPool(poolSize, bufferMaxSize, bufferMaxElements int) *bufferPool {
+	p := &bufferPool{
+		pool:              make(chan *statsdBuffer, poolSize),
+		bufferMaxSize:     bufferMaxSize,
+		bufferMaxElements: bufferMaxElements,
+	}
+	for i := 0; i < poolSize; i++ {
+		p.addNewBuffer()
+	}
+	return p
+}
+
+func (p *bufferPool) addNewBuffer() {
+	p.pool <- newStatsdBuffer(p.bufferMaxSize, p.bufferMaxElements)
+}
+
+func (p *bufferPool) borrowBuffer() *statsdBuffer {
+	select {
+	case b := <-p.pool:
+		return b
+	default:
+		return newStatsdBuffer(p.bufferMaxSize, p.bufferMaxElements)
+	}
+}
+
+func (p *bufferPool) returnBuffer(buffer *statsdBuffer) {
+	buffer.reset()
+	select {
+	case p.pool <- buffer:
+	default:
+	}
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/event.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/event.go
@@ -1,0 +1,91 @@
+package statsd
+
+import (
+	"fmt"
+	"time"
+)
+
+// Events support
+// EventAlertType and EventAlertPriority became exported types after this issue was submitted: https://github.com/DataDog/datadog-go/issues/41
+// The reason why they got exported is so that client code can directly use the types.
+
+// EventAlertType is the alert type for events
+type EventAlertType string
+
+const (
+	// Info is the "info" AlertType for events
+	Info EventAlertType = "info"
+	// Error is the "error" AlertType for events
+	Error EventAlertType = "error"
+	// Warning is the "warning" AlertType for events
+	Warning EventAlertType = "warning"
+	// Success is the "success" AlertType for events
+	Success EventAlertType = "success"
+)
+
+// EventPriority is the event priority for events
+type EventPriority string
+
+const (
+	// Normal is the "normal" Priority for events
+	Normal EventPriority = "normal"
+	// Low is the "low" Priority for events
+	Low EventPriority = "low"
+)
+
+// An Event is an object that can be posted to your DataDog event stream.
+type Event struct {
+	// Title of the event.  Required.
+	Title string
+	// Text is the description of the event.  Required.
+	Text string
+	// Timestamp is a timestamp for the event.  If not provided, the dogstatsd
+	// server will set this to the current time.
+	Timestamp time.Time
+	// Hostname for the event.
+	Hostname string
+	// AggregationKey groups this event with others of the same key.
+	AggregationKey string
+	// Priority of the event.  Can be statsd.Low or statsd.Normal.
+	Priority EventPriority
+	// SourceTypeName is a source type for the event.
+	SourceTypeName string
+	// AlertType can be statsd.Info, statsd.Error, statsd.Warning, or statsd.Success.
+	// If absent, the default value applied by the dogstatsd server is Info.
+	AlertType EventAlertType
+	// Tags for the event.
+	Tags []string
+}
+
+// NewEvent creates a new event with the given title and text.  Error checking
+// against these values is done at send-time, or upon running e.Check.
+func NewEvent(title, text string) *Event {
+	return &Event{
+		Title: title,
+		Text:  text,
+	}
+}
+
+// Check verifies that an event is valid.
+func (e Event) Check() error {
+	if len(e.Title) == 0 {
+		return fmt.Errorf("statsd.Event title is required")
+	}
+	if len(e.Text) == 0 {
+		return fmt.Errorf("statsd.Event text is required")
+	}
+	return nil
+}
+
+// Encode returns the dogstatsd wire protocol representation for an event.
+// Tags may be passed which will be added to the encoded output but not to
+// the Event's list of tags, eg. for default tags.
+func (e Event) Encode(tags ...string) (string, error) {
+	err := e.Check()
+	if err != nil {
+		return "", err
+	}
+	var buffer []byte
+	buffer = appendEvent(buffer, e, tags)
+	return string(buffer), nil
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/format.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/format.go
@@ -1,0 +1,232 @@
+package statsd
+
+import (
+	"strconv"
+	"strings"
+)
+
+var (
+	gaugeSymbol        = []byte("g")
+	countSymbol        = []byte("c")
+	histogramSymbol    = []byte("h")
+	distributionSymbol = []byte("d")
+	setSymbol          = []byte("s")
+	timingSymbol       = []byte("ms")
+)
+
+func appendHeader(buffer []byte, namespace string, name string) []byte {
+	if namespace != "" {
+		buffer = append(buffer, namespace...)
+	}
+	buffer = append(buffer, name...)
+	buffer = append(buffer, ':')
+	return buffer
+}
+
+func appendRate(buffer []byte, rate float64) []byte {
+	if rate < 1 {
+		buffer = append(buffer, "|@"...)
+		buffer = strconv.AppendFloat(buffer, rate, 'f', -1, 64)
+	}
+	return buffer
+}
+
+func appendWithoutNewlines(buffer []byte, s string) []byte {
+	// fastpath for strings without newlines
+	if strings.IndexByte(s, '\n') == -1 {
+		return append(buffer, s...)
+	}
+
+	for _, b := range []byte(s) {
+		if b != '\n' {
+			buffer = append(buffer, b)
+		}
+	}
+	return buffer
+}
+
+func appendTags(buffer []byte, globalTags []string, tags []string) []byte {
+	if len(globalTags) == 0 && len(tags) == 0 {
+		return buffer
+	}
+	buffer = append(buffer, "|#"...)
+	firstTag := true
+
+	for _, tag := range globalTags {
+		if !firstTag {
+			buffer = append(buffer, ',')
+		}
+		buffer = appendWithoutNewlines(buffer, tag)
+		firstTag = false
+	}
+	for _, tag := range tags {
+		if !firstTag {
+			buffer = append(buffer, ',')
+		}
+		buffer = appendWithoutNewlines(buffer, tag)
+		firstTag = false
+	}
+	return buffer
+}
+
+func appendFloatMetric(buffer []byte, typeSymbol []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64, precision int) []byte {
+	buffer = appendHeader(buffer, namespace, name)
+	buffer = strconv.AppendFloat(buffer, value, 'f', precision, 64)
+	buffer = append(buffer, '|')
+	buffer = append(buffer, typeSymbol...)
+	buffer = appendRate(buffer, rate)
+	buffer = appendTags(buffer, globalTags, tags)
+	return buffer
+}
+
+func appendIntegerMetric(buffer []byte, typeSymbol []byte, namespace string, globalTags []string, name string, value int64, tags []string, rate float64) []byte {
+	buffer = appendHeader(buffer, namespace, name)
+	buffer = strconv.AppendInt(buffer, value, 10)
+	buffer = append(buffer, '|')
+	buffer = append(buffer, typeSymbol...)
+	buffer = appendRate(buffer, rate)
+	buffer = appendTags(buffer, globalTags, tags)
+	return buffer
+}
+
+func appendStringMetric(buffer []byte, typeSymbol []byte, namespace string, globalTags []string, name string, value string, tags []string, rate float64) []byte {
+	buffer = appendHeader(buffer, namespace, name)
+	buffer = append(buffer, value...)
+	buffer = append(buffer, '|')
+	buffer = append(buffer, typeSymbol...)
+	buffer = appendRate(buffer, rate)
+	buffer = appendTags(buffer, globalTags, tags)
+	return buffer
+}
+
+func appendGauge(buffer []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64) []byte {
+	return appendFloatMetric(buffer, gaugeSymbol, namespace, globalTags, name, value, tags, rate, -1)
+}
+
+func appendCount(buffer []byte, namespace string, globalTags []string, name string, value int64, tags []string, rate float64) []byte {
+	return appendIntegerMetric(buffer, countSymbol, namespace, globalTags, name, value, tags, rate)
+}
+
+func appendHistogram(buffer []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64) []byte {
+	return appendFloatMetric(buffer, histogramSymbol, namespace, globalTags, name, value, tags, rate, -1)
+}
+
+func appendDistribution(buffer []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64) []byte {
+	return appendFloatMetric(buffer, distributionSymbol, namespace, globalTags, name, value, tags, rate, -1)
+}
+
+func appendSet(buffer []byte, namespace string, globalTags []string, name string, value string, tags []string, rate float64) []byte {
+	return appendStringMetric(buffer, setSymbol, namespace, globalTags, name, value, tags, rate)
+}
+
+func appendTiming(buffer []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64) []byte {
+	return appendFloatMetric(buffer, timingSymbol, namespace, globalTags, name, value, tags, rate, 6)
+}
+
+func escapedEventTextLen(text string) int {
+	return len(text) + strings.Count(text, "\n")
+}
+
+func appendEscapedEventText(buffer []byte, text string) []byte {
+	for _, b := range []byte(text) {
+		if b != '\n' {
+			buffer = append(buffer, b)
+		} else {
+			buffer = append(buffer, "\\n"...)
+		}
+	}
+	return buffer
+}
+
+func appendEvent(buffer []byte, event Event, globalTags []string) []byte {
+	escapedTextLen := escapedEventTextLen(event.Text)
+
+	buffer = append(buffer, "_e{"...)
+	buffer = strconv.AppendInt(buffer, int64(len(event.Title)), 10)
+	buffer = append(buffer, ',')
+	buffer = strconv.AppendInt(buffer, int64(escapedTextLen), 10)
+	buffer = append(buffer, "}:"...)
+	buffer = append(buffer, event.Title...)
+	buffer = append(buffer, '|')
+	if escapedTextLen != len(event.Text) {
+		buffer = appendEscapedEventText(buffer, event.Text)
+	} else {
+		buffer = append(buffer, event.Text...)
+	}
+
+	if !event.Timestamp.IsZero() {
+		buffer = append(buffer, "|d:"...)
+		buffer = strconv.AppendInt(buffer, int64(event.Timestamp.Unix()), 10)
+	}
+
+	if len(event.Hostname) != 0 {
+		buffer = append(buffer, "|h:"...)
+		buffer = append(buffer, event.Hostname...)
+	}
+
+	if len(event.AggregationKey) != 0 {
+		buffer = append(buffer, "|k:"...)
+		buffer = append(buffer, event.AggregationKey...)
+	}
+
+	if len(event.Priority) != 0 {
+		buffer = append(buffer, "|p:"...)
+		buffer = append(buffer, event.Priority...)
+	}
+
+	if len(event.SourceTypeName) != 0 {
+		buffer = append(buffer, "|s:"...)
+		buffer = append(buffer, event.SourceTypeName...)
+	}
+
+	if len(event.AlertType) != 0 {
+		buffer = append(buffer, "|t:"...)
+		buffer = append(buffer, string(event.AlertType)...)
+	}
+
+	buffer = appendTags(buffer, globalTags, event.Tags)
+	return buffer
+}
+
+func appendEscapedServiceCheckText(buffer []byte, text string) []byte {
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\n' {
+			buffer = append(buffer, "\\n"...)
+		} else if text[i] == 'm' && i+1 < len(text) && text[i+1] == ':' {
+			buffer = append(buffer, "m\\:"...)
+			i++
+		} else {
+			buffer = append(buffer, text[i])
+		}
+	}
+	return buffer
+}
+
+func appendServiceCheck(buffer []byte, serviceCheck ServiceCheck, globalTags []string) []byte {
+	buffer = append(buffer, "_sc|"...)
+	buffer = append(buffer, serviceCheck.Name...)
+	buffer = append(buffer, '|')
+	buffer = strconv.AppendInt(buffer, int64(serviceCheck.Status), 10)
+
+	if !serviceCheck.Timestamp.IsZero() {
+		buffer = append(buffer, "|d:"...)
+		buffer = strconv.AppendInt(buffer, int64(serviceCheck.Timestamp.Unix()), 10)
+	}
+
+	if len(serviceCheck.Hostname) != 0 {
+		buffer = append(buffer, "|h:"...)
+		buffer = append(buffer, serviceCheck.Hostname...)
+	}
+
+	buffer = appendTags(buffer, globalTags, serviceCheck.Tags)
+
+	if len(serviceCheck.Message) != 0 {
+		buffer = append(buffer, "|m:"...)
+		buffer = appendEscapedServiceCheckText(buffer, serviceCheck.Message)
+	}
+	return buffer
+}
+
+func appendSeparator(buffer []byte) []byte {
+	return append(buffer, '\n')
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/noop.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/noop.go
@@ -1,0 +1,91 @@
+package statsd
+
+import "time"
+
+// NoOpClient is a statsd client that does nothing. Can be useful in testing
+// situations for library users.
+type NoOpClient struct{}
+
+// Gauge does nothing and returns nil
+func (n *NoOpClient) Gauge(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+// Count does nothing and returns nil
+func (n *NoOpClient) Count(name string, value int64, tags []string, rate float64) error {
+	return nil
+}
+
+// Histogram does nothing and returns nil
+func (n *NoOpClient) Histogram(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+// Distribution does nothing and returns nil
+func (n *NoOpClient) Distribution(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+// Decr does nothing and returns nil
+func (n *NoOpClient) Decr(name string, tags []string, rate float64) error {
+	return nil
+}
+
+// Incr does nothing and returns nil
+func (n *NoOpClient) Incr(name string, tags []string, rate float64) error {
+	return nil
+}
+
+// Set does nothing and returns nil
+func (n *NoOpClient) Set(name string, value string, tags []string, rate float64) error {
+	return nil
+}
+
+// Timing does nothing and returns nil
+func (n *NoOpClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return nil
+}
+
+// TimeInMilliseconds does nothing and returns nil
+func (n *NoOpClient) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+// Event does nothing and returns nil
+func (n *NoOpClient) Event(e *Event) error {
+	return nil
+}
+
+// SimpleEvent does nothing and returns nil
+func (n *NoOpClient) SimpleEvent(title, text string) error {
+	return nil
+}
+
+// ServiceCheck does nothing and returns nil
+func (n *NoOpClient) ServiceCheck(sc *ServiceCheck) error {
+	return nil
+}
+
+// SimpleServiceCheck does nothing and returns nil
+func (n *NoOpClient) SimpleServiceCheck(name string, status ServiceCheckStatus) error {
+	return nil
+}
+
+// Close does nothing and returns nil
+func (n *NoOpClient) Close() error {
+	return nil
+}
+
+// Flush does nothing and returns nil
+func (n *NoOpClient) Flush() error {
+	return nil
+}
+
+// SetWriteTimeout does nothing and returns nil
+func (n *NoOpClient) SetWriteTimeout(d time.Duration) error {
+	return nil
+}
+
+// Verify that NoOpClient implements the ClientInterface.
+// https://golang.org/doc/faq#guarantee_satisfies_interface
+var _ ClientInterface = &NoOpClient{}

--- a/vendor/github.com/DataDog/datadog-go/statsd/options.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/options.go
@@ -1,0 +1,155 @@
+package statsd
+
+import (
+	"math"
+	"time"
+)
+
+var (
+	// DefaultNamespace is the default value for the Namespace option
+	DefaultNamespace = ""
+	// DefaultTags is the default value for the Tags option
+	DefaultTags = []string{}
+	// DefaultMaxBytesPerPayload is the default value for the MaxBytesPerPayload option
+	DefaultMaxBytesPerPayload = 0
+	// DefaultMaxMessagesPerPayload is the default value for the MaxMessagesPerPayload option
+	DefaultMaxMessagesPerPayload = math.MaxInt32
+	// DefaultBufferPoolSize is the default value for the DefaultBufferPoolSize option
+	DefaultBufferPoolSize = 0
+	// DefaultBufferFlushInterval is the default value for the BufferFlushInterval option
+	DefaultBufferFlushInterval = 100 * time.Millisecond
+	// DefaultSenderQueueSize is the default value for the DefaultSenderQueueSize option
+	DefaultSenderQueueSize = 0
+	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
+	DefaultWriteTimeoutUDS = 1 * time.Millisecond
+	// DefaultTelemetry is the default value for the Telemetry option
+	DefaultTelemetry = true
+)
+
+// Options contains the configuration options for a client.
+type Options struct {
+	// Namespace to prepend to all metrics, events and service checks name.
+	Namespace string
+	// Tags are global tags to be applied to every metrics, events and service checks.
+	Tags []string
+	// MaxBytesPerPayload is the maximum number of bytes a single payload will contain.
+	// The magic value 0 will set the option to the optimal size for the transport
+	// protocol used when creating the client: 1432 for UDP and 8192 for UDS.
+	MaxBytesPerPayload int
+	// MaxMessagesPerPayload is the maximum number of metrics, events and/or service checks a single payload will contain.
+	// This option can be set to `1` to create an unbuffered client.
+	MaxMessagesPerPayload int
+	// BufferPoolSize is the size of the pool of buffers in number of buffers.
+	// The magic value 0 will set the option to the optimal size for the transport
+	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
+	BufferPoolSize int
+	// BufferFlushInterval is the interval after which the current buffer will get flushed.
+	BufferFlushInterval time.Duration
+	// SenderQueueSize is the size of the sender queue in number of buffers.
+	// The magic value 0 will set the option to the optimal size for the transport
+	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
+	SenderQueueSize int
+	// WriteTimeoutUDS is the timeout after which a UDS packet is dropped.
+	WriteTimeoutUDS time.Duration
+	// Telemetry is a set of metrics automatically injected by the client in the
+	// dogstatsd stream to be able to monitor the client itself.
+	Telemetry bool
+}
+
+func resolveOptions(options []Option) (*Options, error) {
+	o := &Options{
+		Namespace:             DefaultNamespace,
+		Tags:                  DefaultTags,
+		MaxBytesPerPayload:    DefaultMaxBytesPerPayload,
+		MaxMessagesPerPayload: DefaultMaxMessagesPerPayload,
+		BufferPoolSize:        DefaultBufferPoolSize,
+		BufferFlushInterval:   DefaultBufferFlushInterval,
+		SenderQueueSize:       DefaultSenderQueueSize,
+		WriteTimeoutUDS:       DefaultWriteTimeoutUDS,
+		Telemetry:             DefaultTelemetry,
+	}
+
+	for _, option := range options {
+		err := option(o)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return o, nil
+}
+
+// Option is a client option. Can return an error if validation fails.
+type Option func(*Options) error
+
+// WithNamespace sets the Namespace option.
+func WithNamespace(namespace string) Option {
+	return func(o *Options) error {
+		o.Namespace = namespace
+		return nil
+	}
+}
+
+// WithTags sets the Tags option.
+func WithTags(tags []string) Option {
+	return func(o *Options) error {
+		o.Tags = tags
+		return nil
+	}
+}
+
+// WithMaxMessagesPerPayload sets the MaxMessagesPerPayload option.
+func WithMaxMessagesPerPayload(maxMessagesPerPayload int) Option {
+	return func(o *Options) error {
+		o.MaxMessagesPerPayload = maxMessagesPerPayload
+		return nil
+	}
+}
+
+// WithMaxBytesPerPayload sets the MaxBytesPerPayload option.
+func WithMaxBytesPerPayload(MaxBytesPerPayload int) Option {
+	return func(o *Options) error {
+		o.MaxBytesPerPayload = MaxBytesPerPayload
+		return nil
+	}
+}
+
+// WithBufferPoolSize sets the BufferPoolSize option.
+func WithBufferPoolSize(bufferPoolSize int) Option {
+	return func(o *Options) error {
+		o.BufferPoolSize = bufferPoolSize
+		return nil
+	}
+}
+
+// WithBufferFlushInterval sets the BufferFlushInterval option.
+func WithBufferFlushInterval(bufferFlushInterval time.Duration) Option {
+	return func(o *Options) error {
+		o.BufferFlushInterval = bufferFlushInterval
+		return nil
+	}
+}
+
+// WithSenderQueueSize sets the SenderQueueSize option.
+func WithSenderQueueSize(senderQueueSize int) Option {
+	return func(o *Options) error {
+		o.SenderQueueSize = senderQueueSize
+		return nil
+	}
+}
+
+// WithWriteTimeoutUDS sets the WriteTimeoutUDS option.
+func WithWriteTimeoutUDS(writeTimeoutUDS time.Duration) Option {
+	return func(o *Options) error {
+		o.WriteTimeoutUDS = writeTimeoutUDS
+		return nil
+	}
+}
+
+// WithoutTelemetry disables the telemetry
+func WithoutTelemetry() Option {
+	return func(o *Options) error {
+		o.Telemetry = false
+		return nil
+	}
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/sender.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/sender.go
@@ -1,0 +1,118 @@
+package statsd
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// A statsdWriter offers a standard interface regardless of the underlying
+// protocol. For now UDS and UPD writers are available.
+// Attention: the underlying buffer of `data` is reused after a `statsdWriter.Write` call.
+// `statsdWriter.Write` must be synchronous.
+type statsdWriter interface {
+	Write(data []byte) (n int, err error)
+	SetWriteTimeout(time.Duration) error
+	Close() error
+}
+
+// SenderMetrics contains metrics about the health of the sender
+type SenderMetrics struct {
+	TotalSentBytes                uint64
+	TotalSentPayloads             uint64
+	TotalDroppedPayloads          uint64
+	TotalDroppedBytes             uint64
+	TotalDroppedPayloadsQueueFull uint64
+	TotalDroppedBytesQueueFull    uint64
+	TotalDroppedPayloadsWriter    uint64
+	TotalDroppedBytesWriter       uint64
+}
+
+type sender struct {
+	transport statsdWriter
+	pool      *bufferPool
+	queue     chan *statsdBuffer
+	metrics   SenderMetrics
+	stop      chan struct{}
+}
+
+func newSender(transport statsdWriter, queueSize int, pool *bufferPool) *sender {
+	sender := &sender{
+		transport: transport,
+		pool:      pool,
+		queue:     make(chan *statsdBuffer, queueSize),
+		stop:      make(chan struct{}),
+	}
+
+	go sender.sendLoop()
+	return sender
+}
+
+func (s *sender) send(buffer *statsdBuffer) {
+	select {
+	case s.queue <- buffer:
+	default:
+		atomic.AddUint64(&s.metrics.TotalDroppedPayloads, 1)
+		atomic.AddUint64(&s.metrics.TotalDroppedBytes, uint64(len(buffer.bytes())))
+		atomic.AddUint64(&s.metrics.TotalDroppedPayloadsQueueFull, 1)
+		atomic.AddUint64(&s.metrics.TotalDroppedBytesQueueFull, uint64(len(buffer.bytes())))
+		s.pool.returnBuffer(buffer)
+	}
+}
+
+func (s *sender) write(buffer *statsdBuffer) {
+	_, err := s.transport.Write(buffer.bytes())
+	if err != nil {
+		atomic.AddUint64(&s.metrics.TotalDroppedPayloads, 1)
+		atomic.AddUint64(&s.metrics.TotalDroppedBytes, uint64(len(buffer.bytes())))
+		atomic.AddUint64(&s.metrics.TotalDroppedPayloadsWriter, 1)
+		atomic.AddUint64(&s.metrics.TotalDroppedBytesWriter, uint64(len(buffer.bytes())))
+	} else {
+		atomic.AddUint64(&s.metrics.TotalSentPayloads, 1)
+		atomic.AddUint64(&s.metrics.TotalSentBytes, uint64(len(buffer.bytes())))
+	}
+	s.pool.returnBuffer(buffer)
+}
+
+func (s *sender) flushMetrics() SenderMetrics {
+	return SenderMetrics{
+		TotalSentBytes:                atomic.SwapUint64(&s.metrics.TotalSentBytes, 0),
+		TotalSentPayloads:             atomic.SwapUint64(&s.metrics.TotalSentPayloads, 0),
+		TotalDroppedPayloads:          atomic.SwapUint64(&s.metrics.TotalDroppedPayloads, 0),
+		TotalDroppedBytes:             atomic.SwapUint64(&s.metrics.TotalDroppedBytes, 0),
+		TotalDroppedPayloadsQueueFull: atomic.SwapUint64(&s.metrics.TotalDroppedPayloadsQueueFull, 0),
+		TotalDroppedBytesQueueFull:    atomic.SwapUint64(&s.metrics.TotalDroppedBytesQueueFull, 0),
+		TotalDroppedPayloadsWriter:    atomic.SwapUint64(&s.metrics.TotalDroppedPayloadsWriter, 0),
+		TotalDroppedBytesWriter:       atomic.SwapUint64(&s.metrics.TotalDroppedBytesWriter, 0),
+	}
+}
+
+func (s *sender) sendLoop() {
+	defer close(s.stop)
+	for {
+		select {
+		case buffer := <-s.queue:
+			s.write(buffer)
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+func (s *sender) flush() {
+	for {
+		select {
+		case buffer := <-s.queue:
+			s.write(buffer)
+		default:
+			return
+		}
+	}
+}
+
+func (s *sender) close() error {
+	s.flush()
+	err := s.transport.Close()
+	s.stop <- struct{}{}
+	<-s.stop
+	return err
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/service_check.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/service_check.go
@@ -1,0 +1,70 @@
+package statsd
+
+import (
+	"fmt"
+	"time"
+)
+
+// ServiceCheckStatus support
+type ServiceCheckStatus byte
+
+const (
+	// Ok is the "ok" ServiceCheck status
+	Ok ServiceCheckStatus = 0
+	// Warn is the "warning" ServiceCheck status
+	Warn ServiceCheckStatus = 1
+	// Critical is the "critical" ServiceCheck status
+	Critical ServiceCheckStatus = 2
+	// Unknown is the "unknown" ServiceCheck status
+	Unknown ServiceCheckStatus = 3
+)
+
+// A ServiceCheck is an object that contains status of DataDog service check.
+type ServiceCheck struct {
+	// Name of the service check.  Required.
+	Name string
+	// Status of service check.  Required.
+	Status ServiceCheckStatus
+	// Timestamp is a timestamp for the serviceCheck.  If not provided, the dogstatsd
+	// server will set this to the current time.
+	Timestamp time.Time
+	// Hostname for the serviceCheck.
+	Hostname string
+	// A message describing the current state of the serviceCheck.
+	Message string
+	// Tags for the serviceCheck.
+	Tags []string
+}
+
+// NewServiceCheck creates a new serviceCheck with the given name and status. Error checking
+// against these values is done at send-time, or upon running sc.Check.
+func NewServiceCheck(name string, status ServiceCheckStatus) *ServiceCheck {
+	return &ServiceCheck{
+		Name:   name,
+		Status: status,
+	}
+}
+
+// Check verifies that a service check is valid.
+func (sc ServiceCheck) Check() error {
+	if len(sc.Name) == 0 {
+		return fmt.Errorf("statsd.ServiceCheck name is required")
+	}
+	if byte(sc.Status) < 0 || byte(sc.Status) > 3 {
+		return fmt.Errorf("statsd.ServiceCheck status has invalid value")
+	}
+	return nil
+}
+
+// Encode returns the dogstatsd wire protocol representation for a service check.
+// Tags may be passed which will be added to the encoded output but not to
+// the Service Check's list of tags, eg. for default tags.
+func (sc ServiceCheck) Encode(tags ...string) (string, error) {
+	err := sc.Check()
+	if err != nil {
+		return "", err
+	}
+	var buffer []byte
+	buffer = appendServiceCheck(buffer, sc, tags)
+	return string(buffer), nil
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
@@ -24,27 +24,22 @@ statsd is based on go-statsd-client.
 package statsd
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"io"
 	"math/rand"
-	"strconv"
+	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 /*
-OptimalPayloadSize defines the optimal payload size for a UDP datagram, 1432 bytes
+OptimalUDPPayloadSize defines the optimal payload size for a UDP datagram, 1432 bytes
 is optimal for regular networks with an MTU of 1500 so datagrams don't get
 fragmented. It's generally recommended not to fragment UDP datagrams as losing
 a single fragment will cause the entire datagram to be lost.
-
-This can be increased if your network has a greater MTU or you don't mind UDP
-datagrams getting fragmented. The practical limit is MaxUDPPayloadSize
 */
-const OptimalPayloadSize = 1432
+const OptimalUDPPayloadSize = 1432
 
 /*
 MaxUDPPayloadSize defines the maximum payload size for a UDP datagram.
@@ -54,6 +49,34 @@ any number greater than that will see frames being cut out.
 */
 const MaxUDPPayloadSize = 65467
 
+// DefaultUDPBufferPoolSize is the default size of the buffer pool for UDP clients.
+const DefaultUDPBufferPoolSize = 2048
+
+// DefaultUDSBufferPoolSize is the default size of the buffer pool for UDS clients.
+const DefaultUDSBufferPoolSize = 512
+
+/*
+DefaultMaxAgentPayloadSize is the default maximum payload size the agent
+can receive. This can be adjusted by changing dogstatsd_buffer_size in the
+agent configuration file datadog.yaml.
+*/
+const DefaultMaxAgentPayloadSize = 8192
+
+/*
+TelemetryInterval is the interval at which telemetry will be sent by the client.
+*/
+const TelemetryInterval = 10 * time.Second
+
+/*
+clientTelemetryTag is a tag identifying this specific client.
+*/
+var clientTelemetryTag = "client:go"
+
+/*
+clientVersionTelemetryTag is a tag identifying this specific client version.
+*/
+var clientVersionTelemetryTag = "client_version:3.5.0"
+
 /*
 UnixAddressPrefix holds the prefix to use to enable Unix Domain Socket
 traffic instead of UDP.
@@ -61,127 +84,255 @@ traffic instead of UDP.
 const UnixAddressPrefix = "unix://"
 
 /*
-Stat suffixes
+ddEnvTagsMapping is a mapping of each "DD_" prefixed environment variable
+to a specific tag name.
 */
-var (
-	gaugeSuffix        = []byte("|g")
-	countSuffix        = []byte("|c")
-	histogramSuffix    = []byte("|h")
-	distributionSuffix = []byte("|d")
-	decrSuffix         = []byte("-1|c")
-	incrSuffix         = []byte("1|c")
-	setSuffix          = []byte("|s")
-	timingSuffix       = []byte("|ms")
+var ddEnvTagsMapping = map[string]string{
+	// Client-side entity ID injection for container tagging.
+	"DD_ENTITY_ID": "dd.internal.entity_id",
+	// The name of the env in which the service runs.
+	"DD_ENV": "env",
+	// The name of the running service.
+	"DD_SERVICE": "service",
+	// The current version of the running service.
+	"DD_VERSION": "version",
+}
+
+type metricType int
+
+const (
+	gauge metricType = iota
+	count
+	histogram
+	distribution
+	set
+	timing
+	event
+	serviceCheck
 )
 
-// A statsdWriter offers a standard interface regardless of the underlying
-// protocol. For now UDS and UPD writers are available.
-type statsdWriter interface {
-	Write(data []byte) (n int, err error)
-	SetWriteTimeout(time.Duration) error
+type metric struct {
+	metricType metricType
+	namespace  string
+	globalTags []string
+	name       string
+	fvalue     float64
+	ivalue     int64
+	svalue     string
+	evalue     *Event
+	scvalue    *ServiceCheck
+	tags       []string
+	rate       float64
+}
+
+type noClientErr string
+
+// ErrNoClient is returned if statsd reporting methods are invoked on
+// a nil client.
+const ErrNoClient = noClientErr("statsd client is nil")
+
+func (e noClientErr) Error() string {
+	return string(e)
+}
+
+// ClientInterface is an interface that exposes the common client functions for the
+// purpose of being able to provide a no-op client or even mocking. This can aid
+// downstream users' with their testing.
+type ClientInterface interface {
+	// Gauge measures the value of a metric at a particular time.
+	Gauge(name string, value float64, tags []string, rate float64) error
+
+	// Count tracks how many times something happened per second.
+	Count(name string, value int64, tags []string, rate float64) error
+
+	// Histogram tracks the statistical distribution of a set of values on each host.
+	Histogram(name string, value float64, tags []string, rate float64) error
+
+	// Distribution tracks the statistical distribution of a set of values across your infrastructure.
+	Distribution(name string, value float64, tags []string, rate float64) error
+
+	// Decr is just Count of -1
+	Decr(name string, tags []string, rate float64) error
+
+	// Incr is just Count of 1
+	Incr(name string, tags []string, rate float64) error
+
+	// Set counts the number of unique elements in a group.
+	Set(name string, value string, tags []string, rate float64) error
+
+	// Timing sends timing information, it is an alias for TimeInMilliseconds
+	Timing(name string, value time.Duration, tags []string, rate float64) error
+
+	// TimeInMilliseconds sends timing information in milliseconds.
+	// It is flushed by statsd with percentiles, mean and other info (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing)
+	TimeInMilliseconds(name string, value float64, tags []string, rate float64) error
+
+	// Event sends the provided Event.
+	Event(e *Event) error
+
+	// SimpleEvent sends an event with the provided title and text.
+	SimpleEvent(title, text string) error
+
+	// ServiceCheck sends the provided ServiceCheck.
+	ServiceCheck(sc *ServiceCheck) error
+
+	// SimpleServiceCheck sends an serviceCheck with the provided name and status.
+	SimpleServiceCheck(name string, status ServiceCheckStatus) error
+
+	// Close the client connection.
 	Close() error
+
+	// Flush forces a flush of all the queued dogstatsd payloads.
+	Flush() error
+
+	// SetWriteTimeout allows the user to set a custom write timeout.
+	SetWriteTimeout(d time.Duration) error
 }
 
 // A Client is a handle for sending messages to dogstatsd.  It is safe to
 // use one Client from multiple goroutines simultaneously.
 type Client struct {
-	// Writer handles the underlying networking protocol
-	writer statsdWriter
+	// Sender handles the underlying networking protocol
+	sender *sender
 	// Namespace to prepend to all statsd calls
 	Namespace string
 	// Tags are global tags to be added to every statsd call
 	Tags []string
 	// skipErrors turns off error passing and allows UDS to emulate UDP behaviour
-	SkipErrors bool
-	// BufferLength is the length of the buffer in commands.
-	bufferLength int
-	flushTime    time.Duration
-	commands     []string
-	buffer       bytes.Buffer
-	stop         chan struct{}
+	SkipErrors    bool
+	flushTime     time.Duration
+	bufferPool    *bufferPool
+	buffer        *statsdBuffer
+	metrics       ClientMetrics
+	telemetryTags []string
+	stop          chan struct{}
+	wg            sync.WaitGroup
 	sync.Mutex
+	closerLock sync.Mutex
 }
+
+// ClientMetrics contains metrics about the client
+type ClientMetrics struct {
+	TotalMetrics       uint64
+	TotalEvents        uint64
+	TotalServiceChecks uint64
+}
+
+// Verify that Client implements the ClientInterface.
+// https://golang.org/doc/faq#guarantee_satisfies_interface
+var _ ClientInterface = &Client{}
 
 // New returns a pointer to a new Client given an addr in the format "hostname:port" or
 // "unix:///path/to/socket".
-func New(addr string) (*Client, error) {
-	if strings.HasPrefix(addr, UnixAddressPrefix) {
-		w, err := newUdsWriter(addr[len(UnixAddressPrefix)-1:])
-		if err != nil {
-			return nil, err
-		}
-		return NewWithWriter(w)
-	}
-	w, err := newUDPWriter(addr)
+func New(addr string, options ...Option) (*Client, error) {
+	var w statsdWriter
+	o, err := resolveOptions(options)
 	if err != nil {
 		return nil, err
 	}
-	return NewWithWriter(w)
+
+	var writerType string
+	optimalPayloadSize := OptimalUDPPayloadSize
+	defaultBufferPoolSize := DefaultUDPBufferPoolSize
+	if !strings.HasPrefix(addr, UnixAddressPrefix) {
+		w, err = newUDPWriter(addr)
+		writerType = "udp"
+	} else {
+		// FIXME: The agent has a performance pitfall preventing us from using better defaults here.
+		// Once it's fixed, use `DefaultMaxAgentPayloadSize` and `DefaultUDSBufferPoolSize` instead.
+		optimalPayloadSize = OptimalUDPPayloadSize
+		defaultBufferPoolSize = DefaultUDPBufferPoolSize
+		w, err = newUDSWriter(addr[len(UnixAddressPrefix):])
+		writerType = "uds"
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if o.MaxBytesPerPayload == 0 {
+		o.MaxBytesPerPayload = optimalPayloadSize
+	}
+	if o.BufferPoolSize == 0 {
+		o.BufferPoolSize = defaultBufferPoolSize
+	}
+	if o.SenderQueueSize == 0 {
+		o.SenderQueueSize = defaultBufferPoolSize
+	}
+	return newWithWriter(w, o, writerType)
 }
 
 // NewWithWriter creates a new Client with given writer. Writer is a
 // io.WriteCloser + SetWriteTimeout(time.Duration) error
-func NewWithWriter(w statsdWriter) (*Client, error) {
-	client := &Client{writer: w, SkipErrors: false}
-	return client, nil
+func NewWithWriter(w statsdWriter, options ...Option) (*Client, error) {
+	o, err := resolveOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	return newWithWriter(w, o, "custom")
+}
+
+func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, error) {
+
+	w.SetWriteTimeout(o.WriteTimeoutUDS)
+
+	c := Client{
+		Namespace:     o.Namespace,
+		Tags:          o.Tags,
+		telemetryTags: []string{clientTelemetryTag, clientVersionTelemetryTag, "client_transport:" + writerName},
+	}
+
+	// Inject values of DD_* environment variables as global tags.
+	for envName, tagName := range ddEnvTagsMapping {
+		if value := os.Getenv(envName); value != "" {
+			c.Tags = append(c.Tags, fmt.Sprintf("%s:%s", tagName, value))
+		}
+	}
+
+	if o.MaxBytesPerPayload == 0 {
+		o.MaxBytesPerPayload = OptimalUDPPayloadSize
+	}
+	if o.BufferPoolSize == 0 {
+		o.BufferPoolSize = DefaultUDPBufferPoolSize
+	}
+	if o.SenderQueueSize == 0 {
+		o.SenderQueueSize = DefaultUDPBufferPoolSize
+	}
+
+	c.bufferPool = newBufferPool(o.BufferPoolSize, o.MaxBytesPerPayload, o.MaxMessagesPerPayload)
+	c.buffer = c.bufferPool.borrowBuffer()
+	c.sender = newSender(w, o.SenderQueueSize, c.bufferPool)
+	c.flushTime = o.BufferFlushInterval
+	c.stop = make(chan struct{}, 1)
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.watch()
+	}()
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		if o.Telemetry {
+			c.telemetry()
+		}
+	}()
+	return &c, nil
 }
 
 // NewBuffered returns a Client that buffers its output and sends it in chunks.
 // Buflen is the length of the buffer in number of commands.
+//
+// When addr is empty, the client will default to a UDP client and use the DD_AGENT_HOST
+// and (optionally) the DD_DOGSTATSD_PORT environment variables to build the target address.
 func NewBuffered(addr string, buflen int) (*Client, error) {
-	client, err := New(addr)
-	if err != nil {
-		return nil, err
-	}
-	client.bufferLength = buflen
-	client.commands = make([]string, 0, buflen)
-	client.flushTime = time.Millisecond * 100
-	client.stop = make(chan struct{}, 1)
-	go client.watch()
-	return client, nil
-}
-
-// format a message from its name, value, tags and rate.  Also adds global
-// namespace and tags.
-func (c *Client) format(name string, value interface{}, suffix []byte, tags []string, rate float64) string {
-	var buf bytes.Buffer
-	if c.Namespace != "" {
-		buf.WriteString(c.Namespace)
-	}
-	buf.WriteString(name)
-	buf.WriteString(":")
-
-	switch val := value.(type) {
-	case float64:
-		buf.Write(strconv.AppendFloat([]byte{}, val, 'f', 6, 64))
-
-	case int64:
-		buf.Write(strconv.AppendInt([]byte{}, val, 10))
-
-	case string:
-		buf.WriteString(val)
-
-	default:
-		// do nothing
-	}
-	buf.Write(suffix)
-
-	if rate < 1 {
-		buf.WriteString(`|@`)
-		buf.WriteString(strconv.FormatFloat(rate, 'f', -1, 64))
-	}
-
-	writeTagString(&buf, c.Tags, tags)
-
-	return buf.String()
+	return New(addr, WithMaxMessagesPerPayload(buflen))
 }
 
 // SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP.
 func (c *Client) SetWriteTimeout(d time.Duration) error {
 	if c == nil {
-		return nil
+		return ErrNoClient
 	}
-	return c.writer.SetWriteTimeout(d)
+	return c.sender.transport.SetWriteTimeout(d)
 }
 
 func (c *Client) watch() {
@@ -191,10 +342,7 @@ func (c *Client) watch() {
 		select {
 		case <-ticker.C:
 			c.Lock()
-			if len(c.commands) > 0 {
-				// FIXME: eating error here
-				c.flushLocked()
-			}
+			c.flushUnsafe()
 			c.Unlock()
 		case <-c.stop:
 			ticker.Stop()
@@ -203,165 +351,169 @@ func (c *Client) watch() {
 	}
 }
 
-func (c *Client) append(cmd string) error {
+func (c *Client) telemetry() {
+	ticker := time.NewTicker(TelemetryInterval)
+	for {
+		select {
+		case <-ticker.C:
+			clientMetrics := c.flushMetrics()
+			c.telemetryCount("datadog.dogstatsd.client.metrics", int64(clientMetrics.TotalMetrics), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.events", int64(clientMetrics.TotalEvents), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.service_checks", int64(clientMetrics.TotalServiceChecks), c.telemetryTags, 1)
+			senderMetrics := c.sender.flushMetrics()
+			c.telemetryCount("datadog.dogstatsd.client.packets_sent", int64(senderMetrics.TotalSentPayloads), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.bytes_sent", int64(senderMetrics.TotalSentBytes), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.packets_dropped", int64(senderMetrics.TotalDroppedPayloads), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.bytes_dropped", int64(senderMetrics.TotalDroppedBytes), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.packets_dropped_queue", int64(senderMetrics.TotalDroppedPayloadsQueueFull), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.bytes_dropped_queue", int64(senderMetrics.TotalDroppedBytesQueueFull), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.packets_dropped_writer", int64(senderMetrics.TotalDroppedPayloadsWriter), c.telemetryTags, 1)
+			c.telemetryCount("datadog.dogstatsd.client.bytes_dropped_writer", int64(senderMetrics.TotalDroppedBytesWriter), c.telemetryTags, 1)
+		case <-c.stop:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// same as Count but without global namespace / tags
+func (c *Client) telemetryCount(name string, value int64, tags []string, rate float64) {
+	c.addMetric(metric{metricType: count, name: name, ivalue: value, tags: tags, rate: rate})
+}
+
+// Flush forces a flush of all the queued dogstatsd payloads
+// This method is blocking and will not return until everything is sent
+// through the network
+func (c *Client) Flush() error {
+	if c == nil {
+		return ErrNoClient
+	}
 	c.Lock()
 	defer c.Unlock()
-	c.commands = append(c.commands, cmd)
-	// if we should flush, lets do it
-	if len(c.commands) == c.bufferLength {
-		if err := c.flushLocked(); err != nil {
-			return err
-		}
+	c.flushUnsafe()
+	c.sender.flush()
+	return nil
+}
+
+// flush the current buffer. Lock must be held by caller.
+// flushed buffer written to the network asynchronously.
+func (c *Client) flushUnsafe() {
+	if len(c.buffer.bytes()) > 0 {
+		c.sender.send(c.buffer)
+		c.buffer = c.bufferPool.borrowBuffer()
+	}
+}
+
+func (c *Client) flushMetrics() ClientMetrics {
+	return ClientMetrics{
+		TotalMetrics:       atomic.SwapUint64(&c.metrics.TotalMetrics, 0),
+		TotalEvents:        atomic.SwapUint64(&c.metrics.TotalEvents, 0),
+		TotalServiceChecks: atomic.SwapUint64(&c.metrics.TotalServiceChecks, 0),
+	}
+}
+
+func (c *Client) shouldSample(rate float64) bool {
+	if rate < 1 && rand.Float64() > rate {
+		return true
+	}
+	return false
+}
+
+func (c *Client) globalTags() []string {
+	if c != nil {
+		return c.Tags
 	}
 	return nil
 }
 
-func (c *Client) joinMaxSize(cmds []string, sep string, maxSize int) ([][]byte, []int) {
-	c.buffer.Reset() //clear buffer
-
-	var frames [][]byte
-	var ncmds []int
-	sepBytes := []byte(sep)
-	sepLen := len(sep)
-
-	elem := 0
-	for _, cmd := range cmds {
-		needed := len(cmd)
-
-		if elem != 0 {
-			needed = needed + sepLen
-		}
-
-		if c.buffer.Len()+needed <= maxSize {
-			if elem != 0 {
-				c.buffer.Write(sepBytes)
-			}
-			c.buffer.WriteString(cmd)
-			elem++
-		} else {
-			frames = append(frames, copyAndResetBuffer(&c.buffer))
-			ncmds = append(ncmds, elem)
-			// if cmd is bigger than maxSize it will get flushed on next loop
-			c.buffer.WriteString(cmd)
-			elem = 1
-		}
+func (c *Client) namespace() string {
+	if c != nil {
+		return c.Namespace
 	}
-
-	//add whatever is left! if there's actually something
-	if c.buffer.Len() > 0 {
-		frames = append(frames, copyAndResetBuffer(&c.buffer))
-		ncmds = append(ncmds, elem)
-	}
-
-	return frames, ncmds
+	return ""
 }
 
-func copyAndResetBuffer(buf *bytes.Buffer) []byte {
-	tmpBuf := make([]byte, buf.Len())
-	copy(tmpBuf, buf.Bytes())
-	buf.Reset()
-	return tmpBuf
+func (c *Client) writeMetricUnsafe(m metric) error {
+	switch m.metricType {
+	case gauge:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeGauge(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case count:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeCount(m.namespace, m.globalTags, m.name, m.ivalue, m.tags, m.rate)
+	case histogram:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeHistogram(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case distribution:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeDistribution(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case set:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeSet(m.namespace, m.globalTags, m.name, m.svalue, m.tags, m.rate)
+	case timing:
+		atomic.AddUint64(&c.metrics.TotalMetrics, 1)
+		return c.buffer.writeTiming(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case event:
+		atomic.AddUint64(&c.metrics.TotalEvents, 1)
+		return c.buffer.writeEvent(*m.evalue, m.globalTags)
+	case serviceCheck:
+		atomic.AddUint64(&c.metrics.TotalServiceChecks, 1)
+		return c.buffer.writeServiceCheck(*m.scvalue, m.globalTags)
+	default:
+		return nil
+	}
 }
 
-// Flush forces a flush of the pending commands in the buffer
-func (c *Client) Flush() error {
+func (c *Client) addMetric(m metric) error {
 	if c == nil {
+		return ErrNoClient
+	}
+	if c.shouldSample(m.rate) {
 		return nil
 	}
 	c.Lock()
-	defer c.Unlock()
-	return c.flushLocked()
-}
-
-// flush the commands in the buffer.  Lock must be held by caller.
-func (c *Client) flushLocked() error {
-	frames, flushable := c.joinMaxSize(c.commands, "\n", OptimalPayloadSize)
 	var err error
-	cmdsFlushed := 0
-	for i, data := range frames {
-		_, e := c.writer.Write(data)
-		if e != nil {
-			err = e
-			break
-		}
-		cmdsFlushed += flushable[i]
+	if err = c.writeMetricUnsafe(m); err == errBufferFull {
+		c.flushUnsafe()
+		err = c.writeMetricUnsafe(m)
 	}
-
-	// clear the slice with a slice op, doesn't realloc
-	if cmdsFlushed == len(c.commands) {
-		c.commands = c.commands[:0]
-	} else {
-		//this case will cause a future realloc...
-		// drop problematic command though (sorry).
-		c.commands = c.commands[cmdsFlushed+1:]
-	}
+	c.Unlock()
 	return err
-}
-
-func (c *Client) sendMsg(msg string) error {
-	// return an error if message is bigger than MaxUDPPayloadSize
-	if len(msg) > MaxUDPPayloadSize {
-		return errors.New("message size exceeds MaxUDPPayloadSize")
-	}
-
-	// if this client is buffered, then we'll just append this
-	if c.bufferLength > 0 {
-		return c.append(msg)
-	}
-
-	_, err := c.writer.Write([]byte(msg))
-
-	if c.SkipErrors {
-		return nil
-	}
-	return err
-}
-
-// send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
-func (c *Client) send(name string, value interface{}, suffix []byte, tags []string, rate float64) error {
-	if c == nil {
-		return nil
-	}
-	if rate < 1 && rand.Float64() > rate {
-		return nil
-	}
-	data := c.format(name, value, suffix, tags, rate)
-	return c.sendMsg(data)
 }
 
 // Gauge measures the value of a metric at a particular time.
 func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
-	return c.send(name, value, gaugeSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: gauge, name: name, fvalue: value, tags: tags, rate: rate})
 }
 
 // Count tracks how many times something happened per second.
 func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
-	return c.send(name, value, countSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: count, name: name, ivalue: value, tags: tags, rate: rate})
 }
 
 // Histogram tracks the statistical distribution of a set of values on each host.
 func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
-	return c.send(name, value, histogramSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: histogram, name: name, fvalue: value, tags: tags, rate: rate})
 }
 
 // Distribution tracks the statistical distribution of a set of values across your infrastructure.
 func (c *Client) Distribution(name string, value float64, tags []string, rate float64) error {
-	return c.send(name, value, distributionSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: distribution, name: name, fvalue: value, tags: tags, rate: rate})
 }
 
 // Decr is just Count of -1
 func (c *Client) Decr(name string, tags []string, rate float64) error {
-	return c.send(name, nil, decrSuffix, tags, rate)
+	return c.Count(name, -1, tags, rate)
 }
 
 // Incr is just Count of 1
 func (c *Client) Incr(name string, tags []string, rate float64) error {
-	return c.send(name, nil, incrSuffix, tags, rate)
+	return c.Count(name, 1, tags, rate)
 }
 
 // Set counts the number of unique elements in a group.
 func (c *Client) Set(name string, value string, tags []string, rate float64) error {
-	return c.send(name, value, setSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: set, name: name, svalue: value, tags: tags, rate: rate})
 }
 
 // Timing sends timing information, it is an alias for TimeInMilliseconds
@@ -372,19 +524,12 @@ func (c *Client) Timing(name string, value time.Duration, tags []string, rate fl
 // TimeInMilliseconds sends timing information in milliseconds.
 // It is flushed by statsd with percentiles, mean and other info (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing)
 func (c *Client) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
-	return c.send(name, value, timingSuffix, tags, rate)
+	return c.addMetric(metric{namespace: c.namespace(), globalTags: c.globalTags(), metricType: timing, name: name, fvalue: value, tags: tags, rate: rate})
 }
 
 // Event sends the provided Event.
 func (c *Client) Event(e *Event) error {
-	if c == nil {
-		return nil
-	}
-	stat, err := e.Encode(c.Tags...)
-	if err != nil {
-		return err
-	}
-	return c.sendMsg(stat)
+	return c.addMetric(metric{globalTags: c.globalTags(), metricType: event, evalue: e, rate: 1})
 }
 
 // SimpleEvent sends an event with the provided title and text.
@@ -395,14 +540,7 @@ func (c *Client) SimpleEvent(title, text string) error {
 
 // ServiceCheck sends the provided ServiceCheck.
 func (c *Client) ServiceCheck(sc *ServiceCheck) error {
-	if c == nil {
-		return nil
-	}
-	stat, err := sc.Encode(c.Tags...)
-	if err != nil {
-		return err
-	}
-	return c.sendMsg(stat)
+	return c.addMetric(metric{globalTags: c.globalTags(), metricType: serviceCheck, scvalue: sc, rate: 1})
 }
 
 // SimpleServiceCheck sends an serviceCheck with the provided name and status.
@@ -414,267 +552,29 @@ func (c *Client) SimpleServiceCheck(name string, status ServiceCheckStatus) erro
 // Close the client connection.
 func (c *Client) Close() error {
 	if c == nil {
-		return nil
+		return ErrNoClient
 	}
+
+	// Acquire closer lock to ensure only one thread can close the stop channel
+	c.closerLock.Lock()
+	defer c.closerLock.Unlock()
+
+	// Notify all other threads that they should stop
 	select {
-	case c.stop <- struct{}{}:
+	case <-c.stop:
+		return nil
 	default:
 	}
+	close(c.stop)
 
-	// if this client is buffered, flush before closing the writer
-	if c.bufferLength > 0 {
-		if err := c.Flush(); err != nil {
-			return err
-		}
-	}
+	// Wait for the threads to stop
+	c.wg.Wait()
 
-	return c.writer.Close()
-}
+	// Finally flush any remaining metrics that may have come in at the last moment
+	c.Lock()
+	defer c.Unlock()
 
-// Events support
-// EventAlertType and EventAlertPriority became exported types after this issue was submitted: https://github.com/DataDog/datadog-go/issues/41
-// The reason why they got exported is so that client code can directly use the types.
-
-// EventAlertType is the alert type for events
-type EventAlertType string
-
-const (
-	// Info is the "info" AlertType for events
-	Info EventAlertType = "info"
-	// Error is the "error" AlertType for events
-	Error EventAlertType = "error"
-	// Warning is the "warning" AlertType for events
-	Warning EventAlertType = "warning"
-	// Success is the "success" AlertType for events
-	Success EventAlertType = "success"
-)
-
-// EventPriority is the event priority for events
-type EventPriority string
-
-const (
-	// Normal is the "normal" Priority for events
-	Normal EventPriority = "normal"
-	// Low is the "low" Priority for events
-	Low EventPriority = "low"
-)
-
-// An Event is an object that can be posted to your DataDog event stream.
-type Event struct {
-	// Title of the event.  Required.
-	Title string
-	// Text is the description of the event.  Required.
-	Text string
-	// Timestamp is a timestamp for the event.  If not provided, the dogstatsd
-	// server will set this to the current time.
-	Timestamp time.Time
-	// Hostname for the event.
-	Hostname string
-	// AggregationKey groups this event with others of the same key.
-	AggregationKey string
-	// Priority of the event.  Can be statsd.Low or statsd.Normal.
-	Priority EventPriority
-	// SourceTypeName is a source type for the event.
-	SourceTypeName string
-	// AlertType can be statsd.Info, statsd.Error, statsd.Warning, or statsd.Success.
-	// If absent, the default value applied by the dogstatsd server is Info.
-	AlertType EventAlertType
-	// Tags for the event.
-	Tags []string
-}
-
-// NewEvent creates a new event with the given title and text.  Error checking
-// against these values is done at send-time, or upon running e.Check.
-func NewEvent(title, text string) *Event {
-	return &Event{
-		Title: title,
-		Text:  text,
-	}
-}
-
-// Check verifies that an event is valid.
-func (e Event) Check() error {
-	if len(e.Title) == 0 {
-		return fmt.Errorf("statsd.Event title is required")
-	}
-	if len(e.Text) == 0 {
-		return fmt.Errorf("statsd.Event text is required")
-	}
-	return nil
-}
-
-// Encode returns the dogstatsd wire protocol representation for an event.
-// Tags may be passed which will be added to the encoded output but not to
-// the Event's list of tags, eg. for default tags.
-func (e Event) Encode(tags ...string) (string, error) {
-	err := e.Check()
-	if err != nil {
-		return "", err
-	}
-	text := e.escapedText()
-
-	var buffer bytes.Buffer
-	buffer.WriteString("_e{")
-	buffer.WriteString(strconv.FormatInt(int64(len(e.Title)), 10))
-	buffer.WriteRune(',')
-	buffer.WriteString(strconv.FormatInt(int64(len(text)), 10))
-	buffer.WriteString("}:")
-	buffer.WriteString(e.Title)
-	buffer.WriteRune('|')
-	buffer.WriteString(text)
-
-	if !e.Timestamp.IsZero() {
-		buffer.WriteString("|d:")
-		buffer.WriteString(strconv.FormatInt(int64(e.Timestamp.Unix()), 10))
-	}
-
-	if len(e.Hostname) != 0 {
-		buffer.WriteString("|h:")
-		buffer.WriteString(e.Hostname)
-	}
-
-	if len(e.AggregationKey) != 0 {
-		buffer.WriteString("|k:")
-		buffer.WriteString(e.AggregationKey)
-
-	}
-
-	if len(e.Priority) != 0 {
-		buffer.WriteString("|p:")
-		buffer.WriteString(string(e.Priority))
-	}
-
-	if len(e.SourceTypeName) != 0 {
-		buffer.WriteString("|s:")
-		buffer.WriteString(e.SourceTypeName)
-	}
-
-	if len(e.AlertType) != 0 {
-		buffer.WriteString("|t:")
-		buffer.WriteString(string(e.AlertType))
-	}
-
-	writeTagString(&buffer, tags, e.Tags)
-
-	return buffer.String(), nil
-}
-
-// ServiceCheckStatus support
-type ServiceCheckStatus byte
-
-const (
-	// Ok is the "ok" ServiceCheck status
-	Ok ServiceCheckStatus = 0
-	// Warn is the "warning" ServiceCheck status
-	Warn ServiceCheckStatus = 1
-	// Critical is the "critical" ServiceCheck status
-	Critical ServiceCheckStatus = 2
-	// Unknown is the "unknown" ServiceCheck status
-	Unknown ServiceCheckStatus = 3
-)
-
-// An ServiceCheck is an object that contains status of DataDog service check.
-type ServiceCheck struct {
-	// Name of the service check.  Required.
-	Name string
-	// Status of service check.  Required.
-	Status ServiceCheckStatus
-	// Timestamp is a timestamp for the serviceCheck.  If not provided, the dogstatsd
-	// server will set this to the current time.
-	Timestamp time.Time
-	// Hostname for the serviceCheck.
-	Hostname string
-	// A message describing the current state of the serviceCheck.
-	Message string
-	// Tags for the serviceCheck.
-	Tags []string
-}
-
-// NewServiceCheck creates a new serviceCheck with the given name and status.  Error checking
-// against these values is done at send-time, or upon running sc.Check.
-func NewServiceCheck(name string, status ServiceCheckStatus) *ServiceCheck {
-	return &ServiceCheck{
-		Name:   name,
-		Status: status,
-	}
-}
-
-// Check verifies that an event is valid.
-func (sc ServiceCheck) Check() error {
-	if len(sc.Name) == 0 {
-		return fmt.Errorf("statsd.ServiceCheck name is required")
-	}
-	if byte(sc.Status) < 0 || byte(sc.Status) > 3 {
-		return fmt.Errorf("statsd.ServiceCheck status has invalid value")
-	}
-	return nil
-}
-
-// Encode returns the dogstatsd wire protocol representation for an serviceCheck.
-// Tags may be passed which will be added to the encoded output but not to
-// the Event's list of tags, eg. for default tags.
-func (sc ServiceCheck) Encode(tags ...string) (string, error) {
-	err := sc.Check()
-	if err != nil {
-		return "", err
-	}
-	message := sc.escapedMessage()
-
-	var buffer bytes.Buffer
-	buffer.WriteString("_sc|")
-	buffer.WriteString(sc.Name)
-	buffer.WriteRune('|')
-	buffer.WriteString(strconv.FormatInt(int64(sc.Status), 10))
-
-	if !sc.Timestamp.IsZero() {
-		buffer.WriteString("|d:")
-		buffer.WriteString(strconv.FormatInt(int64(sc.Timestamp.Unix()), 10))
-	}
-
-	if len(sc.Hostname) != 0 {
-		buffer.WriteString("|h:")
-		buffer.WriteString(sc.Hostname)
-	}
-
-	writeTagString(&buffer, tags, sc.Tags)
-
-	if len(message) != 0 {
-		buffer.WriteString("|m:")
-		buffer.WriteString(message)
-	}
-
-	return buffer.String(), nil
-}
-
-func (e Event) escapedText() string {
-	return strings.Replace(e.Text, "\n", "\\n", -1)
-}
-
-func (sc ServiceCheck) escapedMessage() string {
-	msg := strings.Replace(sc.Message, "\n", "\\n", -1)
-	return strings.Replace(msg, "m:", `m\:`, -1)
-}
-
-func removeNewlines(str string) string {
-	return strings.Replace(str, "\n", "", -1)
-}
-
-func writeTagString(w io.Writer, tagList1, tagList2 []string) {
-	// the tag lists may be shared with other callers, so we cannot modify
-	// them in any way (which means we cannot append to them either)
-	// therefore we must make an entirely separate copy just for this call
-	totalLen := len(tagList1) + len(tagList2)
-	if totalLen == 0 {
-		return
-	}
-	tags := make([]string, 0, totalLen)
-	tags = append(tags, tagList1...)
-	tags = append(tags, tagList2...)
-
-	io.WriteString(w, "|#")
-	io.WriteString(w, removeNewlines(tags[0]))
-	for _, tag := range tags[1:] {
-		io.WriteString(w, ",")
-		io.WriteString(w, removeNewlines(tag))
-	}
+	c.flushUnsafe()
+	c.sender.flush()
+	return c.sender.close()
 }

--- a/vendor/github.com/DataDog/datadog-go/statsd/udp.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/udp.go
@@ -2,8 +2,16 @@ package statsd
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"time"
+)
+
+const (
+	autoHostEnvName = "DD_AGENT_HOST"
+	autoPortEnvName = "DD_DOGSTATSD_PORT"
+	defaultUDPPort  = "8125"
 )
 
 // udpWriter is an internal class wrapping around management of UDP connection
@@ -13,6 +21,13 @@ type udpWriter struct {
 
 // New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
 func newUDPWriter(addr string) (*udpWriter, error) {
+	if addr == "" {
+		addr = addressFromEnvironment()
+	}
+	if addr == "" {
+		return nil, errors.New("No address passed and autodetection from environment failed")
+	}
+
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
@@ -37,4 +52,22 @@ func (w *udpWriter) Write(data []byte) (int, error) {
 
 func (w *udpWriter) Close() error {
 	return w.conn.Close()
+}
+
+func (w *udpWriter) remoteAddr() net.Addr {
+	return w.conn.RemoteAddr()
+}
+
+func addressFromEnvironment() string {
+	autoHost := os.Getenv(autoHostEnvName)
+	if autoHost == "" {
+		return ""
+	}
+
+	autoPort := os.Getenv(autoPortEnvName)
+	if autoPort == "" {
+		autoPort = defaultUDPPort
+	}
+
+	return fmt.Sprintf("%s:%s", autoHost, autoPort)
 }

--- a/vendor/github.com/DataDog/datadog-go/statsd/uds.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/uds.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"net"
+	"sync"
 	"time"
 )
 
@@ -19,10 +20,11 @@ type udsWriter struct {
 	conn net.Conn
 	// write timeout
 	writeTimeout time.Duration
+	sync.RWMutex // used to lock conn / writer can replace it
 }
 
-// New returns a pointer to a new udsWriter given a socket file path as addr.
-func newUdsWriter(addr string) (*udsWriter, error) {
+// newUDSWriter returns a pointer to a new udsWriter given a socket file path as addr.
+func newUDSWriter(addr string) (*udsWriter, error) {
 	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
 	if err != nil {
 		return nil, err
@@ -41,19 +43,17 @@ func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
 // Write data to the UDS connection with write timeout and minimal error handling:
 // create the connection if nil, and destroy it if the statsd server has disconnected
 func (w *udsWriter) Write(data []byte) (int, error) {
-	// Try connecting (first packet or connection lost)
-	if w.conn == nil {
-		conn, err := net.Dial(w.addr.Network(), w.addr.String())
-		if err != nil {
-			return 0, err
-		}
-		w.conn = conn
+	conn, err := w.ensureConnection()
+	if err != nil {
+		return 0, err
 	}
-	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-	n, e := w.conn.Write(data)
-	if e != nil {
+
+	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	n, e := conn.Write(data)
+
+	if err, isNetworkErr := e.(net.Error); err != nil && (!isNetworkErr || !err.Temporary()) {
 		// Statsd server disconnected, retry connecting at next packet
-		w.conn = nil
+		w.unsetConnection()
 		return 0, e
 	}
 	return n, e
@@ -64,4 +64,35 @@ func (w *udsWriter) Close() error {
 		return w.conn.Close()
 	}
 	return nil
+}
+
+func (w *udsWriter) ensureConnection() (net.Conn, error) {
+	// Check if we've already got a socket we can use
+	w.RLock()
+	currentConn := w.conn
+	w.RUnlock()
+
+	if currentConn != nil {
+		return currentConn, nil
+	}
+
+	// Looks like we might need to connect - try again with write locking.
+	w.Lock()
+	defer w.Unlock()
+	if w.conn != nil {
+		return w.conn, nil
+	}
+
+	newConn, err := net.Dial(w.addr.Network(), w.addr.String())
+	if err != nil {
+		return nil, err
+	}
+	w.conn = newConn
+	return newConn, nil
+}
+
+func (w *udsWriter) unsetConnection() {
+	w.Lock()
+	defer w.Unlock()
+	w.conn = nil
 }


### PR DESCRIPTION
#### Summary
I updated the DataDog/datadog-go client dependency because the changes contain fixes for correctly parsing unix socket addresses. https://github.com/DataDog/datadog-go/pull/113

I also changed the url parsing to be able to take in a format like "unix:@abstract.sock". The net/url package unfortunately wont be able to decipher something like "unix://@abstract.sock" due to the @ following the standard username@host format. https://golang.org/pkg/net/url/#URL

I also added logic to skip locking the socket if it is an abstract socket.

#### Motivation
In Kubernetes we want to use unix sockets while avoiding volume mounts. Using abstract unix sockets is a way to go about it.

#### Test plan
Wrote automated tests. Ran this in our new pods that use abstract unix sockets as well as in our existing pods that use unix sockets in the filesystem to verify everything works.

#### Rollout/monitoring/revert plan
This change is backwards compatible and only affects socket paths starting with "@". Which wouldn't work with the existing version.

cc: @prudhvi 
