### PR TITLE
Update CHANGELOG for v14.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-# 14.1.0, (WIP)
+# 14.1.0, 2021-03-16
 
 ## Added
+
 * The ability to emit dogstatsd metrics from veneur-emit over plain TCP in addition to the current plain UDP. Thanks, [shrivu-stripe](https://github.com/shrivu-stripe)!
 * A config option and health checking for beginning support of emitting/receiving metrics via gRPC. Thanks, [eriwo-stripe](https://github.com/eriwo-stripe)!  
 * A gRPC server that listens for SSF spans and dogstatsd metrics on grpc_listening_addresses. Thanks [eriwo-stripe](https://github.com/eriwo-stripe) and [shrivu-stripe](https://github.com/shrivu-stripe)!
 * The ability to emit metrics from veneur-emit via the gRPC protocol as well as the option to specify a proxy for those metrics. Thanks [eriwo-stripe](https://github.com/eriwo-stripe) and [shrivu-stripe](https://github.com/shrivu-stripe)!
+* Log the SignalFX endpoint base on creation of the sink. Useful for grepping across multiple host logs. Thanks [rma-stripe](https://github.com/rma-stripe)!
+
+## Updated
+
+* Upgrade to Goji 2.0.2 and use the modern Goji mux API. Thanks [hans-stripe](https://github.com/hans-stripe)!
+* Increase the timeout of TestCountActiveHandlers from 3 seconds to 10 seconds. Helps some tests pass in certain environments. Thanks [sushain97](https://github.com/sushain97)!
 
 # 14.0.0, 2020-01-14
 


### PR DESCRIPTION
#### Summary

Update CHANGELOG to release Veneur v14.1.0 and tag commit as "v14.1.0".

#### Motivation

New release.

#### Test plan

The changes were tested as documented in this PR: https://github.com/stripe/veneur/pull/822

#### Rollout/monitoring/revert plan

Same plan as documented in this PR: https://github.com/stripe/veneur/pull/822


r? @rma-stripe 
cc @stripe/observability 
