### PR TITLE
Hardcode an assumption for the veneur-global container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Updated
 * Migrated from dep to Go modules. Clients must now use the updated import path `github.com/stripe/veneur/v14`. Thanks, [andybons](https://github.com/andybons)!
+* Introduced a workaround for finding the `veneur-global` container in a pod with multiple containers in Kubernetes.
 
 # 13.0.0, 2020-01-05
 

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -46,9 +46,12 @@ func (kd *KubernetesDiscoverer) GetDestinationsForService(serviceName string) ([
 			continue
 		}
 
-		// TODO don't assume there is only one container for the veneur global
 		if len(pod.Spec.Containers) > 0 {
 			for _, container := range pod.Spec.Containers {
+				if container.Name != "veneur-global" {
+					continue
+				}
+
 				for _, port := range container.Ports {
 					if port.Name == "http" {
 						forwardPort = strconv.Itoa(int(port.ContainerPort))


### PR DESCRIPTION
#### Summary
There's an assumption in the current kubernetes integration code that
there is only one container in the veneur-global pod. This is a band-aid
fix by introducing another hardcoded assumption on top of the selector
label "app=veneur-global":

The veneur-global container must be named "veneur-global".

#### Motivation
We run istio on our k8s clusters and the logic for fetching the correct "http" port is broken (it configures itself with one of istio's ports).


#### Test plan
I ran this manually. There are no existing tests for the Kubernetes code.


#### Rollout/monitoring/revert plan
Existing `veneur-global` deploys will need to ensure their container is named "veneur-global". Otherwise, it will fail to configure a `forwardPort` and fail.