### PR TITLE
Create a StringSecret type to enforce redacting secrets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # 14.2.0, UNRELEASED
 
+## Added
+* A flag -print-secrets to disable redacting config secrets.
+
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!
 * Regenerate testing certs/CA that have expired and have broken tests. Thanks, [randallm](https://github.com/randallm)
+* The config field `trace_lightstep_access_token` is redacted if printed. Thanks [arnavdugar](https://github.com/arnavdugar)!
 
 # 14.1.0, 2021-03-16
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -59,9 +59,9 @@ func main() {
 	veneur.SetLogger(logger)
 	if err != nil {
 		e := err
-		if conf.SentryDsn != "" {
+		if conf.SentryDsn.Value != "" {
 			err = sentry.Init(sentry.ClientOptions{
-				Dsn: conf.SentryDsn,
+				Dsn: conf.SentryDsn.Value,
 			})
 			if err != nil {
 				logrus.WithError(err).Error("Error initializing Sentry client")

--- a/config.go
+++ b/config.go
@@ -1,15 +1,17 @@
 package veneur
 
+import "github.com/stripe/veneur/v14/util"
+
 type Config struct {
-	Aggregates                             []string `yaml:"aggregates"`
-	AwsAccessKeyID                         string   `yaml:"aws_access_key_id"`
-	AwsRegion                              string   `yaml:"aws_region"`
-	AwsS3Bucket                            string   `yaml:"aws_s3_bucket"`
-	AwsSecretAccessKey                     string   `yaml:"aws_secret_access_key"`
-	BlockProfileRate                       int      `yaml:"block_profile_rate"`
-	CountUniqueTimeseries                  bool     `yaml:"count_unique_timeseries"`
-	DatadogAPIHostname                     string   `yaml:"datadog_api_hostname"`
-	DatadogAPIKey                          string   `yaml:"datadog_api_key"`
+	Aggregates                             []string          `yaml:"aggregates"`
+	AwsAccessKeyID                         util.StringSecret `yaml:"aws_access_key_id"`
+	AwsRegion                              string            `yaml:"aws_region"`
+	AwsS3Bucket                            string            `yaml:"aws_s3_bucket"`
+	AwsSecretAccessKey                     util.StringSecret `yaml:"aws_secret_access_key"`
+	BlockProfileRate                       int               `yaml:"block_profile_rate"`
+	CountUniqueTimeseries                  bool              `yaml:"count_unique_timeseries"`
+	DatadogAPIHostname                     string            `yaml:"datadog_api_hostname"`
+	DatadogAPIKey                          util.StringSecret `yaml:"datadog_api_key"`
 	DatadogExcludeTagsPrefixByPrefixMetric []struct {
 		MetricPrefix string   `yaml:"metric_prefix"`
 		Tags         []string `yaml:"tags"`
@@ -28,74 +30,74 @@ type Config struct {
 		MigrateMetricSinks bool `yaml:"migrate_metric_sinks"`
 		MigrateSpanSinks   bool `yaml:"migrate_span_sinks"`
 	}
-	FlushFile                    string   `yaml:"flush_file"`
-	FlushMaxPerBody              int      `yaml:"flush_max_per_body"`
-	FlushWatchdogMissedFlushes   int      `yaml:"flush_watchdog_missed_flushes"`
-	ForwardAddress               string   `yaml:"forward_address"`
-	ForwardUseGrpc               bool     `yaml:"forward_use_grpc"`
-	GrpcAddress                  string   `yaml:"grpc_address"`
-	GrpcListenAddresses          []string `yaml:"grpc_listen_addresses"`
-	Hostname                     string   `yaml:"hostname"`
-	HTTPAddress                  string   `yaml:"http_address"`
-	HTTPQuit                     bool     `yaml:"http_quit"`
-	IndicatorSpanTimerName       string   `yaml:"indicator_span_timer_name"`
-	Interval                     string   `yaml:"interval"`
-	KafkaBroker                  string   `yaml:"kafka_broker"`
-	KafkaCheckTopic              string   `yaml:"kafka_check_topic"`
-	KafkaEventTopic              string   `yaml:"kafka_event_topic"`
-	KafkaMetricBufferBytes       int      `yaml:"kafka_metric_buffer_bytes"`
-	KafkaMetricBufferFrequency   string   `yaml:"kafka_metric_buffer_frequency"`
-	KafkaMetricBufferMessages    int      `yaml:"kafka_metric_buffer_messages"`
-	KafkaMetricRequireAcks       string   `yaml:"kafka_metric_require_acks"`
-	KafkaMetricTopic             string   `yaml:"kafka_metric_topic"`
-	KafkaPartitioner             string   `yaml:"kafka_partitioner"`
-	KafkaRetryMax                int      `yaml:"kafka_retry_max"`
-	KafkaSpanBufferBytes         int      `yaml:"kafka_span_buffer_bytes"`
-	KafkaSpanBufferFrequency     string   `yaml:"kafka_span_buffer_frequency"`
-	KafkaSpanBufferMesages       int      `yaml:"kafka_span_buffer_mesages"`
-	KafkaSpanRequireAcks         string   `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRatePercent   float64  `yaml:"kafka_span_sample_rate_percent"`
-	KafkaSpanSampleTag           string   `yaml:"kafka_span_sample_tag"`
-	KafkaSpanSerializationFormat string   `yaml:"kafka_span_serialization_format"`
-	KafkaSpanTopic               string   `yaml:"kafka_span_topic"`
-	LightstepAccessToken         string   `yaml:"lightstep_access_token"`
-	LightstepCollectorHost       string   `yaml:"lightstep_collector_host"`
-	LightstepMaximumSpans        int      `yaml:"lightstep_maximum_spans"`
-	LightstepNumClients          int      `yaml:"lightstep_num_clients"`
-	LightstepReconnectPeriod     string   `yaml:"lightstep_reconnect_period"`
-	MetricMaxLength              int      `yaml:"metric_max_length"`
+	FlushFile                    string            `yaml:"flush_file"`
+	FlushMaxPerBody              int               `yaml:"flush_max_per_body"`
+	FlushWatchdogMissedFlushes   int               `yaml:"flush_watchdog_missed_flushes"`
+	ForwardAddress               string            `yaml:"forward_address"`
+	ForwardUseGrpc               bool              `yaml:"forward_use_grpc"`
+	GrpcAddress                  string            `yaml:"grpc_address"`
+	GrpcListenAddresses          []string          `yaml:"grpc_listen_addresses"`
+	Hostname                     string            `yaml:"hostname"`
+	HTTPAddress                  string            `yaml:"http_address"`
+	HTTPQuit                     bool              `yaml:"http_quit"`
+	IndicatorSpanTimerName       string            `yaml:"indicator_span_timer_name"`
+	Interval                     string            `yaml:"interval"`
+	KafkaBroker                  string            `yaml:"kafka_broker"`
+	KafkaCheckTopic              string            `yaml:"kafka_check_topic"`
+	KafkaEventTopic              string            `yaml:"kafka_event_topic"`
+	KafkaMetricBufferBytes       int               `yaml:"kafka_metric_buffer_bytes"`
+	KafkaMetricBufferFrequency   string            `yaml:"kafka_metric_buffer_frequency"`
+	KafkaMetricBufferMessages    int               `yaml:"kafka_metric_buffer_messages"`
+	KafkaMetricRequireAcks       string            `yaml:"kafka_metric_require_acks"`
+	KafkaMetricTopic             string            `yaml:"kafka_metric_topic"`
+	KafkaPartitioner             string            `yaml:"kafka_partitioner"`
+	KafkaRetryMax                int               `yaml:"kafka_retry_max"`
+	KafkaSpanBufferBytes         int               `yaml:"kafka_span_buffer_bytes"`
+	KafkaSpanBufferFrequency     string            `yaml:"kafka_span_buffer_frequency"`
+	KafkaSpanBufferMesages       int               `yaml:"kafka_span_buffer_mesages"`
+	KafkaSpanRequireAcks         string            `yaml:"kafka_span_require_acks"`
+	KafkaSpanSampleRatePercent   float64           `yaml:"kafka_span_sample_rate_percent"`
+	KafkaSpanSampleTag           string            `yaml:"kafka_span_sample_tag"`
+	KafkaSpanSerializationFormat string            `yaml:"kafka_span_serialization_format"`
+	KafkaSpanTopic               string            `yaml:"kafka_span_topic"`
+	LightstepAccessToken         util.StringSecret `yaml:"lightstep_access_token"`
+	LightstepCollectorHost       string            `yaml:"lightstep_collector_host"`
+	LightstepMaximumSpans        int               `yaml:"lightstep_maximum_spans"`
+	LightstepNumClients          int               `yaml:"lightstep_num_clients"`
+	LightstepReconnectPeriod     string            `yaml:"lightstep_reconnect_period"`
+	MetricMaxLength              int               `yaml:"metric_max_length"`
 	MetricSinks                  []struct {
 		Kind   string      `yaml:"kind"`
 		Name   string      `yaml:"name"`
 		Config interface{} `yaml:"config"`
 	} `yaml:"metric_sinks"`
-	MutexProfileFraction                      int       `yaml:"mutex_profile_fraction"`
-	NewrelicAccountID                         int       `yaml:"newrelic_account_id"`
-	NewrelicCommonTags                        []string  `yaml:"newrelic_common_tags"`
-	NewrelicEventType                         string    `yaml:"newrelic_event_type"`
-	NewrelicInsertKey                         string    `yaml:"newrelic_insert_key"`
-	NewrelicRegion                            string    `yaml:"newrelic_region"`
-	NewrelicServiceCheckEventType             string    `yaml:"newrelic_service_check_event_type"`
-	NewrelicTraceObserverURL                  string    `yaml:"newrelic_trace_observer_url"`
-	NumReaders                                int       `yaml:"num_readers"`
-	NumSpanWorkers                            int       `yaml:"num_span_workers"`
-	NumWorkers                                int       `yaml:"num_workers"`
-	ObjectiveSpanTimerName                    string    `yaml:"objective_span_timer_name"`
-	OmitEmptyHostname                         bool      `yaml:"omit_empty_hostname"`
-	Percentiles                               []float64 `yaml:"percentiles"`
-	PrometheusNetworkType                     string    `yaml:"prometheus_network_type"`
-	PrometheusRepeaterAddress                 string    `yaml:"prometheus_repeater_address"`
-	ReadBufferSizeBytes                       int       `yaml:"read_buffer_size_bytes"`
-	SentryDsn                                 string    `yaml:"sentry_dsn"`
-	SignalfxAPIKey                            string    `yaml:"signalfx_api_key"`
-	SignalfxDynamicPerTagAPIKeysEnable        bool      `yaml:"signalfx_dynamic_per_tag_api_keys_enable"`
-	SignalfxDynamicPerTagAPIKeysRefreshPeriod string    `yaml:"signalfx_dynamic_per_tag_api_keys_refresh_period"`
-	SignalfxEndpointAPI                       string    `yaml:"signalfx_endpoint_api"`
-	SignalfxEndpointBase                      string    `yaml:"signalfx_endpoint_base"`
-	SignalfxFlushMaxPerBody                   int       `yaml:"signalfx_flush_max_per_body"`
-	SignalfxHostnameTag                       string    `yaml:"signalfx_hostname_tag"`
-	SignalfxMetricNamePrefixDrops             []string  `yaml:"signalfx_metric_name_prefix_drops"`
-	SignalfxMetricTagPrefixDrops              []string  `yaml:"signalfx_metric_tag_prefix_drops"`
+	MutexProfileFraction                      int               `yaml:"mutex_profile_fraction"`
+	NewrelicAccountID                         int               `yaml:"newrelic_account_id"`
+	NewrelicCommonTags                        []string          `yaml:"newrelic_common_tags"`
+	NewrelicEventType                         string            `yaml:"newrelic_event_type"`
+	NewrelicInsertKey                         util.StringSecret `yaml:"newrelic_insert_key"`
+	NewrelicRegion                            string            `yaml:"newrelic_region"`
+	NewrelicServiceCheckEventType             string            `yaml:"newrelic_service_check_event_type"`
+	NewrelicTraceObserverURL                  string            `yaml:"newrelic_trace_observer_url"`
+	NumReaders                                int               `yaml:"num_readers"`
+	NumSpanWorkers                            int               `yaml:"num_span_workers"`
+	NumWorkers                                int               `yaml:"num_workers"`
+	ObjectiveSpanTimerName                    string            `yaml:"objective_span_timer_name"`
+	OmitEmptyHostname                         bool              `yaml:"omit_empty_hostname"`
+	Percentiles                               []float64         `yaml:"percentiles"`
+	PrometheusNetworkType                     string            `yaml:"prometheus_network_type"`
+	PrometheusRepeaterAddress                 string            `yaml:"prometheus_repeater_address"`
+	ReadBufferSizeBytes                       int               `yaml:"read_buffer_size_bytes"`
+	SentryDsn                                 util.StringSecret `yaml:"sentry_dsn"`
+	SignalfxAPIKey                            util.StringSecret `yaml:"signalfx_api_key"`
+	SignalfxDynamicPerTagAPIKeysEnable        bool              `yaml:"signalfx_dynamic_per_tag_api_keys_enable"`
+	SignalfxDynamicPerTagAPIKeysRefreshPeriod string            `yaml:"signalfx_dynamic_per_tag_api_keys_refresh_period"`
+	SignalfxEndpointAPI                       string            `yaml:"signalfx_endpoint_api"`
+	SignalfxEndpointBase                      string            `yaml:"signalfx_endpoint_base"`
+	SignalfxFlushMaxPerBody                   int               `yaml:"signalfx_flush_max_per_body"`
+	SignalfxHostnameTag                       string            `yaml:"signalfx_hostname_tag"`
+	SignalfxMetricNamePrefixDrops             []string          `yaml:"signalfx_metric_name_prefix_drops"`
+	SignalfxMetricTagPrefixDrops              []string          `yaml:"signalfx_metric_tag_prefix_drops"`
 	SignalfxPerTagAPIKeys                     []struct {
 		APIKey string `yaml:"api_key"`
 		Name   string `yaml:"name"`
@@ -107,33 +109,33 @@ type Config struct {
 		Name   string      `yaml:"name"`
 		Config interface{} `yaml:"config"`
 	} `yaml:"span_sinks"`
-	SplunkHecAddress                  string   `yaml:"splunk_hec_address"`
-	SplunkHecBatchSize                int      `yaml:"splunk_hec_batch_size"`
-	SplunkHecConnectionLifetimeJitter string   `yaml:"splunk_hec_connection_lifetime_jitter"`
-	SplunkHecIngestTimeout            string   `yaml:"splunk_hec_ingest_timeout"`
-	SplunkHecMaxConnectionLifetime    string   `yaml:"splunk_hec_max_connection_lifetime"`
-	SplunkHecSendTimeout              string   `yaml:"splunk_hec_send_timeout"`
-	SplunkHecSubmissionWorkers        int      `yaml:"splunk_hec_submission_workers"`
-	SplunkHecTLSValidateHostname      string   `yaml:"splunk_hec_tls_validate_hostname"`
-	SplunkHecToken                    string   `yaml:"splunk_hec_token"`
-	SplunkSpanSampleRate              int      `yaml:"splunk_span_sample_rate"`
-	SsfBufferSize                     int      `yaml:"ssf_buffer_size"`
-	SsfListenAddresses                []string `yaml:"ssf_listen_addresses"`
-	StatsAddress                      string   `yaml:"stats_address"`
-	StatsdListenAddresses             []string `yaml:"statsd_listen_addresses"`
-	SynchronizeWithInterval           bool     `yaml:"synchronize_with_interval"`
-	Tags                              []string `yaml:"tags"`
-	TagsExclude                       []string `yaml:"tags_exclude"`
-	TLSAuthorityCertificate           string   `yaml:"tls_authority_certificate"`
-	TLSCertificate                    string   `yaml:"tls_certificate"`
-	TLSKey                            string   `yaml:"tls_key"`
-	TraceLightstepAccessToken         string   `yaml:"trace_lightstep_access_token"`
-	TraceLightstepCollectorHost       string   `yaml:"trace_lightstep_collector_host"`
-	TraceLightstepMaximumSpans        int      `yaml:"trace_lightstep_maximum_spans"`
-	TraceLightstepNumClients          int      `yaml:"trace_lightstep_num_clients"`
-	TraceLightstepReconnectPeriod     string   `yaml:"trace_lightstep_reconnect_period"`
-	TraceMaxLengthBytes               int      `yaml:"trace_max_length_bytes"`
-	VeneurMetricsAdditionalTags       []string `yaml:"veneur_metrics_additional_tags"`
+	SplunkHecAddress                  string            `yaml:"splunk_hec_address"`
+	SplunkHecBatchSize                int               `yaml:"splunk_hec_batch_size"`
+	SplunkHecConnectionLifetimeJitter string            `yaml:"splunk_hec_connection_lifetime_jitter"`
+	SplunkHecIngestTimeout            string            `yaml:"splunk_hec_ingest_timeout"`
+	SplunkHecMaxConnectionLifetime    string            `yaml:"splunk_hec_max_connection_lifetime"`
+	SplunkHecSendTimeout              string            `yaml:"splunk_hec_send_timeout"`
+	SplunkHecSubmissionWorkers        int               `yaml:"splunk_hec_submission_workers"`
+	SplunkHecTLSValidateHostname      string            `yaml:"splunk_hec_tls_validate_hostname"`
+	SplunkHecToken                    string            `yaml:"splunk_hec_token"`
+	SplunkSpanSampleRate              int               `yaml:"splunk_span_sample_rate"`
+	SsfBufferSize                     int               `yaml:"ssf_buffer_size"`
+	SsfListenAddresses                []string          `yaml:"ssf_listen_addresses"`
+	StatsAddress                      string            `yaml:"stats_address"`
+	StatsdListenAddresses             []string          `yaml:"statsd_listen_addresses"`
+	SynchronizeWithInterval           bool              `yaml:"synchronize_with_interval"`
+	Tags                              []string          `yaml:"tags"`
+	TagsExclude                       []string          `yaml:"tags_exclude"`
+	TLSAuthorityCertificate           string            `yaml:"tls_authority_certificate"`
+	TLSCertificate                    string            `yaml:"tls_certificate"`
+	TLSKey                            util.StringSecret `yaml:"tls_key"`
+	TraceLightstepAccessToken         util.StringSecret `yaml:"trace_lightstep_access_token"`
+	TraceLightstepCollectorHost       string            `yaml:"trace_lightstep_collector_host"`
+	TraceLightstepMaximumSpans        int               `yaml:"trace_lightstep_maximum_spans"`
+	TraceLightstepNumClients          int               `yaml:"trace_lightstep_num_clients"`
+	TraceLightstepReconnectPeriod     string            `yaml:"trace_lightstep_reconnect_period"`
+	TraceMaxLengthBytes               int               `yaml:"trace_max_length_bytes"`
+	VeneurMetricsAdditionalTags       []string          `yaml:"veneur_metrics_additional_tags"`
 	VeneurMetricsScopes               struct {
 		Counter   string `yaml:"counter"`
 		Gauge     string `yaml:"gauge"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -193,9 +193,9 @@ func (c *Config) applyDefaults() {
 			c.LightstepCollectorHost = c.TraceLightstepCollectorHost
 		}
 	}
-	if c.TraceLightstepAccessToken != "" {
+	if c.TraceLightstepAccessToken.Value != "" {
 		log.Warn("trace_lightstep_access_token configuration option has been replaced by lightstep_access_token and will be removed in the next version")
-		if c.LightstepAccessToken == "" {
+		if c.LightstepAccessToken.Value == "" {
 			c.LightstepAccessToken = c.TraceLightstepAccessToken
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -170,7 +170,7 @@ trace_lightstep_num_clients: 2
 	// they should get copied to the new config options
 	assert.Equal(t, 1234, c.DatadogFlushMaxPerBody)
 	assert.Equal(t, 3456, c.DatadogSpanBufferSize)
-	assert.Equal(t, "123", c.LightstepAccessToken)
+	assert.Equal(t, "123", c.LightstepAccessToken.Value)
 	assert.Equal(t, "456", c.LightstepCollectorHost)
 	assert.Equal(t, "789", c.LightstepReconnectPeriod)
 	assert.Equal(t, 1, c.LightstepMaximumSpans)

--- a/http_test.go
+++ b/http_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stripe/veneur/v14/trace"
+	"github.com/stripe/veneur/v14/util"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -277,7 +278,7 @@ func TestOkTraceHealthCheck(t *testing.T) {
 	config := localConfig()
 	// We must enable tracing, as it's disabled by default, by turning on one
 	// of the tracing sinks.
-	config.LightstepAccessToken = "farts"
+	config.LightstepAccessToken = util.StringSecret{Value: "farts"}
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/sinks/prometheus"
+	"github.com/stripe/veneur/v14/util"
 )
 
 func TestFlushTracesBySink(t *testing.T) {
@@ -85,7 +86,7 @@ func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
 	defer remoteServer.Close()
 
 	config := globalConfig()
-	config.DatadogAPIKey = "secret"
+	config.DatadogAPIKey = util.StringSecret{Value: "secret"}
 	config.DatadogTraceAPIAddress = remoteServer.URL
 
 	server := setupVeneurServer(t, config, nil, nil, nil, nil)
@@ -121,7 +122,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 	config := globalConfig()
 
 	// this can be anything as long as it's not empty
-	config.LightstepAccessToken = "secret"
+	config.LightstepAccessToken = util.StringSecret{Value: "secret"}
 	server := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer server.Shutdown()
 
@@ -143,7 +144,7 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 func TestNewDatadogMetricSinkConfig(t *testing.T) {
 	// test the variables that have been renamed
 	config := Config{
-		DatadogAPIKey:          "apikey",
+		DatadogAPIKey:          util.StringSecret{Value: "apikey"},
 		DatadogAPIHostname:     "http://api",
 		DatadogTraceAPIAddress: "http://trace",
 		DatadogSpanBufferSize:  32,

--- a/server_test.go
+++ b/server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stripe/veneur/v14/tdigest"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+	"github.com/stripe/veneur/v14/util"
 	"github.com/zenazn/goji/graceful"
 )
 
@@ -76,7 +77,7 @@ func generateConfig(forwardAddr string) Config {
 
 		// Use a shorter interval for tests
 		Interval:              DefaultFlushInterval.String(),
-		DatadogAPIKey:         "",
+		DatadogAPIKey:         util.StringSecret{Value: ""},
 		MetricMaxLength:       4096,
 		Percentiles:           []float64{.5, .75, .99},
 		Aggregates:            []string{"min", "max", "count"},
@@ -98,7 +99,7 @@ func generateConfig(forwardAddr string) Config {
 		// more complicated.
 		StatsAddress:           "localhost:8125",
 		Tags:                   []string{},
-		SentryDsn:              "",
+		SentryDsn:              util.StringSecret{Value: ""},
 		DatadogFlushMaxPerBody: 1024,
 
 		// Don't use the default port 8128: Veneur sends its own traces there, causing failures
@@ -484,7 +485,7 @@ func TestTCPConfig(t *testing.T) {
 	}
 
 	config.StatsdListenAddresses = []string{"tcp://localhost:8129"}
-	config.TLSKey = "somekey"
+	config.TLSKey = util.StringSecret{Value: "somekey"}
 	config.TLSCertificate = ""
 	_, err = NewFromConfig(ServerConfig{
 		Logger: logger,
@@ -498,7 +499,7 @@ func TestTCPConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal("could not read test keys/certs:", err)
 	}
-	config.TLSKey = pems["serverkey.pem"]
+	config.TLSKey = util.StringSecret{Value: pems["serverkey.pem"]}
 	config.TLSCertificate = "somecert"
 	_, err = NewFromConfig(ServerConfig{
 		Logger: logger,
@@ -508,7 +509,7 @@ func TestTCPConfig(t *testing.T) {
 		t.Error("invalid key and certificate is a config error")
 	}
 
-	config.TLSKey = pems["serverkey.pem"]
+	config.TLSKey = util.StringSecret{Value: pems["serverkey.pem"]}
 	config.TLSCertificate = pems["servercert.pem"]
 	_, err = NewFromConfig(ServerConfig{
 		Logger: logger,
@@ -914,7 +915,7 @@ func TestTCPMetrics(t *testing.T) {
 			config.Interval = "60s"
 			config.NumWorkers = 1
 			config.StatsdListenAddresses = []string{"tcp://127.0.0.1:0"}
-			config.TLSKey = serverConfig.serverKey
+			config.TLSKey = util.StringSecret{Value: serverConfig.serverKey}
 			config.TLSCertificate = serverConfig.serverCertificate
 			config.TLSAuthorityCertificate = serverConfig.authorityCertificate
 			f := newFixture(t, config, nil, nil)
@@ -1026,7 +1027,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 	path := filepath.Join(tdir, "test.sock")
 	// test the variables that have been renamed
 	config := Config{
-		DatadogAPIKey:          "apikey",
+		DatadogAPIKey:          util.StringSecret{Value: "apikey"},
 		DatadogAPIHostname:     "http://api",
 		DatadogTraceAPIAddress: "http://trace",
 		SsfListenAddresses:     []string{fmt.Sprintf("unix://%s", path)},
@@ -1089,7 +1090,7 @@ func BenchmarkSendSSFUNIX(b *testing.B) {
 func BenchmarkSendSSFUDP(b *testing.B) {
 	// test the variables that have been renamed
 	config := Config{
-		DatadogAPIKey:          "apikey",
+		DatadogAPIKey:          util.StringSecret{Value: "apikey"},
 		DatadogAPIHostname:     "http://api",
 		DatadogTraceAPIAddress: "http://trace",
 		SsfListenAddresses:     []string{"udp://127.0.0.1:0"},

--- a/util/string_secret.go
+++ b/util/string_secret.go
@@ -1,0 +1,26 @@
+package util
+
+import "flag"
+
+var PrintSecrets = flag.Bool(
+	"print-secrets", false, "Disables redacting config secrets")
+
+const Redacted = "REDACTED"
+
+type StringSecret struct {
+	Value string
+}
+
+func (s StringSecret) String() string {
+	if *PrintSecrets {
+		return s.Value
+	}
+	if s.Value == "" {
+		return ""
+	}
+	return Redacted
+}
+
+func (s *StringSecret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return unmarshal(&s.Value)
+}

--- a/util/string_secret_test.go
+++ b/util/string_secret_test.go
@@ -1,0 +1,46 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/v14/util"
+	"gopkg.in/yaml.v3"
+)
+
+type yamlStruct struct {
+	StringSecret util.StringSecret `yaml:"stringSecret"`
+}
+
+func TestUnmarshal(t *testing.T) {
+	yamlFile := []byte("stringSecret: secret-value")
+	data := yamlStruct{}
+	err := yaml.Unmarshal(yamlFile, &data)
+	assert.Nil(t, err)
+	assert.Equal(t, "secret-value", data.StringSecret.Value)
+}
+
+func TestPrint(t *testing.T) {
+	stringSecret := util.StringSecret{Value: "secret-value"}
+	printedStringSecret := fmt.Sprintf("%v", stringSecret)
+	assert.Equal(t, util.Redacted, printedStringSecret)
+}
+
+func TestPrintEmptyValue(t *testing.T) {
+	stringSecret := util.StringSecret{Value: ""}
+	printedStringSecret := fmt.Sprintf("%v", stringSecret)
+	assert.Equal(t, "", printedStringSecret)
+}
+
+func TestPrintRedactingDisabled(t *testing.T) {
+	*util.PrintSecrets = true
+	stringSecret := util.StringSecret{Value: "secret-value"}
+	printedStringSecret := fmt.Sprintf("%v", stringSecret)
+	assert.Equal(t, "secret-value", printedStringSecret)
+}
+
+func TestGetValue(t *testing.T) {
+	stringSecret := util.StringSecret{Value: "secret-value"}
+	assert.Equal(t, "secret-value", stringSecret.Value)
+}


### PR DESCRIPTION
#### Summary
This change simplifies making sure sensitive config values are not accidentally logged. In addition, the field `trace_lightstep_access_token` is now marked to be redacted.


#### Motivation
This change makes it easier to audit that the correct fields are marked to be redacted.


#### Test plan
```
go test github.com/stripe/veneur/v14
```
