### PR TITLE
Allow kubernetes discoverer to find gRPC destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Upgrade to Goji 2.0.2 and use the modern Goji mux API. Thanks [hans-stripe](https://github.com/hans-stripe)!
 * Increase the timeout of TestCountActiveHandlers from 3 seconds to 10 seconds. Helps some tests pass in certain environments. Thanks [sushain97](https://github.com/sushain97)!
 
+## Bugfixes
+
+* Fixed forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!
+
 # 14.0.0, 2020-01-14
 
 ## Updated

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -50,6 +50,12 @@ func (kd *KubernetesDiscoverer) GetDestinationsForService(serviceName string) ([
 		if len(pod.Spec.Containers) > 0 {
 			for _, container := range pod.Spec.Containers {
 				for _, port := range container.Ports {
+					if port.Name == "grpc" {
+						forwardPort = strconv.Itoa(int(port.ContainerPort))
+						log.WithField("port", forwardPort).Debug("Found grpc port")
+						break
+					}
+
 					if port.Name == "http" {
 						forwardPort = strconv.Itoa(int(port.ContainerPort))
 						log.WithField("port", forwardPort).Debug("Found http port")
@@ -83,8 +89,7 @@ func (kd *KubernetesDiscoverer) GetDestinationsForService(serviceName string) ([
 			continue
 		}
 
-		// prepend with // so that it is a valid URL parseable by url.Parse
-		podIp := fmt.Sprintf("http://%s:%s", pod.Status.PodIP, forwardPort)
+		podIp := fmt.Sprintf("%s:%s", pod.Status.PodIP, forwardPort)
 		ips = append(ips, podIp)
 	}
 	return ips, nil


### PR DESCRIPTION
Summary
I updated the kubnetes discoverer to look for veneur global containers with a grpc port name. This will allow us to specify that we are using gRPC.
Additionally, I removed the http:// prefix in the saved podIp because it hits a "too many colons in address" error with gRPC. This will still work with forwarding with http because in proxy.go, the doPost method will check and append http:// if its missing.

Motivation
In Kubernetes we want to proxy metrics to veneur global with gRPC. This edit in our fork fixed the issues we were hitting.

Test plan
Ran this in our veneur-proxy pods that utilize this Kubernetes discoverer code with gRPC to verify everything works.

Rollout/monitoring/revert plan
This change should be backwards compatible as the doPost function for http communication prepends the necessary prefix. This only affects gRPC destinations used by proxysrv which shouldn't have been available with kubernetes.
