### PR TITLE
Use Go 1.14 for Jenkins builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For running Veneur under Docker, you probably want either the pre-built images
 # published at https://hub.docker.com/r/stripe/veneur/
 # or the Dockerfiles in https://github.com/stripe/veneur/tree/master/public-docker-images
-FROM golang:1.13
+FROM golang:1.14
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Use Go 1.14 for Jenkins builds.

This doesn't affect the public Docker images.

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @rma-stripe 
cc @stripe/observability 