### PR TITLE
Emit metric when using default SignalFX key as fallback

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -65,7 +65,6 @@ func (c *collection) addPoint(key string, point *datapoint.Datapoint) {
 			c.pointsByKey[key] = append(c.pointsByKey[key], point)
 			return
 		}
-		c.sink.log.Warn(fmt.Sprintf("No SignalFx client exists for tag value '%s', using default client", key))
 	}
 	c.points = append(c.points, point)
 }

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -68,7 +68,7 @@ func (c *collection) addPoint(ctx context.Context, key string, point *datapoint.
 			c.pointsByKey[key] = append(c.pointsByKey[key], point)
 			return
 		}
-		span.Add(ssf.Count("flush.fallback_client_points_flushed", 1, map[string]string{"key": key, "sink": "signalfx", "veneurglobalonly": "true"}))
+		span.Add(ssf.Count("flush.fallback_client_points_flushed", 1, map[string]string{"vary_by": c.sink.varyBy, "key": key, "sink": "signalfx", "veneurglobalonly": "true"}))
 	}
 	c.points = append(c.points, point)
 }

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -56,7 +56,10 @@ type collection struct {
 	pointsByKey map[string][]*datapoint.Datapoint
 }
 
-func (c *collection) addPoint(key string, point *datapoint.Datapoint) {
+func (c *collection) addPoint(ctx context.Context, key string, point *datapoint.Datapoint) {
+	span, _ := trace.StartSpanFromContext(ctx, "")
+	defer span.ClientFinish(c.sink.traceClient)
+
 	c.sink.clientsByTagValueMu.RLock()
 	defer c.sink.clientsByTagValueMu.RUnlock()
 
@@ -65,6 +68,7 @@ func (c *collection) addPoint(key string, point *datapoint.Datapoint) {
 			c.pointsByKey[key] = append(c.pointsByKey[key], point)
 			return
 		}
+		span.Add(ssf.Count("flush.fallback_client_points_flushed", 1, map[string]string{"key": key, "sink": "signalfx", "veneurglobalonly": "true"}))
 	}
 	c.points = append(c.points, point)
 }
@@ -470,7 +474,7 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 			countStatusMetrics++
 			point = sfxclient.GaugeF(metric.Name, dims, metric.Value)
 		}
-		coll.addPoint(metricKey, point)
+		coll.addPoint(subCtx, metricKey, point)
 		numPoints++
 	}
 	tags := map[string]string{"sink": "signalfx"}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This log line logs too much - on every flush interval for all hosts that use the default client, when varyBy is set.

#### Motivation
<!-- Why are you making this change? -->
Increased log volume on live hosts running the latest veneur

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
