### PR TITLE
Add configuration for custom sinks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,20 @@ jobs:
             env PAGER=cat git diff --cached
             git diff-index --cached --exit-code HEAD
 
+  test_config:
+    executor:
+      name: stable
+    working_directory: /go/src/github.com/stripe/veneur
+    environment:
+      GO111MODULE: "on"
+    steps:
+      - checkout
+      - run:
+          name: check example.yaml
+          command: |
+            go build -o dist/main cmd/veneur/main.go
+            ./dist/main -f example.yaml -validate-config -validate-config-strict
+
   test_stable:
     executor:
       name: stable
@@ -183,6 +197,7 @@ workflows:
   continuous_integration:
     jobs:
       - code_hygiene
+      - test_config
       - test_stable
       - test_previous
       - test_tip

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14"
+	"github.com/stripe/veneur/v14/sinks"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 )
@@ -46,7 +47,16 @@ func main() {
 	}
 
 	logger := logrus.StandardLogger()
-	server, err := veneur.NewFromConfig(logger, conf)
+	server, err := veneur.NewFromConfig(veneur.ServerConfig{
+		Config:          conf,
+		Logger:          logger,
+		MetricSinkTypes: map[string]func(string, interface{}) sinks.MetricSink{
+			// TODO(arnavdugar): Migrate metric sink types.
+		},
+		SpanSinkTypes: map[string]func(string, interface{}) sinks.SpanSink{
+			// TODO(arnavdugar): Migrate span sink types.
+		},
+	})
 	veneur.SetLogger(logger)
 	if err != nil {
 		e := err

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -48,12 +48,14 @@ func main() {
 
 	logger := logrus.StandardLogger()
 	server, err := veneur.NewFromConfig(veneur.ServerConfig{
-		Config:          conf,
-		Logger:          logger,
-		MetricSinkTypes: map[string]func(string, interface{}) sinks.MetricSink{
+		Config: conf,
+		Logger: logger,
+		MetricSinkTypes: map[string]func(
+			*veneur.Server, string, interface{}) sinks.MetricSink{
 			// TODO(arnavdugar): Migrate metric sink types.
 		},
-		SpanSinkTypes: map[string]func(string, interface{}) sinks.SpanSink{
+		SpanSinkTypes: map[string]func(
+			*veneur.Server, string, interface{}) sinks.SpanSink{
 			// TODO(arnavdugar): Migrate span sink types.
 		},
 	})

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14"
-	"github.com/stripe/veneur/v14/sinks"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 )
@@ -48,14 +47,12 @@ func main() {
 
 	logger := logrus.StandardLogger()
 	server, err := veneur.NewFromConfig(veneur.ServerConfig{
-		Config: conf,
-		Logger: logger,
-		MetricSinkTypes: map[string]func(
-			*veneur.Server, string, interface{}) sinks.MetricSink{
+		Config:          conf,
+		Logger:          logger,
+		MetricSinkTypes: veneur.MetricSinkTypes{
 			// TODO(arnavdugar): Migrate metric sink types.
 		},
-		SpanSinkTypes: map[string]func(
-			*veneur.Server, string, interface{}) sinks.SpanSink{
+		SpanSinkTypes: veneur.SpanSinkTypes{
 			// TODO(arnavdugar): Migrate span sink types.
 		},
 	})

--- a/config.go
+++ b/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	ExtendTags                   []string `yaml:"extend_tags"`
 	FalconerAddress              string   `yaml:"falconer_address"`
 	Features                     struct {
-		MigrateMetricSinks string `yaml:"migrate_metric_sinks"`
-		MigrateSpanSinks   string `yaml:"migrate_span_sinks"`
+		MigrateMetricSinks bool `yaml:"migrate_metric_sinks"`
+		MigrateSpanSinks   bool `yaml:"migrate_span_sinks"`
 	}
 	FlushFile                    string   `yaml:"flush_file"`
 	FlushMaxPerBody              int      `yaml:"flush_max_per_body"`

--- a/config.go
+++ b/config.go
@@ -14,52 +14,61 @@ type Config struct {
 		MetricPrefix string   `yaml:"metric_prefix"`
 		Tags         []string `yaml:"tags"`
 	} `yaml:"datadog_exclude_tags_prefix_by_prefix_metric"`
-	DatadogFlushMaxPerBody                    int       `yaml:"datadog_flush_max_per_body"`
-	DatadogMetricNamePrefixDrops              []string  `yaml:"datadog_metric_name_prefix_drops"`
-	DatadogSpanBufferSize                     int       `yaml:"datadog_span_buffer_size"`
-	DatadogTraceAPIAddress                    string    `yaml:"datadog_trace_api_address"`
-	Debug                                     bool      `yaml:"debug"`
-	DebugFlushedMetrics                       bool      `yaml:"debug_flushed_metrics"`
-	DebugIngestedSpans                        bool      `yaml:"debug_ingested_spans"`
-	EnableProfiling                           bool      `yaml:"enable_profiling"`
-	ExtendTags                                []string  `yaml:"extend_tags"`
-	FalconerAddress                           string    `yaml:"falconer_address"`
-	FlushFile                                 string    `yaml:"flush_file"`
-	FlushMaxPerBody                           int       `yaml:"flush_max_per_body"`
-	FlushWatchdogMissedFlushes                int       `yaml:"flush_watchdog_missed_flushes"`
-	ForwardAddress                            string    `yaml:"forward_address"`
-	ForwardUseGrpc                            bool      `yaml:"forward_use_grpc"`
-	GrpcAddress                               string    `yaml:"grpc_address"`
-	GrpcListenAddresses                       []string  `yaml:"grpc_listen_addresses"`
-	Hostname                                  string    `yaml:"hostname"`
-	HTTPAddress                               string    `yaml:"http_address"`
-	HTTPQuit                                  bool      `yaml:"http_quit"`
-	IndicatorSpanTimerName                    string    `yaml:"indicator_span_timer_name"`
-	Interval                                  string    `yaml:"interval"`
-	KafkaBroker                               string    `yaml:"kafka_broker"`
-	KafkaCheckTopic                           string    `yaml:"kafka_check_topic"`
-	KafkaEventTopic                           string    `yaml:"kafka_event_topic"`
-	KafkaMetricBufferBytes                    int       `yaml:"kafka_metric_buffer_bytes"`
-	KafkaMetricBufferFrequency                string    `yaml:"kafka_metric_buffer_frequency"`
-	KafkaMetricBufferMessages                 int       `yaml:"kafka_metric_buffer_messages"`
-	KafkaMetricRequireAcks                    string    `yaml:"kafka_metric_require_acks"`
-	KafkaMetricTopic                          string    `yaml:"kafka_metric_topic"`
-	KafkaPartitioner                          string    `yaml:"kafka_partitioner"`
-	KafkaRetryMax                             int       `yaml:"kafka_retry_max"`
-	KafkaSpanBufferBytes                      int       `yaml:"kafka_span_buffer_bytes"`
-	KafkaSpanBufferFrequency                  string    `yaml:"kafka_span_buffer_frequency"`
-	KafkaSpanBufferMesages                    int       `yaml:"kafka_span_buffer_mesages"`
-	KafkaSpanRequireAcks                      string    `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRatePercent                float64   `yaml:"kafka_span_sample_rate_percent"`
-	KafkaSpanSampleTag                        string    `yaml:"kafka_span_sample_tag"`
-	KafkaSpanSerializationFormat              string    `yaml:"kafka_span_serialization_format"`
-	KafkaSpanTopic                            string    `yaml:"kafka_span_topic"`
-	LightstepAccessToken                      string    `yaml:"lightstep_access_token"`
-	LightstepCollectorHost                    string    `yaml:"lightstep_collector_host"`
-	LightstepMaximumSpans                     int       `yaml:"lightstep_maximum_spans"`
-	LightstepNumClients                       int       `yaml:"lightstep_num_clients"`
-	LightstepReconnectPeriod                  string    `yaml:"lightstep_reconnect_period"`
-	MetricMaxLength                           int       `yaml:"metric_max_length"`
+	DatadogFlushMaxPerBody       int      `yaml:"datadog_flush_max_per_body"`
+	DatadogMetricNamePrefixDrops []string `yaml:"datadog_metric_name_prefix_drops"`
+	DatadogSpanBufferSize        int      `yaml:"datadog_span_buffer_size"`
+	DatadogTraceAPIAddress       string   `yaml:"datadog_trace_api_address"`
+	Debug                        bool     `yaml:"debug"`
+	DebugFlushedMetrics          bool     `yaml:"debug_flushed_metrics"`
+	DebugIngestedSpans           bool     `yaml:"debug_ingested_spans"`
+	EnableProfiling              bool     `yaml:"enable_profiling"`
+	ExtendTags                   []string `yaml:"extend_tags"`
+	FalconerAddress              string   `yaml:"falconer_address"`
+	Features                     struct {
+		MigrateMetricSinks string `yaml:"migrate_metric_sinks"`
+		MigrateSpanSinks   string `yaml:"migrate_span_sinks"`
+	}
+	FlushFile                    string   `yaml:"flush_file"`
+	FlushMaxPerBody              int      `yaml:"flush_max_per_body"`
+	FlushWatchdogMissedFlushes   int      `yaml:"flush_watchdog_missed_flushes"`
+	ForwardAddress               string   `yaml:"forward_address"`
+	ForwardUseGrpc               bool     `yaml:"forward_use_grpc"`
+	GrpcAddress                  string   `yaml:"grpc_address"`
+	GrpcListenAddresses          []string `yaml:"grpc_listen_addresses"`
+	Hostname                     string   `yaml:"hostname"`
+	HTTPAddress                  string   `yaml:"http_address"`
+	HTTPQuit                     bool     `yaml:"http_quit"`
+	IndicatorSpanTimerName       string   `yaml:"indicator_span_timer_name"`
+	Interval                     string   `yaml:"interval"`
+	KafkaBroker                  string   `yaml:"kafka_broker"`
+	KafkaCheckTopic              string   `yaml:"kafka_check_topic"`
+	KafkaEventTopic              string   `yaml:"kafka_event_topic"`
+	KafkaMetricBufferBytes       int      `yaml:"kafka_metric_buffer_bytes"`
+	KafkaMetricBufferFrequency   string   `yaml:"kafka_metric_buffer_frequency"`
+	KafkaMetricBufferMessages    int      `yaml:"kafka_metric_buffer_messages"`
+	KafkaMetricRequireAcks       string   `yaml:"kafka_metric_require_acks"`
+	KafkaMetricTopic             string   `yaml:"kafka_metric_topic"`
+	KafkaPartitioner             string   `yaml:"kafka_partitioner"`
+	KafkaRetryMax                int      `yaml:"kafka_retry_max"`
+	KafkaSpanBufferBytes         int      `yaml:"kafka_span_buffer_bytes"`
+	KafkaSpanBufferFrequency     string   `yaml:"kafka_span_buffer_frequency"`
+	KafkaSpanBufferMesages       int      `yaml:"kafka_span_buffer_mesages"`
+	KafkaSpanRequireAcks         string   `yaml:"kafka_span_require_acks"`
+	KafkaSpanSampleRatePercent   float64  `yaml:"kafka_span_sample_rate_percent"`
+	KafkaSpanSampleTag           string   `yaml:"kafka_span_sample_tag"`
+	KafkaSpanSerializationFormat string   `yaml:"kafka_span_serialization_format"`
+	KafkaSpanTopic               string   `yaml:"kafka_span_topic"`
+	LightstepAccessToken         string   `yaml:"lightstep_access_token"`
+	LightstepCollectorHost       string   `yaml:"lightstep_collector_host"`
+	LightstepMaximumSpans        int      `yaml:"lightstep_maximum_spans"`
+	LightstepNumClients          int      `yaml:"lightstep_num_clients"`
+	LightstepReconnectPeriod     string   `yaml:"lightstep_reconnect_period"`
+	MetricMaxLength              int      `yaml:"metric_max_length"`
+	MetricSinks                  []struct {
+		Kind   string      `yaml:"kind"`
+		Name   string      `yaml:"name"`
+		Config interface{} `yaml:"config"`
+	} `yaml:"metric_sinks"`
 	MutexProfileFraction                      int       `yaml:"mutex_profile_fraction"`
 	NewrelicAccountID                         int       `yaml:"newrelic_account_id"`
 	NewrelicCommonTags                        []string  `yaml:"newrelic_common_tags"`
@@ -91,8 +100,13 @@ type Config struct {
 		APIKey string `yaml:"api_key"`
 		Name   string `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`
-	SignalfxVaryKeyBy                 string   `yaml:"signalfx_vary_key_by"`
-	SpanChannelCapacity               int      `yaml:"span_channel_capacity"`
+	SignalfxVaryKeyBy   string `yaml:"signalfx_vary_key_by"`
+	SpanChannelCapacity int    `yaml:"span_channel_capacity"`
+	SpanSinks           []struct {
+		Kind   string      `yaml:"kind"`
+		Name   string      `yaml:"name"`
+		Config interface{} `yaml:"config"`
+	} `yaml:"span_sinks"`
 	SplunkHecAddress                  string   `yaml:"splunk_hec_address"`
 	SplunkHecBatchSize                int      `yaml:"splunk_hec_batch_size"`
 	SplunkHecConnectionLifetimeJitter string   `yaml:"splunk_hec_connection_lifetime_jitter"`

--- a/generate.go
+++ b/generate.go
@@ -7,7 +7,6 @@ package veneur
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=. tdigest/tdigest.proto
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=Mtdigest/tdigest.proto=github.com/stripe/veneur/v14/tdigest:. samplers/metricpb/metric.proto
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=Mtdigest/tdigest.proto=github.com/stripe/veneur/v14/tdigest,Msamplers/metricpb/metric.proto=github.com/stripe/veneur/v14/samplers/metricpb,Mgoogle/protobuf/empty.proto=github.com/golang/protobuf/ptypes/empty,plugins=grpc:. forwardrpc/forward.proto
-//go:generate gojson -input example.yaml -o config.go -fmt yaml -pkg veneur -name Config
 //go:generate gojson -input example_proxy.yaml -o config_proxy.go -fmt yaml -pkg veneur -name ProxyConfig
 //go:generate stringer -type MetricType ./samplers
 //TODO(aditya) reenable go:generate gojson -input fixtures/datadog_trace.json -o datadog_trace_span.go -fmt json -pkg veneur -name DatadogTraceSpan

--- a/http_test.go
+++ b/http_test.go
@@ -295,7 +295,10 @@ func TestNoTracingConfiguredTraceHealthCheck(t *testing.T) {
 	config := localConfig()
 
 	config.SsfListenAddresses = []string{}
-	server, _ := NewFromConfig(logrus.New(), config)
+	server, _ := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 	server.Start()
 	defer server.Shutdown()
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -89,7 +89,10 @@ func TestLocalFilePluginRegister(t *testing.T) {
 	config := globalConfig()
 	config.FlushFile = "/dev/null"
 
-	server, err := NewFromConfig(logrus.New(), config)
+	server, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server.go
+++ b/server.go
@@ -837,41 +837,25 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 			logger.WithField("name", blackhole.Name()).Info("Starting logger debug sink")
 		}
 	}
-	switch conf.Features.MigrateMetricSinks {
-	case "append":
-		customMetricSinks, err :=
-			ret.createMetricSinks(logger, conf, config.MetricSinkTypes)
-		if err != nil {
-			return nil, err
-		}
-		ret.metricSinks = append(ret.metricSinks, customMetricSinks...)
-	case "exclusive":
-		customMetricSinks, err :=
-			ret.createMetricSinks(logger, conf, config.MetricSinkTypes)
-		if err != nil {
-			return nil, err
-		}
-		ret.metricSinks = customMetricSinks
-	default:
-		break
+	customMetricSinks, err :=
+		ret.createMetricSinks(logger, conf, config.MetricSinkTypes)
+	if err != nil {
+		return nil, err
 	}
-	switch conf.Features.MigrateSpanSinks {
-	case "append":
-		customSpanSinks, err :=
-			ret.createSpanSinks(logger, conf, config.SpanSinkTypes)
-		if err != nil {
-			return nil, err
-		}
-		ret.spanSinks = append(ret.spanSinks, customSpanSinks...)
-	case "exclusive":
-		customSpanSinks, err :=
-			ret.createSpanSinks(logger, conf, config.SpanSinkTypes)
-		if err != nil {
-			return nil, err
-		}
+	if conf.Features.MigrateMetricSinks {
+		ret.metricSinks = customMetricSinks
+	} else {
+		ret.metricSinks = append(ret.metricSinks, customMetricSinks...)
+	}
+	customSpanSinks, err :=
+		ret.createSpanSinks(logger, conf, config.SpanSinkTypes)
+	if err != nil {
+		return nil, err
+	}
+	if conf.Features.MigrateSpanSinks {
 		ret.spanSinks = customSpanSinks
-	default:
-		break
+	} else {
+		ret.spanSinks = append(ret.spanSinks, customSpanSinks...)
 	}
 
 	// After all sinks are initialized, set the list of tags to exclude

--- a/server.go
+++ b/server.go
@@ -82,12 +82,20 @@ const defaultTCPReadTimeout = 10 * time.Minute
 
 const httpQuitEndpoint = "/quitquitquit"
 
+type SpanSinkTypes = map[string]func(
+	*Server, string, Config, interface{},
+) (sinks.SpanSink, error)
+
+type MetricSinkTypes = map[string]func(
+	*Server, string, Config, interface{},
+) (sinks.MetricSink, error)
+
 // Config used to create a new server.
 type ServerConfig struct {
 	Config          Config
 	Logger          *logrus.Logger
-	MetricSinkTypes map[string]func(*Server, string, Config, interface{}) (sinks.MetricSink, error)
-	SpanSinkTypes   map[string]func(*Server, string, Config, interface{}) (sinks.SpanSink, error)
+	MetricSinkTypes MetricSinkTypes
+	SpanSinkTypes   SpanSinkTypes
 }
 
 // A Server is the actual veneur instance that will be run.
@@ -304,10 +312,6 @@ func scopesFromConfig(conf Config) (scopedstatsd.MetricScopes, error) {
 	return ms, nil
 }
 
-type SpanSinkTypes = map[string]func(
-	*Server, string, Config, interface{},
-) (sinks.SpanSink, error)
-
 func (server *Server) createSpanSinks(
 	logger *logrus.Logger, config Config, sinkTypes SpanSinkTypes,
 ) ([]sinks.SpanSink, error) {
@@ -325,10 +329,6 @@ func (server *Server) createSpanSinks(
 	}
 	return sinks, nil
 }
-
-type MetricSinkTypes = map[string]func(
-	*Server, string, Config, interface{},
-) (sinks.MetricSink, error)
 
 func (server *Server) createMetricSinks(
 	logger *logrus.Logger, config Config, sinkTypes MetricSinkTypes,

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -153,7 +153,10 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	server, err := NewFromConfig(logrus.New(), config)
+	server, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +177,10 @@ func TestNewPrometheusMetricSinkConfig(t *testing.T) {
 		StatsAddress: "localhost:62251",
 	}
 
-	server, err := NewFromConfig(logrus.New(), config)
+	server, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 	assert.NoError(t, err)
 
 	sink := server.metricSinks[0].(*prometheus.StatsdRepeater)

--- a/server_test.go
+++ b/server_test.go
@@ -133,7 +133,10 @@ func generateMetrics() (metricValues []float64, expectedMetrics map[string]float
 // "nothing".
 func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper, mSink sinks.MetricSink, sSink sinks.SpanSink, traceClient *trace.Client) *Server {
 	logger := logrus.New()
-	server, err := NewFromConfig(logger, config)
+	server, err := NewFromConfig(ServerConfig{
+		Logger: logger,
+		Config: config,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +475,10 @@ func TestTCPConfig(t *testing.T) {
 	logger.Out = ioutil.Discard
 
 	config.StatsdListenAddresses = []string{"tcp://invalid:invalid"}
-	_, err := NewFromConfig(logger, config)
+	_, err := NewFromConfig(ServerConfig{
+		Logger: logger,
+		Config: config,
+	})
 	if err == nil {
 		t.Error("invalid TCP address is a config error")
 	}
@@ -480,7 +486,10 @@ func TestTCPConfig(t *testing.T) {
 	config.StatsdListenAddresses = []string{"tcp://localhost:8129"}
 	config.TLSKey = "somekey"
 	config.TLSCertificate = ""
-	_, err = NewFromConfig(logger, config)
+	_, err = NewFromConfig(ServerConfig{
+		Logger: logger,
+		Config: config,
+	})
 	if err == nil {
 		t.Error("key without certificate is a config error")
 	}
@@ -491,14 +500,20 @@ func TestTCPConfig(t *testing.T) {
 	}
 	config.TLSKey = pems["serverkey.pem"]
 	config.TLSCertificate = "somecert"
-	_, err = NewFromConfig(logger, config)
+	_, err = NewFromConfig(ServerConfig{
+		Logger: logger,
+		Config: config,
+	})
 	if err == nil {
 		t.Error("invalid key and certificate is a config error")
 	}
 
 	config.TLSKey = pems["serverkey.pem"]
 	config.TLSCertificate = pems["servercert.pem"]
-	_, err = NewFromConfig(logger, config)
+	_, err = NewFromConfig(ServerConfig{
+		Logger: logger,
+		Config: config,
+	})
 	if err != nil {
 		t.Error("expected valid config")
 	}
@@ -1020,7 +1035,10 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	s, err := NewFromConfig(logrus.New(), config)
+	s, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1082,7 +1100,10 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 		Interval:     "10s",
 		StatsAddress: "localhost:62251",
 	}
-	s, err := NewFromConfig(logrus.New(), config)
+	s, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: config,
+	})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1363,7 +1384,10 @@ func generateSSFPackets(tb testing.TB, length int) [][]byte {
 // multiple times as Serve should try to call it again after the gRPC server
 // exits.
 func TestServeStopGRPC(t *testing.T) {
-	s, err := NewFromConfig(logrus.New(), globalConfig())
+	s, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: globalConfig(),
+	})
 	assert.NoError(t, err, "Creating a server shouldn't have caused an error")
 
 	done := make(chan struct{})
@@ -1412,7 +1436,10 @@ func TestServeStopHTTP(t *testing.T) {
 	t.Skipf("Testing stopping the Server over HTTP requires a slow pause, and " +
 		"this test probably doesn't need to be run all the time.")
 
-	s, err := NewFromConfig(logrus.New(), globalConfig())
+	s, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: globalConfig(),
+	})
 	assert.NoError(t, err, "Creating a server shouldn't have caused an error")
 
 	done := make(chan struct{})


### PR DESCRIPTION
Summary
r? @stripe/observability

Motivation
This change prepares for allowing custom sinks and multiple sinks of the same type, and cleans up the config format.

Test plan
N/A; all of the changes are guarded behind feature flags that are not yet ready for external consumption.

Deploy
N/A