### PR TITLE
Add veneur.flush.unique_timeseries_daily_cumulative metric

### DIFF
--- a/server.go
+++ b/server.go
@@ -58,6 +58,8 @@ import (
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+
+	"github.com/axiomhq/hyperloglog"
 )
 
 // VERSION stores the current veneur version.
@@ -148,6 +150,8 @@ type Server struct {
 
 	stuckIntervals int
 	lastFlushUnix  int64
+
+	cumulativeTimeseries *hyperloglog.Sketch
 }
 
 type GlobalListeningPerProtocolMetrics struct {
@@ -313,6 +317,8 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		ret.HistogramAggregates.Value += samplers.AggregatesLookup[agg]
 	}
 	ret.HistogramAggregates.Count = len(conf.Aggregates)
+
+	ret.cumulativeTimeseries = hyperloglog.New()
 
 	var err error
 	ret.interval, err = conf.ParseInterval()


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Add `veneur.flush.unique_timeseries_daily_cumulative metric`, a metric which uses a HyperLogLog to estimate the number of unique MTS processed each day. 

This approach is reasonably accurate if we assume that each metric - unique combination of all tags - is only emitted by a single instance of Veneur at a time, which is true if 

(a) host-local metrics are tagged with a host identifier
(b) global metrics use Veneur's built-in consistent hashing scheme


The current test failure on tip is due to the way we fetch dependencies in the test container; it's unrelated to this change (and doesn't block us from building/deploying this branch).

#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @krisreeves-stripe 
cc @stripe/observability 