### PR TITLE
Migrate signalfx sink to new config format.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,10 @@
 package veneur
 
-import "github.com/stripe/veneur/v14/util"
+import (
+	"time"
+
+	"github.com/stripe/veneur/v14/util"
+)
 
 type Config struct {
 	Aggregates                             []string          `yaml:"aggregates"`
@@ -91,7 +95,7 @@ type Config struct {
 	SentryDsn                                 util.StringSecret `yaml:"sentry_dsn"`
 	SignalfxAPIKey                            util.StringSecret `yaml:"signalfx_api_key"`
 	SignalfxDynamicPerTagAPIKeysEnable        bool              `yaml:"signalfx_dynamic_per_tag_api_keys_enable"`
-	SignalfxDynamicPerTagAPIKeysRefreshPeriod string            `yaml:"signalfx_dynamic_per_tag_api_keys_refresh_period"`
+	SignalfxDynamicPerTagAPIKeysRefreshPeriod time.Duration     `yaml:"signalfx_dynamic_per_tag_api_keys_refresh_period"`
 	SignalfxEndpointAPI                       string            `yaml:"signalfx_endpoint_api"`
 	SignalfxEndpointBase                      string            `yaml:"signalfx_endpoint_base"`
 	SignalfxFlushMaxPerBody                   int               `yaml:"signalfx_flush_max_per_body"`

--- a/config.go
+++ b/config.go
@@ -99,8 +99,8 @@ type Config struct {
 	SignalfxMetricNamePrefixDrops             []string          `yaml:"signalfx_metric_name_prefix_drops"`
 	SignalfxMetricTagPrefixDrops              []string          `yaml:"signalfx_metric_tag_prefix_drops"`
 	SignalfxPerTagAPIKeys                     []struct {
-		APIKey string `yaml:"api_key"`
-		Name   string `yaml:"name"`
+		APIKey util.StringSecret `yaml:"api_key"`
+		Name   string            `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`
 	SignalfxVaryKeyBy   string `yaml:"signalfx_vary_key_by"`
 	SpanChannelCapacity int    `yaml:"span_channel_capacity"`

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/lightstep/lightstep-tracer-go v0.13.1-0.20170818234450-ea8cdd9df863
 	github.com/mailru/easyjson v0.0.0-20180606163543-3fdea8d05856 // indirect
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/newrelic/newrelic-client-go v0.39.0
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.4.0
 	github.com/opentracing/opentracing-go v1.0.2
@@ -61,6 +62,7 @@ require (
 	gopkg.in/logfmt.v0 v0.3.0 // indirect
 	gopkg.in/stack.v1 v1.6.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.0.0-20190325185214-7544f9db76f6
 	k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841
 	k8s.io/client-go v8.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -534,6 +534,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/server.go
+++ b/server.go
@@ -78,11 +78,11 @@ const defaultTCPReadTimeout = 10 * time.Minute
 const httpQuitEndpoint = "/quitquitquit"
 
 type SpanSinkTypes = map[string]func(
-	*Server, string, Config, interface{},
+	*Server, string, *logrus.Entry, Config, interface{},
 ) (sinks.SpanSink, error)
 
 type MetricSinkTypes = map[string]func(
-	*Server, string, Config, interface{},
+	*Server, string, *logrus.Entry, Config, interface{},
 ) (sinks.MetricSink, error)
 
 // Config used to create a new server.
@@ -213,10 +213,6 @@ func SetLogger(logger *logrus.Logger) {
 	log = logger
 }
 
-func GetLogger() *logrus.Logger {
-	return log
-}
-
 func scopeFromName(name string) (ssf.SSFSample_Scope, error) {
 	switch name {
 	case "default":
@@ -320,7 +316,9 @@ func (server *Server) createSpanSinks(
 		if !ok {
 			logger.Warnf("Unknown sink kind %s; skipping.", sinkConfig.Kind)
 		}
-		sink, err := sinkFactory(server, sinkConfig.Name, config, sinkConfig.Config)
+		sink, err := sinkFactory(
+			server, sinkConfig.Name, logger.WithField("sink", sinkConfig.Name),
+			config, sinkConfig.Config)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +336,9 @@ func (server *Server) createMetricSinks(
 		if !ok {
 			logger.Warnf("Unknown sink kind %s; skipping.", sinkConfig.Kind)
 		}
-		sink, err := sinkFactory(server, sinkConfig.Name, config, sinkConfig.Config)
+		sink, err := sinkFactory(
+			server, sinkConfig.Name, logger.WithField("sink", sinkConfig.Name),
+			config, sinkConfig.Config)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/pkg/profile"
 
-	vhttp "github.com/stripe/veneur/v14/http"
 	"github.com/stripe/veneur/v14/importsrv"
 	"github.com/stripe/veneur/v14/plugins"
 	localfilep "github.com/stripe/veneur/v14/plugins/localfile"
@@ -51,7 +50,6 @@ import (
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/sinks/newrelic"
 	"github.com/stripe/veneur/v14/sinks/prometheus"
-	"github.com/stripe/veneur/v14/sinks/signalfx"
 	"github.com/stripe/veneur/v14/sinks/splunk"
 	"github.com/stripe/veneur/v14/sinks/ssfmetrics"
 	"github.com/stripe/veneur/v14/sinks/xray"
@@ -213,6 +211,10 @@ type ssfServiceSpanMetrics struct {
 // SetLogger sets the default logger in veneur to the passed value.
 func SetLogger(logger *logrus.Logger) {
 	log = logger
+}
+
+func GetLogger() *logrus.Logger {
+	return log
 }
 
 func scopeFromName(name string) (ssf.SSFSample_Scope, error) {
@@ -573,40 +575,6 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 			ClientAuth:   clientAuthMode,
 			ClientCAs:    clientCAs,
 		}
-	}
-
-	if conf.SignalfxAPIKey.Value != "" {
-		tracedHTTP := *ret.HTTPClient
-		tracedHTTP.Transport = vhttp.NewTraceRoundTripper(tracedHTTP.Transport, ret.TraceClient, "signalfx")
-
-		fallback := signalfx.NewClient(
-			conf.SignalfxEndpointBase, conf.SignalfxAPIKey.Value, &tracedHTTP)
-		byTagClients := map[string]signalfx.DPClient{}
-		for _, perTag := range conf.SignalfxPerTagAPIKeys {
-			byTagClients[perTag.Name] = signalfx.NewClient(conf.SignalfxEndpointBase, perTag.APIKey, &tracedHTTP)
-		}
-
-		if conf.SignalfxDynamicPerTagAPIKeysRefreshPeriod == "" {
-			conf.SignalfxDynamicPerTagAPIKeysRefreshPeriod = "10m"
-		}
-
-		dynamicKeyRefreshPeriod, err := time.ParseDuration(conf.SignalfxDynamicPerTagAPIKeysRefreshPeriod)
-		if err != nil {
-			return ret, err
-		}
-
-		log.WithField("endpoint_base", conf.SignalfxEndpointBase).Info("Creating SignalFx sink")
-		sfxSink, err := signalfx.NewSignalFxSink(
-			conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback,
-			conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops,
-			conf.SignalfxMetricTagPrefixDrops, metricSink,
-			conf.SignalfxFlushMaxPerBody, conf.SignalfxAPIKey.Value,
-			conf.SignalfxDynamicPerTagAPIKeysEnable, dynamicKeyRefreshPeriod,
-			conf.SignalfxEndpointBase, conf.SignalfxEndpointAPI, &tracedHTTP)
-		if err != nil {
-			return ret, err
-		}
-		ret.metricSinks = append(ret.metricSinks, sfxSink)
 	}
 
 	if conf.NewrelicInsertKey.Value != "" && conf.NewrelicAccountID > 0 {

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stripe/veneur/v14/protocol/dogstatsd"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/ssf"
+	"github.com/stripe/veneur/v14/util"
 )
 
 type FakeSink struct {
@@ -84,8 +85,18 @@ func newDerivedProcessor() *testDerivedSink {
 func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
 	client := NewClient("http://www.example.com", "secret", http.DefaultClient)
-	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), client, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,26 +106,34 @@ func TestNewSignalFxSink(t *testing.T) {
 	}
 
 	httpsink, ok := client.(*sfxclient.HTTPSink)
-	if !ok {
-		assert.Fail(t, "SignalFx sink isn't the correct type")
-	}
+	assert.True(t, ok, "SignalFx sink isn't the correct type")
 	assert.Equal(t, "http://www.example.com/v2/datapoint", httpsink.DatapointEndpoint)
 	assert.Equal(t, "http://www.example.com/v2/event", httpsink.EventEndpoint)
 
 	assert.Equal(t, "signalfx", sink.Name())
 	assert.Equal(t, "host", sink.hostnameTag)
-	assert.Equal(t, "glooblestoots", sink.hostname)
+	assert.Equal(t, "signalfx-hostname", sink.hostname)
 	assert.Equal(t, map[string]string{"yay": "pie"}, sink.commonDimensions)
 }
 
 func TestSignalFxFlushRouting(t *testing.T) {
 	fakeSink := NewFakeSink()
-	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "any",
 		Timestamp: 1476119058,
 		Value:     float64(100),
@@ -123,32 +142,29 @@ func TestSignalFxFlushRouting(t *testing.T) {
 			"baz:quz",
 		},
 		Type: samplers.GaugeMetric,
-	},
-		samplers.InterMetric{
-			Name:      "sfx",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"veneursinkonly:signalfx",
-			},
-			Type:  samplers.GaugeMetric,
-			Sinks: samplers.RouteInformation{"signalfx": struct{}{}},
+	}, {
+		Name:      "sfx",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"veneursinkonly:signalfx",
 		},
-		samplers.InterMetric{
-			Name:      "not.us",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"veneursinkonly:anyone_else",
-			},
-			Type:  samplers.GaugeMetric,
-			Sinks: samplers.RouteInformation{"anyone_else": struct{}{}},
+		Type:  samplers.GaugeMetric,
+		Sinks: samplers.RouteInformation{"signalfx": struct{}{}},
+	}, {
+		Name:      "not.us",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"veneursinkonly:anyone_else",
 		},
-	}
+		Type:  samplers.GaugeMetric,
+		Sinks: samplers.RouteInformation{"anyone_else": struct{}{}},
+	}}
 
 	sink.Flush(context.TODO(), interMetrics)
 
@@ -164,11 +180,23 @@ func TestSignalFxFlushRouting(t *testing.T) {
 func TestSignalFxFlushGauge(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "a.b.c",
 		Timestamp: 1476119058,
 		Value:     float64(100),
@@ -193,17 +221,28 @@ func TestSignalFxFlushGauge(t *testing.T) {
 	assert.Equal(t, "bar", dims["foo"], "Metric has a busted tag")
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing common tag")
-	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
+	assert.Equal(t, "signalfx-hostname", dims["host"], "Metric is missing host tag")
 	assert.Empty(t, derived.samples, "Gauges should not generated derived metrics")
 }
 
 func TestSignalFxFlushCounter(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "a.b.c",
 		Timestamp: 1476119058,
 		Value:     10,
@@ -230,51 +269,57 @@ func TestSignalFxFlushCounter(t *testing.T) {
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "", dims["novalue"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing a common tag")
-	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
+	assert.Equal(t, "signalfx-hostname", dims["host"], "Metric is missing host tag")
 	assert.Empty(t, derived.samples, "Counters should not generated derived metrics")
 }
 
 func TestSignalFxFlushWithDrops(t *testing.T) {
 	fakeSink := NewFakeSink()
-	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, []string{"foo.bar"}, []string{"baz:gorch"}, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             []string{"foo.bar"},
+		MetricTagPrefixDrops:              []string{"baz:gorch"},
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{
-		samplers.InterMetric{
-			Name:      "foo.bar.baz", // tag prefix drop
-			Timestamp: 1476119058,
-			Value:     10,
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"novalue",
-			},
-			Type: samplers.CounterMetric,
+	interMetrics := []samplers.InterMetric{{
+		Name:      "foo.bar.baz", // tag prefix drop
+		Timestamp: 1476119058,
+		Value:     10,
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"novalue",
 		},
-		samplers.InterMetric{
-			Name:      "fart.farts",
-			Timestamp: 1476119058,
-			Value:     10,
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"novalue",
-			},
-			Type: samplers.CounterMetric,
+		Type: samplers.CounterMetric,
+	}, {
+		Name:      "fart.farts",
+		Timestamp: 1476119058,
+		Value:     10,
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"novalue",
 		},
-		samplers.InterMetric{
-			Name:      "fart.farts2",
-			Timestamp: 1476119058,
-			Value:     10,
-			Tags: []string{
-				"baz:gorch", // literal tag drop
-				"baz:quz",
-				"novalue",
-			},
-			Type: samplers.CounterMetric,
+		Type: samplers.CounterMetric,
+	}, {
+		Name:      "fart.farts2",
+		Timestamp: 1476119058,
+		Value:     10,
+		Tags: []string{
+			"baz:gorch", // literal tag drop
+			"baz:quz",
+			"novalue",
 		},
-	}
+		Type: samplers.CounterMetric,
+	}}
 
 	sink.Flush(context.TODO(), interMetrics)
 
@@ -286,10 +331,21 @@ func TestSignalFxFlushWithDrops(t *testing.T) {
 func TestSignalFxFlushStatus(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "a.b.c",
 		Timestamp: 1476119058,
 		Value:     float64(ssf.SSFSample_UNKNOWN),
@@ -317,14 +373,25 @@ func TestSignalFxFlushStatus(t *testing.T) {
 	assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 	assert.Equal(t, "", dims["novalue"], "Metric has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Metric is missing a common tag")
-	assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
+	assert.Equal(t, "signalfx-hostname", dims["host"], "Metric is missing host tag")
 	assert.Empty(t, derived.samples, "Counters should not generated derived metrics")
 }
 
 func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	serviceCheckMsg := "Service Farts starting[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -344,8 +411,18 @@ func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 
 func TestSignalFxEventFlush(t *testing.T) {
 	fakeSink := NewFakeSink()
-	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	evMessage := "[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -370,18 +447,28 @@ func TestSignalFxEventFlush(t *testing.T) {
 	assert.Equal(t, "gorch", dims["baz"], "Event has a busted tag")
 	assert.Equal(t, "pie", dims["yay"], "Event missing a common tag")
 	assert.Equal(t, "", dims["novalue"], "Event has a busted tag")
-	assert.Equal(t, "glooblestoots", dims["host"], "Event is missing host tag")
+	assert.Equal(t, "signalfx-hostname", dims["host"], "Event is missing host tag")
 }
 
 func TestSignalFxSetExcludeTags(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie", "boo": "snakes"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
-
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
 	sink.SetExcludedTags([]string{"foo", "boo", "host"})
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "a.b.c",
 		Timestamp: 1476119058,
 		Value:     10,
@@ -440,34 +527,41 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 	specialized := NewFakeSink()
 
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{"available": specialized}, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
-
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "test_by",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{"available": specialized}, nil)
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{
-		samplers.InterMetric{
-			Name:      "a.b.c",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:needs_fallback",
-			},
-			Type: samplers.GaugeMetric,
+	interMetrics := []samplers.InterMetric{{
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:needs_fallback",
 		},
-		samplers.InterMetric{
-			Name:      "a.b.c",
-			Timestamp: 1476119058,
-			Value:     float64(99),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:available",
-			},
-			Type: samplers.GaugeMetric,
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(99),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:available",
 		},
-	}
+		Type: samplers.GaugeMetric,
+	}}
 
 	sink.Flush(context.TODO(), interMetrics)
 
@@ -485,7 +579,7 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 		assert.Equal(t, "bar", dims["foo"], "Metric has a busted tag")
 		assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 		assert.Equal(t, "pie", dims["yay"], "Metric is missing common tag")
-		assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
+		assert.Equal(t, "signalfx-hostname", dims["host"], "Metric is missing host tag")
 		assert.Equal(t, "needs_fallback", dims["test_by"], "Metric should have the right test_by tag")
 	}
 	{
@@ -500,7 +594,7 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 		assert.Equal(t, "bar", dims["foo"], "Metric has a busted tag")
 		assert.Equal(t, "quz", dims["baz"], "Metric has a busted tag")
 		assert.Equal(t, "pie", dims["yay"], "Metric is missing common tag")
-		assert.Equal(t, "glooblestoots", dims["host"], "Metric is missing host tag")
+		assert.Equal(t, "signalfx-hostname", dims["host"], "Metric is missing host tag")
 		assert.Equal(t, "available", dims["test_by"], "Metric should have the right test_by tag")
 	}
 	assert.Empty(t, derived.samples, "Gauges should not generated derived metrics")
@@ -509,36 +603,43 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 func TestSignalFxFlushBatches(t *testing.T) {
 	fallback := NewFakeSink()
 
-	derived := newDerivedProcessor()
 	perBatch := 1
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   perBatch,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "test_by",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, nil)
 
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{
-		samplers.InterMetric{
-			Name:      "a.b.c",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:first",
-			},
-			Type: samplers.GaugeMetric,
+	interMetrics := []samplers.InterMetric{{
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:first",
 		},
-		samplers.InterMetric{
-			Name:      "a.b.c",
-			Timestamp: 1476119058,
-			Value:     float64(99),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:second",
-			},
-			Type: samplers.GaugeMetric,
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(99),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:second",
 		},
-	}
+		Type: samplers.GaugeMetric,
+	}}
 
 	require.NoError(t, sink.Flush(context.TODO(), interMetrics))
 
@@ -557,36 +658,43 @@ func TestSignalFxFlushBatches(t *testing.T) {
 func TestSignalFxFlushBatchHang(t *testing.T) {
 	fallback := failSink{}
 
-	derived := newDerivedProcessor()
 	perBatch := 1
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   perBatch,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "test_by",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, nil)
 
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{
-		samplers.InterMetric{
-			Name:      "a.b.c",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:first",
-			},
-			Type: samplers.GaugeMetric,
+	interMetrics := []samplers.InterMetric{{
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:first",
 		},
-		samplers.InterMetric{
-			Name:      "a.b.c.d",
-			Timestamp: 1476119058,
-			Value:     float64(100),
-			Tags: []string{
-				"foo:bar",
-				"baz:quz",
-				"test_by:first",
-			},
-			Type: samplers.GaugeMetric,
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.c.d",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"foo:bar",
+			"baz:quz",
+			"test_by:first",
 		},
-	}
+		Type: samplers.GaugeMetric,
+	}}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
@@ -721,13 +829,21 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	}
 
 	server := httptest.NewServer(m)
-
 	fallback := NewFakeSink()
-
-	derived := newDerivedProcessor()
 	perBatch := 1
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        true,
+		DynamicPerTagAPIKeysRefreshPeriod: dynamicKeyRefreshPeriod,
+		EndpointAPI:                       server.URL,
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   perBatch,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         "test_by",
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, server.Client())
 
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", true, dynamicKeyRefreshPeriod, "", server.URL, server.Client())
 	require.NoError(t, err)
 
 	err = sink.Start(nil)
@@ -777,12 +893,9 @@ LOOP:
 	// three responses
 	assert.Subset(t, expectedPerTagClients, actualPerTagClients, "The actual values should be a subset of the expected values")
 	assert.Subset(t, actualPerTagClients, expectedPerTagClients, "The expected values should be a subset of the actual values")
-
 }
 
 func TestSignalFxVaryByOverride(t *testing.T) {
-	derived := newDerivedProcessor()
-
 	varyByTagKey := "vary_by"
 	commonDimensions := map[string]string{"vary_by": "bar"}
 	defaultFakeSink := NewFakeSink()
@@ -792,11 +905,21 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 	perTagClients["foo"] = customFakeSinkFoo
 	perTagClients["bar"] = customFakeSinkBar
 
-	sink, err := NewSignalFxSink("host", "glooblestoots", commonDimensions, logrus.New(), defaultFakeSink, varyByTagKey, perTagClients, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
-
+	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		VaryKeyBy:                         varyByTagKey,
+	}, "signalfx-hostname", commonDimensions, logrus.New(), defaultFakeSink, perTagClients, nil)
 	assert.NoError(t, err)
 
-	interMetrics := []samplers.InterMetric{samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{{
 		Name:      "a.b.c",
 		Timestamp: 1476119058,
 		Value:     float64(100),
@@ -804,14 +927,13 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 			"vary_by:foo",
 		},
 		Type: samplers.GaugeMetric,
-	},
-		samplers.InterMetric{
-			Name:      "a.b.d",
-			Timestamp: 1476119059,
-			Value:     float64(100),
-			Tags:      []string{},
-			Type:      samplers.GaugeMetric,
-		}}
+	}, {
+		Name:      "a.b.d",
+		Timestamp: 1476119059,
+		Value:     float64(100),
+		Tags:      []string{},
+		Type:      samplers.GaugeMetric,
+	}}
 
 	sink.Flush(context.TODO(), interMetrics)
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -85,7 +85,7 @@ func newDerivedProcessor() *testDerivedSink {
 func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
 	client := NewClient("http://www.example.com", "secret", http.DefaultClient)
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -118,7 +118,7 @@ func TestNewSignalFxSink(t *testing.T) {
 
 func TestSignalFxFlushRouting(t *testing.T) {
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -181,7 +181,7 @@ func TestSignalFxFlushGauge(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
 
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -228,7 +228,7 @@ func TestSignalFxFlushGauge(t *testing.T) {
 func TestSignalFxFlushCounter(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -275,7 +275,7 @@ func TestSignalFxFlushCounter(t *testing.T) {
 
 func TestSignalFxFlushWithDrops(t *testing.T) {
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -331,7 +331,7 @@ func TestSignalFxFlushWithDrops(t *testing.T) {
 func TestSignalFxFlushStatus(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -380,7 +380,7 @@ func TestSignalFxFlushStatus(t *testing.T) {
 func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -411,7 +411,7 @@ func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 
 func TestSignalFxEventFlush(t *testing.T) {
 	fakeSink := NewFakeSink()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -453,7 +453,7 @@ func TestSignalFxEventFlush(t *testing.T) {
 func TestSignalFxSetExcludeTags(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -527,7 +527,7 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 	specialized := NewFakeSink()
 
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -604,7 +604,7 @@ func TestSignalFxFlushBatches(t *testing.T) {
 	fallback := NewFakeSink()
 
 	perBatch := 1
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -659,7 +659,7 @@ func TestSignalFxFlushBatchHang(t *testing.T) {
 	fallback := failSink{}
 
 	perBatch := 1
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
@@ -831,7 +831,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	server := httptest.NewServer(m)
 	fallback := NewFakeSink()
 	perBatch := 1
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        true,
 		DynamicPerTagAPIKeysRefreshPeriod: dynamicKeyRefreshPeriod,
@@ -905,7 +905,7 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 	perTagClients["foo"] = customFakeSinkFoo
 	perTagClients["bar"] = customFakeSinkBar
 
-	sink, err := NewSignalFxSink(SignalFxSinkConfig{
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
 		APIKey:                            util.StringSecret{Value: ""},
 		DynamicPerTagAPIKeysEnable:        false,
 		DynamicPerTagAPIKeysRefreshPeriod: time.Second,

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -96,7 +96,7 @@ func TestNewSignalFxSink(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), nil, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestSignalFxFlushRouting(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 
 	assert.NoError(t, err)
 
@@ -192,7 +192,7 @@ func TestSignalFxFlushGauge(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 
 	assert.NoError(t, err)
 
@@ -239,7 +239,7 @@ func TestSignalFxFlushCounter(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{{
@@ -286,7 +286,7 @@ func TestSignalFxFlushWithDrops(t *testing.T) {
 		MetricNamePrefixDrops:             []string{"foo.bar"},
 		MetricTagPrefixDrops:              []string{"baz:gorch"},
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{{
@@ -342,7 +342,7 @@ func TestSignalFxFlushStatus(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{{
@@ -391,7 +391,7 @@ func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	serviceCheckMsg := "Service Farts starting[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -422,7 +422,7 @@ func TestSignalFxEventFlush(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	assert.NoError(t, err)
 
 	evMessage := "[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -464,7 +464,7 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, nil, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fakeSink, nil, nil)
 	sink.SetExcludedTags([]string{"foo", "boo", "host"})
 	assert.NoError(t, err)
 
@@ -538,7 +538,7 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "test_by",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{"available": specialized}, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fallback, map[string]DPClient{"available": specialized}, nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{{
@@ -615,7 +615,7 @@ func TestSignalFxFlushBatches(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "test_by",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fallback, map[string]DPClient{}, nil)
 
 	assert.NoError(t, err)
 
@@ -670,7 +670,7 @@ func TestSignalFxFlushBatchHang(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "test_by",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, nil)
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fallback, map[string]DPClient{}, nil)
 
 	assert.NoError(t, err)
 
@@ -842,7 +842,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         "test_by",
-	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.New(), fallback, map[string]DPClient{}, server.Client())
+	}, "signalfx-hostname", map[string]string{"yay": "pie"}, logrus.NewEntry(logrus.New()), fallback, map[string]DPClient{}, server.Client())
 
 	require.NoError(t, err)
 
@@ -916,7 +916,7 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 		MetricNamePrefixDrops:             nil,
 		MetricTagPrefixDrops:              nil,
 		VaryKeyBy:                         varyByTagKey,
-	}, "signalfx-hostname", commonDimensions, logrus.New(), defaultFakeSink, perTagClients, nil)
+	}, "signalfx-hostname", commonDimensions, logrus.NewEntry(logrus.New()), defaultFakeSink, perTagClients, nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{{

--- a/util/decode_config.go
+++ b/util/decode_config.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func DecodeConfig(input interface{}, output interface{}) error {
+	configDecoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			StringSecretDecode,
+			mapstructure.StringToTimeDurationHookFunc(),
+		),
+		Result:  &output,
+		TagName: "yaml",
+	})
+	if err != nil {
+		return err
+	}
+	err = configDecoder.Decode(input)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func StringSecretDecode(
+	inputType reflect.Type, outputType reflect.Type, data interface{},
+) (interface{}, error) {
+	if outputType != reflect.TypeOf(StringSecret{}) {
+		return data, nil
+	}
+	value, ok := data.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid type %v", inputType)
+	}
+	return StringSecret{
+		Value: value,
+	}, nil
+}

--- a/util/decode_config.go
+++ b/util/decode_config.go
@@ -7,10 +7,14 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// DecodeConfig wraps the mapstructure decoder to unpack a map into a struct.
+// This method provides logic to handle decoding into StringSecret and
+// time.Duration fields, and is intended to be used by sinks while unpacking the
+// configuration specific to that sink from within the entire config.
 func DecodeConfig(input interface{}, output interface{}) error {
 	configDecoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			StringSecretDecode,
+			stringSecretDecode,
 			mapstructure.StringToTimeDurationHookFunc(),
 		),
 		Result:  &output,
@@ -26,7 +30,8 @@ func DecodeConfig(input interface{}, output interface{}) error {
 	return nil
 }
 
-func StringSecretDecode(
+// A mapstructure decode hook to handle decoding StringSecret fields.
+func stringSecretDecode(
 	inputType reflect.Type, outputType reflect.Type, data interface{},
 ) (interface{}, error) {
 	if outputType != reflect.TypeOf(StringSecret{}) {

--- a/util/decode_config_test.go
+++ b/util/decode_config_test.go
@@ -1,0 +1,68 @@
+package util_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/v14/util"
+)
+
+func TestDecodeConfig(t *testing.T) {
+	type configStruct struct {
+		ConfigItem string `yaml:"config_item"`
+	}
+
+	config := map[string]interface{}{
+		"config_item": "config-value",
+	}
+	result := configStruct{}
+	err := util.DecodeConfig(config, &result)
+
+	require.Nil(t, err)
+	assert.Equal(t, "config-value", result.ConfigItem)
+}
+
+func TestDecodeConfigWithStringSecret(t *testing.T) {
+	type configStruct struct {
+		ConfigItem util.StringSecret `yaml:"config_item"`
+	}
+
+	config := map[string]interface{}{
+		"config_item": "config-value",
+	}
+	result := configStruct{}
+	err := util.DecodeConfig(config, &result)
+
+	require.Nil(t, err)
+	assert.Equal(t, "config-value", result.ConfigItem.Value)
+}
+
+func TestDecodeConfigWithDuration(t *testing.T) {
+	type configStruct struct {
+		ConfigItem time.Duration `yaml:"config_item"`
+	}
+
+	config := map[string]interface{}{
+		"config_item": "10m",
+	}
+	result := configStruct{}
+	err := util.DecodeConfig(config, &result)
+
+	require.Nil(t, err)
+	assert.Equal(t, int64(600000), result.ConfigItem.Milliseconds())
+}
+
+func TestDecodeConfigWithDurationUnset(t *testing.T) {
+	type configStruct struct {
+		ConfigItem time.Duration `yaml:"config_item"`
+	}
+
+	config := map[string]interface{}{}
+	result := configStruct{}
+	err := util.DecodeConfig(config, &result)
+
+	require.Nil(t, err)
+	assert.Equal(t, int64(0), result.ConfigItem.Milliseconds())
+}

--- a/vendor/github.com/mitchellh/mapstructure/.travis.yml
+++ b/vendor/github.com/mitchellh/mapstructure/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - "1.14.x"
-  - tip
-
-script:
-  - go test
-  - go test -bench . -benchmem

--- a/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
+++ b/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
@@ -1,3 +1,15 @@
+## unreleased
+
+* Fix regression where `*time.Time` value would be set to empty and not be sent 
+  to decode hooks properly [GH-232]
+
+## 1.4.0
+
+* A new decode hook type `DecodeHookFuncValue` has been added that has
+  access to the full values. [GH-183]
+* Squash is now supported with embedded fields that are struct pointers [GH-205]
+* Empty strings will convert to 0 for all numeric types when weakly decoding [GH-206]
+
 ## 1.3.3
 
 * Decoding maps from maps creates a settable value for decode hooks [GH-203]

--- a/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
+++ b/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
@@ -1,6 +1,7 @@
 package mapstructure
 
 import (
+	"encoding"
 	"errors"
 	"fmt"
 	"net"
@@ -16,10 +17,11 @@ func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
 	// Create variables here so we can reference them with the reflect pkg
 	var f1 DecodeHookFuncType
 	var f2 DecodeHookFuncKind
+	var f3 DecodeHookFuncValue
 
 	// Fill in the variables into this interface and the rest is done
 	// automatically using the reflect package.
-	potential := []interface{}{f1, f2}
+	potential := []interface{}{f1, f2, f3}
 
 	v := reflect.ValueOf(h)
 	vt := v.Type()
@@ -38,13 +40,15 @@ func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
 // that took reflect.Kind instead of reflect.Type.
 func DecodeHookExec(
 	raw DecodeHookFunc,
-	from reflect.Type, to reflect.Type,
-	data interface{}) (interface{}, error) {
+	from reflect.Value, to reflect.Value) (interface{}, error) {
+
 	switch f := typedDecodeHook(raw).(type) {
 	case DecodeHookFuncType:
-		return f(from, to, data)
+		return f(from.Type(), to.Type(), from.Interface())
 	case DecodeHookFuncKind:
-		return f(from.Kind(), to.Kind(), data)
+		return f(from.Kind(), to.Kind(), from.Interface())
+	case DecodeHookFuncValue:
+		return f(from, to)
 	default:
 		return nil, errors.New("invalid decode hook signature")
 	}
@@ -56,22 +60,16 @@ func DecodeHookExec(
 // The composed funcs are called in order, with the result of the
 // previous transformation.
 func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
-	return func(
-		f reflect.Type,
-		t reflect.Type,
-		data interface{}) (interface{}, error) {
+	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
 		var err error
+		var data interface{}
+		newFrom := f
 		for _, f1 := range fs {
-			data, err = DecodeHookExec(f1, f, t, data)
+			data, err = DecodeHookExec(f1, newFrom, t)
 			if err != nil {
 				return nil, err
 			}
-
-			// Modify the from kind to be correct with the new data
-			f = nil
-			if val := reflect.ValueOf(data); val.IsValid() {
-				f = val.Type()
-			}
+			newFrom = reflect.ValueOf(data)
 		}
 
 		return data, nil
@@ -214,4 +212,45 @@ func WeaklyTypedHook(
 	}
 
 	return data, nil
+}
+
+func RecursiveStructToMapHookFunc() DecodeHookFunc {
+	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
+		if f.Kind() != reflect.Struct {
+			return f.Interface(), nil
+		}
+
+		var i interface{} = struct{}{}
+		if t.Type() != reflect.TypeOf(&i).Elem() {
+			return f.Interface(), nil
+		}
+
+		m := make(map[string]interface{})
+		t.Set(reflect.ValueOf(m))
+
+		return f.Interface(), nil
+	}
+}
+
+// TextUnmarshallerHookFunc returns a DecodeHookFunc that applies
+// strings to the UnmarshalText function, when the target type
+// implements the encoding.TextUnmarshaler interface
+func TextUnmarshallerHookFunc() DecodeHookFuncType {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		result := reflect.New(t).Interface()
+		unmarshaller, ok := result.(encoding.TextUnmarshaler)
+		if !ok {
+			return data, nil
+		}
+		if err := unmarshaller.UnmarshalText([]byte(data.(string))); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
 }

--- a/vendor/github.com/mitchellh/mapstructure/mapstructure.go
+++ b/vendor/github.com/mitchellh/mapstructure/mapstructure.go
@@ -72,6 +72,17 @@
 //         "name": "alice",
 //     }
 //
+// When decoding from a struct to a map, the squash tag squashes the struct
+// fields into a single map. Using the example structs from above:
+//
+//     Friend{Person: Person{Name: "alice"}}
+//
+// Will be decoded into a map:
+//
+//     map[string]interface{}{
+//         "name": "alice",
+//     }
+//
 // DecoderConfig has a field that changes the behavior of mapstructure
 // to always squash embedded structs.
 //
@@ -161,10 +172,11 @@ import (
 // data transformations. See "DecodeHook" in the DecoderConfig
 // struct.
 //
-// The type should be DecodeHookFuncType or DecodeHookFuncKind.
-// Either is accepted. Types are a superset of Kinds (Types can return
-// Kinds) and are generally a richer thing to use, but Kinds are simpler
-// if you only need those.
+// The type must be one of DecodeHookFuncType, DecodeHookFuncKind, or
+// DecodeHookFuncValue.
+// Values are a superset of Types (Values can return types), and Types are a
+// superset of Kinds (Types can return Kinds) and are generally a richer thing
+// to use, but Kinds are simpler if you only need those.
 //
 // The reason DecodeHookFunc is multi-typed is for backwards compatibility:
 // we started with Kinds and then realized Types were the better solution,
@@ -180,15 +192,22 @@ type DecodeHookFuncType func(reflect.Type, reflect.Type, interface{}) (interface
 // source and target types.
 type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error)
 
+// DecodeHookFuncRaw is a DecodeHookFunc which has complete access to both the source and target
+// values.
+type DecodeHookFuncValue func(from reflect.Value, to reflect.Value) (interface{}, error)
+
 // DecoderConfig is the configuration that is used to create a new decoder
 // and allows customization of various aspects of decoding.
 type DecoderConfig struct {
 	// DecodeHook, if set, will be called before any decoding and any
 	// type conversion (if WeaklyTypedInput is on). This lets you modify
-	// the values before they're set down onto the resulting struct.
+	// the values before they're set down onto the resulting struct. The
+	// DecodeHook is called for every map and value in the input. This means
+	// that if a struct has embedded fields with squash tags the decode hook
+	// is called only once with all of the input data, not once for each
+	// embedded struct.
 	//
-	// If an error is returned, the entire decode will fail with that
-	// error.
+	// If an error is returned, the entire decode will fail with that error.
 	DecodeHook DecodeHookFunc
 
 	// If ErrorUnused is true, then it is an error for there to exist
@@ -409,9 +428,7 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 	if d.config.DecodeHook != nil {
 		// We have a DecodeHook, so let's pre-process the input.
 		var err error
-		input, err = DecodeHookExec(
-			d.config.DecodeHook,
-			inputVal.Type(), outVal.Type(), input)
+		input, err = DecodeHookExec(d.config.DecodeHook, inputVal, outVal)
 		if err != nil {
 			return fmt.Errorf("error decoding '%s': %s", name, err)
 		}
@@ -562,8 +579,8 @@ func (d *Decoder) decodeString(name string, data interface{}, val reflect.Value)
 
 	if !converted {
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 
 	return nil
@@ -588,7 +605,12 @@ func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) er
 			val.SetInt(0)
 		}
 	case dataKind == reflect.String && d.config.WeaklyTypedInput:
-		i, err := strconv.ParseInt(dataVal.String(), 0, val.Type().Bits())
+		str := dataVal.String()
+		if str == "" {
+			str = "0"
+		}
+
+		i, err := strconv.ParseInt(str, 0, val.Type().Bits())
 		if err == nil {
 			val.SetInt(i)
 		} else {
@@ -604,8 +626,8 @@ func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) er
 		val.SetInt(i)
 	default:
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 
 	return nil
@@ -640,7 +662,12 @@ func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) e
 			val.SetUint(0)
 		}
 	case dataKind == reflect.String && d.config.WeaklyTypedInput:
-		i, err := strconv.ParseUint(dataVal.String(), 0, val.Type().Bits())
+		str := dataVal.String()
+		if str == "" {
+			str = "0"
+		}
+
+		i, err := strconv.ParseUint(str, 0, val.Type().Bits())
 		if err == nil {
 			val.SetUint(i)
 		} else {
@@ -660,8 +687,8 @@ func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) e
 		val.SetUint(uint64(i))
 	default:
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 
 	return nil
@@ -691,8 +718,8 @@ func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) e
 		}
 	default:
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 
 	return nil
@@ -717,7 +744,12 @@ func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) 
 			val.SetFloat(0)
 		}
 	case dataKind == reflect.String && d.config.WeaklyTypedInput:
-		f, err := strconv.ParseFloat(dataVal.String(), val.Type().Bits())
+		str := dataVal.String()
+		if str == "" {
+			str = "0"
+		}
+
+		f, err := strconv.ParseFloat(str, val.Type().Bits())
 		if err == nil {
 			val.SetFloat(f)
 		} else {
@@ -733,8 +765,8 @@ func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) 
 		val.SetFloat(i)
 	default:
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 
 	return nil
@@ -785,7 +817,7 @@ func (d *Decoder) decodeMapFromSlice(name string, dataVal reflect.Value, val ref
 
 	for i := 0; i < dataVal.Len(); i++ {
 		err := d.decode(
-			fmt.Sprintf("%s[%d]", name, i),
+			name+"["+strconv.Itoa(i)+"]",
 			dataVal.Index(i).Interface(), val)
 		if err != nil {
 			return err
@@ -818,7 +850,7 @@ func (d *Decoder) decodeMapFromMap(name string, dataVal reflect.Value, val refle
 	}
 
 	for _, k := range dataVal.MapKeys() {
-		fieldName := fmt.Sprintf("%s[%s]", name, k)
+		fieldName := name + "[" + k.String() + "]"
 
 		// First decode the key into the proper type
 		currentKey := reflect.Indirect(reflect.New(valKeyType))
@@ -871,6 +903,7 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 
 		// If Squash is set in the config, we squash the field down.
 		squash := d.config.Squash && v.Kind() == reflect.Struct && f.Anonymous
+
 		// Determine the name of the key in the map
 		if index := strings.Index(tagValue, ","); index != -1 {
 			if tagValue[:index] == "-" {
@@ -883,8 +916,16 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 
 			// If "squash" is specified in the tag, we squash the field down.
 			squash = !squash && strings.Index(tagValue[index+1:], "squash") != -1
-			if squash && v.Kind() != reflect.Struct {
-				return fmt.Errorf("cannot squash non-struct type '%s'", v.Type())
+			if squash {
+				// When squashing, the embedded type can be a pointer to a struct.
+				if v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct {
+					v = v.Elem()
+				}
+
+				// The final type must be a struct
+				if v.Kind() != reflect.Struct {
+					return fmt.Errorf("cannot squash non-struct type '%s'", v.Type())
+				}
 			}
 			keyName = tagValue[:index]
 		} else if len(tagValue) > 0 {
@@ -995,8 +1036,8 @@ func (d *Decoder) decodeFunc(name string, data interface{}, val reflect.Value) e
 	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	if val.Type() != dataVal.Type() {
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s'",
-			name, val.Type(), dataVal.Type())
+			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+			name, val.Type(), dataVal.Type(), data)
 	}
 	val.Set(dataVal)
 	return nil
@@ -1062,7 +1103,7 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 		}
 		currentField := valSlice.Index(i)
 
-		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		fieldName := name + "[" + strconv.Itoa(i) + "]"
 		if err := d.decode(fieldName, currentData, currentField); err != nil {
 			errors = appendErrors(errors, err)
 		}
@@ -1129,7 +1170,7 @@ func (d *Decoder) decodeArray(name string, data interface{}, val reflect.Value) 
 		currentData := dataVal.Index(i).Interface()
 		currentField := valArray.Index(i)
 
-		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		fieldName := name + "[" + strconv.Itoa(i) + "]"
 		if err := d.decode(fieldName, currentData, currentField); err != nil {
 			errors = appendErrors(errors, err)
 		}
@@ -1232,10 +1273,14 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 
 		for i := 0; i < structType.NumField(); i++ {
 			fieldType := structType.Field(i)
-			fieldKind := fieldType.Type.Kind()
+			fieldVal := structVal.Field(i)
+			if fieldVal.Kind() == reflect.Ptr && fieldVal.Elem().Kind() == reflect.Struct {
+				// Handle embedded struct pointers as embedded structs.
+				fieldVal = fieldVal.Elem()
+			}
 
 			// If "squash" is specified in the tag, we squash the field down.
-			squash := d.config.Squash && fieldKind == reflect.Struct && fieldType.Anonymous
+			squash := d.config.Squash && fieldVal.Kind() == reflect.Struct && fieldType.Anonymous
 			remain := false
 
 			// We always parse the tags cause we're looking for other tags too
@@ -1253,21 +1298,21 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			}
 
 			if squash {
-				if fieldKind != reflect.Struct {
+				if fieldVal.Kind() != reflect.Struct {
 					errors = appendErrors(errors,
-						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldKind))
+						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldVal.Kind()))
 				} else {
-					structs = append(structs, structVal.FieldByName(fieldType.Name))
+					structs = append(structs, fieldVal)
 				}
 				continue
 			}
 
 			// Build our field
 			if remain {
-				remainField = &field{fieldType, structVal.Field(i)}
+				remainField = &field{fieldType, fieldVal}
 			} else {
 				// Normal struct field, store it away
-				fields = append(fields, field{fieldType, structVal.Field(i)})
+				fields = append(fields, field{fieldType, fieldVal})
 			}
 		}
 	}
@@ -1326,7 +1371,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		// If the name is empty string, then we're at the root, and we
 		// don't dot-join the fields.
 		if name != "" {
-			fieldName = fmt.Sprintf("%s.%s", name, fieldName)
+			fieldName = name + "." + fieldName
 		}
 
 		if err := d.decode(fieldName, rawMapVal.Interface(), fieldValue); err != nil {
@@ -1373,7 +1418,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		for rawKey := range dataValKeysUnused {
 			key := rawKey.(string)
 			if name != "" {
-				key = fmt.Sprintf("%s.%s", name, key)
+				key = name + "." + key
 			}
 
 			d.config.Metadata.Unused = append(d.config.Metadata.Unused, key)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,8 @@ github.com/mailru/easyjson/jwriter
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
-# github.com/mitchellh/mapstructure v1.3.3
+# github.com/mitchellh/mapstructure v1.4.1
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
@@ -425,6 +426,7 @@ gopkg.in/stack.v1
 ## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
+## explicit
 gopkg.in/yaml.v3
 # k8s.io/api v0.0.0-20190325185214-7544f9db76f6
 ## explicit


### PR DESCRIPTION
#### Summary
This change migrates the SignalFx sink to use the new config format.


#### Motivation
This work is part of enabling multi-sink routing.


#### Test plan
```
go test github.com/stripe/veneur/v14
```
