### PR TITLE
Allow non-integral X-Ray sampling rates

### DIFF
--- a/config.go
+++ b/config.go
@@ -125,5 +125,5 @@ type Config struct {
 	} `yaml:"veneur_metrics_scopes"`
 	XrayAddress          string   `yaml:"xray_address"`
 	XrayAnnotationTags   []string `yaml:"xray_annotation_tags"`
-	XraySamplePercentage int      `yaml:"xray_sample_percentage"`
+	XraySamplePercentage float64  `yaml:"xray_sample_percentage"`
 }

--- a/example.yaml
+++ b/example.yaml
@@ -412,11 +412,9 @@ signalfx_dynamic_per_tag_api_keys_refresh_period: "10m"
 xray_address: "localhost:2000"
 
 # Sample rate in percent (as an integer)
-# This should ideally be a floating point number, but at the time this was
-# written, gojson interpreted whole-number floats in yaml as integers.
 # The sink will hash the trace id of the span such that all Veneur instances
 # will sample the same segments by using the trace id as input for a checksum.
-xray_sample_percentage: 100
+xray_sample_percentage: 100.0
 
 # All tags are sent as (unindexed) Metadata to X-ray. Up to 50 tags per trace
 # (not per span) can be indexed as Annotations for search. Tag keys specified here

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -80,7 +80,7 @@ type XRaySpanSink struct {
 var _ sinks.SpanSink = &XRaySpanSink{}
 
 // NewXRaySpanSink creates a new instance of a XRaySpanSink.
-func NewXRaySpanSink(daemonAddr string, sampleRatePercentage int, commonTags map[string]string, annotationTags []string, log *logrus.Logger) (*XRaySpanSink, error) {
+func NewXRaySpanSink(daemonAddr string, sampleRatePercentage float64, commonTags map[string]string, annotationTags []string, log *logrus.Logger) (*XRaySpanSink, error) {
 
 	log.WithFields(logrus.Fields{
 		"Address": daemonAddr,


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Allow non-integer values to be set for X-Ray sampling rates. Notably, this allows users to set rates below 1% (without disabling X-Ray entirely).

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 