### PR TITLE
Add TCP Support for Statsd in veneur-emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The Datadog sink can now filter tags by metric names prefix with `datadog_exclude_tags_prefix_by_prefix_metric`. Thanks, [kaplanelad](https://github.com/kaplanelad)!
 * When specifying the SignalFx key with `signalfx_vary_key_by`, if both the host and the metric provide a value, the metric-provided value will take precedence over the host-provided value. This allows more granular forms of metric organization and attribution. Thanks, [aditya](https://github.com/chimeracoder)!
 * Support for listening to abstract statsd metrics on Unix Domain Socket(Datagram type). Thanks, [androohan](https://github.com/androohan)!
+* Support for sending statsd metrics over TCP in veneur-emit. Thanks, [shrivu-stripe](https://github.com/shrivu-stripe)!
 
 ## Updated
 * Updated the vendored version of DataDog/datadog-go which fixes parsing for abstract unix domain sockets in the statsd client. Thanks, [androohan](https://github.com/androohan)!

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -274,19 +274,13 @@ func Main(args []string) int {
 			return 1
 		}
 	} else {
-		if netAddr.Network() != "udp" {
-			logrus.WithField("address", addr).
-				WithField("network", netAddr.Network()).
-				Error("hostport must be a UDP address for statsd metrics")
-			return 1
-		}
 		if len(span.Metrics) == 0 {
 			logrus.Error("No metrics to send. Must pass metric data via at least one of -count, -gauge, -timing, or -set.")
 			return 1
 		}
-		err = sendStatsd(netAddr.String(), span)
+		err = sendStatsd(netAddr, span)
 		if err != nil {
-			logrus.WithError(err).Error("Could not send UDP metrics")
+			logrus.WithError(err).Error("Could not send metrics")
 			return 1
 		}
 	}
@@ -574,10 +568,54 @@ func sendSSF(client *trace.Client, span *ssf.SSFSpan) error {
 	return <-done
 }
 
+// Adapted from https://github.com/DataDog/datadog-go/blob/master/statsd/udp.go
+func newDatadogTCPWriter(addr string) (*datadogTCPWriter, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return nil, err
+	}
+	writer := &datadogTCPWriter{conn: conn}
+	return writer, nil
+}
+
+type datadogTCPWriter struct {
+	timeout time.Duration
+	conn    net.Conn
+}
+
+func (w *datadogTCPWriter) Write(data []byte) (n int, err error) {
+	return w.conn.Write(data)
+}
+
+func (w *datadogTCPWriter) SetWriteTimeout(timeout time.Duration) error {
+	return nil
+}
+
+func (w *datadogTCPWriter) Close() error {
+	return w.conn.Close()
+}
+
 // sendStatsd sends the metrics gathered in a span to a dogstatsd
 // endpoint.
-func sendStatsd(addr string, span *ssf.SSFSpan) error {
-	client, err := statsd.New(addr)
+func sendStatsd(addr net.Addr, span *ssf.SSFSpan) error {
+	var client *statsd.Client
+	var err error
+	network := addr.Network()
+	switch network {
+	case "udp":
+		client, err = statsd.New(addr.String())
+	case "tcp":
+		writer, err := newDatadogTCPWriter(addr.String())
+		if err == nil {
+			client, err = statsd.NewWithWriter(writer)
+		}
+	default:
+		err = fmt.Errorf("%s is not supported for sending statsd metrics", network)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -568,7 +568,7 @@ func sendSSF(client *trace.Client, span *ssf.SSFSpan) error {
 	return <-done
 }
 
-// Adapted from https://github.com/DataDog/datadog-go/blob/master/statsd/udp.go
+// newDatadogTCPWriter is adapted from https://github.com/DataDog/datadog-go/blob/master/statsd/udp.go
 func newDatadogTCPWriter(addr string) (*datadogTCPWriter, error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
@@ -583,8 +583,7 @@ func newDatadogTCPWriter(addr string) (*datadogTCPWriter, error) {
 }
 
 type datadogTCPWriter struct {
-	timeout time.Duration
-	conn    net.Conn
+	conn net.Conn
 }
 
 func (w *datadogTCPWriter) Write(data []byte) (n int, err error) {
@@ -592,6 +591,7 @@ func (w *datadogTCPWriter) Write(data []byte) (n int, err error) {
 }
 
 func (w *datadogTCPWriter) SetWriteTimeout(timeout time.Duration) error {
+	// This is unused in the current implementation
 	return nil
 }
 

--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -646,7 +646,7 @@ func sendStatsd(addr net.Addr, span *ssf.SSFSpan) error {
 			return err
 		}
 	}
-	client.Flush()
+	client.Close()
 	return nil
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Adds a statsd over TCP support to veneur-emit.

I found the best way to enable statsd over TCP was to create a custom statsd writer for datadog. This avoids having to maintain/use a second statsd client and ensures we get all the features supported by datadog. This PR keeps the udp code path the same and just switches the default udp writer with a custom tcp one when tcp is used. Using a custom writer requires implementing a private interface although this is a [known use case](https://github.com/DataDog/datadog-go/issues/64).

This PR also switches our call `datadogClient.Flush()` to `datadogClient.Close()` (which calls flush internally). In slightly modifying how we used datadog-go another race condition started appearing (found in this [PR](https://github.com/DataDog/datadog-go/pull/120) although when I applied this diff the race still existed) causing metrics to be dropped. As noted in the linked PR, if we aren't reusing the datadog client (we are not), the easy work around is just closing the client and in testing the race condition appears to be gone.

#### Motivation
Stripe wants to use veneur over TCP.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
```yaml
statsd_listen_addresses:
  - tcp://127.0.0.1:8200
  - udp://127.0.0.1:8201
```
```bash
go run ./cmd/veneur-emit -hostport tcp://127.0.0.1:8200 -name "my.test.metric" -count 1 -command sleep 1
go run ./cmd/veneur-emit -hostport udp://127.0.0.1:8201 -name "my.test.metric" -count 1 -command sleep 1
```

r? @rma-stripe 
cc @stripe/observability