### PR TITLE
Increase the timeout in TestCountActiveHandlers

### DIFF
--- a/proxysrv/server_test.go
+++ b/proxysrv/server_test.go
@@ -187,7 +187,7 @@ func TestCountActiveHandlers(t *testing.T) {
 			tick := time.NewTicker(10 * time.Nanosecond)
 			defer tick.Stop()
 
-			timeout := time.NewTicker(3 * time.Second)
+			timeout := time.NewTicker(10 * time.Second)
 			defer timeout.Stop()
 			for int64(n) != atomic.LoadInt64(s.activeProxyHandlers) {
 				select {
@@ -204,7 +204,7 @@ func TestCountActiveHandlers(t *testing.T) {
 
 			// Stop all of the servers and check that the counter goes to zero
 			close(done)
-			timeout = time.NewTicker(3 * time.Second)
+			timeout = time.NewTicker(10 * time.Second)
 			defer timeout.Stop()
 			for atomic.LoadInt64(s.activeProxyHandlers) != 0 {
 				select {


### PR DESCRIPTION
#### Summary
Modifies the timeout for TestCountActiveHandlers from 3->10s.

cc @adunham-stripe

#### Motivation
We're switching `puppet-config` which runs the tests for this repo as part of its build to a new remote execution platform. These tests are now timing out: https://cibot.qa.corp.stripe.com/builds/bui_IznZdQvsNE6nfp/logs?unknown_failure=true#L480-L483 (link only visible internally).

We're not entirely certain why -- perhaps since network device setup is slower/lazy on the new platform. However, this seems like an uncontroversial enough change.

#### Test plan
Tests now pass with this commit once it's cherry-picked on top of the branches being currently used:
https://cibot.qa.corp.stripe.com/builds/bui_J0sLaraUpfPjpH/logs#L307-L314

#### Rollout/monitoring/revert plan
This should have zero production impact. As such, it is fine to revert.