### PR TITLE
Prevent sensitive config fields from accidentally being logged.

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -58,7 +58,10 @@ func main() {
 		Logger: logger,
 		MetricSinkTypes: veneur.MetricSinkTypes{
 			// TODO(arnavdugar): Migrate metric sink types.
-			"signalfx": signalfx.CreateSignalFxSink,
+			"signalfx": {
+				Create:      signalfx.Create,
+				ParseConfig: signalfx.ParseConfig,
+			},
 		},
 		SpanSinkTypes: veneur.SpanSinkTypes{
 			// TODO(arnavdugar): Migrate span sink types.

--- a/server.go
+++ b/server.go
@@ -77,13 +77,25 @@ const defaultTCPReadTimeout = 10 * time.Minute
 
 const httpQuitEndpoint = "/quitquitquit"
 
-type SpanSinkTypes = map[string]func(
-	*Server, string, *logrus.Entry, Config, interface{},
-) (sinks.SpanSink, error)
+type SpanSinkTypes = map[string]struct {
+	// Creates a new span sink intsance.
+	Create func(
+		*Server, string, *logrus.Entry, Config, interface{},
+	) (sinks.SpanSink, error)
+	// Parses the config for the sink into a format that is validated and safe to
+	// log.
+	ParseConfig func(interface{}) (interface{}, error)
+}
 
-type MetricSinkTypes = map[string]func(
-	*Server, string, *logrus.Entry, Config, interface{},
-) (sinks.MetricSink, error)
+type MetricSinkTypes = map[string]struct {
+	// Creates a new metric sink instance.
+	Create func(
+		*Server, string, *logrus.Entry, Config, interface{},
+	) (sinks.MetricSink, error)
+	// Parses the config for the sink into a format that is validated and safe to
+	// log.
+	ParseConfig func(interface{}) (interface{}, error)
+}
 
 // Config used to create a new server.
 type ServerConfig struct {
@@ -308,17 +320,24 @@ func scopesFromConfig(conf Config) (scopedstatsd.MetricScopes, error) {
 }
 
 func (server *Server) createSpanSinks(
-	logger *logrus.Logger, config Config, sinkTypes SpanSinkTypes,
+	logger *logrus.Logger, config *Config, sinkTypes SpanSinkTypes,
 ) ([]sinks.SpanSink, error) {
 	sinks := []sinks.SpanSink{}
-	for _, sinkConfig := range config.SpanSinks {
+	for index, sinkConfig := range config.SpanSinks {
 		sinkFactory, ok := sinkTypes[sinkConfig.Kind]
 		if !ok {
 			logger.Warnf("Unknown sink kind %s; skipping.", sinkConfig.Kind)
 		}
-		sink, err := sinkFactory(
+		parsedSinkConfig, err := sinkFactory.ParseConfig(sinkConfig.Config)
+		if err != nil {
+			return nil, err
+		}
+		// Overwrite the map config with the parsed config. This prevents senstive
+		// fields in the map from accidentally being logged.
+		config.SpanSinks[index].Config = parsedSinkConfig
+		sink, err := sinkFactory.Create(
 			server, sinkConfig.Name, logger.WithField("sink", sinkConfig.Name),
-			config, sinkConfig.Config)
+			*config, parsedSinkConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -328,17 +347,24 @@ func (server *Server) createSpanSinks(
 }
 
 func (server *Server) createMetricSinks(
-	logger *logrus.Logger, config Config, sinkTypes MetricSinkTypes,
+	logger *logrus.Logger, config *Config, sinkTypes MetricSinkTypes,
 ) ([]sinks.MetricSink, error) {
 	sinks := []sinks.MetricSink{}
-	for _, sinkConfig := range config.MetricSinks {
+	for index, sinkConfig := range config.MetricSinks {
 		sinkFactory, ok := sinkTypes[sinkConfig.Kind]
 		if !ok {
 			logger.Warnf("Unknown sink kind %s; skipping.", sinkConfig.Kind)
 		}
-		sink, err := sinkFactory(
+		parsedSinkConfig, err := sinkFactory.ParseConfig(sinkConfig.Config)
+		if err != nil {
+			return nil, err
+		}
+		// Overwrite the map config with the parsed config. This prevents senstive
+		// fields in the map from accidentally being logged.
+		config.SpanSinks[index].Config = parsedSinkConfig
+		sink, err := sinkFactory.Create(
 			server, sinkConfig.Name, logger.WithField("sink", sinkConfig.Name),
-			config, sinkConfig.Config)
+			*config, parsedSinkConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -811,7 +837,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		}
 	}
 	customMetricSinks, err :=
-		ret.createMetricSinks(logger, conf, config.MetricSinkTypes)
+		ret.createMetricSinks(logger, &conf, config.MetricSinkTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +847,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		ret.metricSinks = append(ret.metricSinks, customMetricSinks...)
 	}
 	customSpanSinks, err :=
-		ret.createSpanSinks(logger, conf, config.SpanSinkTypes)
+		ret.createSpanSinks(logger, &conf, config.SpanSinkTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -361,7 +361,7 @@ func (server *Server) createMetricSinks(
 		}
 		// Overwrite the map config with the parsed config. This prevents senstive
 		// fields in the map from accidentally being logged.
-		config.SpanSinks[index].Config = parsedSinkConfig
+		config.MetricSinks[index].Config = parsedSinkConfig
 		sink, err := sinkFactory.Create(
 			server, sinkConfig.Name, logger.WithField("sink", sinkConfig.Name),
 			*config, parsedSinkConfig)

--- a/server.go
+++ b/server.go
@@ -77,24 +77,27 @@ const defaultTCPReadTimeout = 10 * time.Minute
 
 const httpQuitEndpoint = "/quitquitquit"
 
+type MetricSinkConfig interface{}
+type SpanSinkConfig interface{}
+
 type SpanSinkTypes = map[string]struct {
 	// Creates a new span sink intsance.
 	Create func(
-		*Server, string, *logrus.Entry, Config, interface{},
+		*Server, string, *logrus.Entry, Config, SpanSinkConfig,
 	) (sinks.SpanSink, error)
 	// Parses the config for the sink into a format that is validated and safe to
 	// log.
-	ParseConfig func(interface{}) (interface{}, error)
+	ParseConfig func(interface{}) (SpanSinkConfig, error)
 }
 
 type MetricSinkTypes = map[string]struct {
 	// Creates a new metric sink instance.
 	Create func(
-		*Server, string, *logrus.Entry, Config, interface{},
+		*Server, string, *logrus.Entry, Config, MetricSinkConfig,
 	) (sinks.MetricSink, error)
 	// Parses the config for the sink into a format that is validated and safe to
 	// log.
-	ParseConfig func(interface{}) (interface{}, error)
+	ParseConfig func(interface{}) (MetricSinkConfig, error)
 }
 
 // Config used to create a new server.

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -241,7 +241,7 @@ func MigrateConfig(conf *veneur.Config) error {
 
 // ParseConfig decodes the map config for a SignalFx sink into a
 // SignalFxSinkConfig struct.
-func ParseConfig(config interface{}) (interface{}, error) {
+func ParseConfig(config interface{}) (veneur.MetricSinkConfig, error) {
 	signalFxConfig := SignalFxSinkConfig{}
 	err := util.DecodeConfig(config, &signalFxConfig)
 	if err != nil {
@@ -256,9 +256,12 @@ func ParseConfig(config interface{}) (interface{}, error) {
 // provided configuration.
 func Create(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig interface{},
+	config veneur.Config, sinkConfig veneur.MetricSinkConfig,
 ) (sinks.MetricSink, error) {
-	signalFxConfig := sinkConfig.(SignalFxSinkConfig)
+	signalFxConfig, ok := sinkConfig.(SignalFxSinkConfig)
+	if !ok {
+		return nil, errors.New("invalid sink config type")
+	}
 
 	tracedHTTP := *server.HTTPClient
 	tracedHTTP.Transport = vhttp.NewTraceRoundTripper(

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -239,19 +239,26 @@ func MigrateConfig(conf *veneur.Config) error {
 	return nil
 }
 
-// CreateSignalFxSink creates a new SignalFx sink for metrics. This function
-// should match the signature of a value in veneur.MetricSinkTypes, and is
-// intended to be passed into veneur.NewFromConfig to be called based on the
-// provided configuration.
-func CreateSignalFxSink(
-	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig interface{},
-) (sinks.MetricSink, error) {
+// ParseConfig decodes the map config for a SignalFx sink into a
+// SignalFxSinkConfig struct.
+func ParseConfig(config interface{}) (interface{}, error) {
 	signalFxConfig := SignalFxSinkConfig{}
-	err := util.DecodeConfig(sinkConfig, &signalFxConfig)
+	err := util.DecodeConfig(config, &signalFxConfig)
 	if err != nil {
 		return nil, err
 	}
+	return signalFxConfig, nil
+}
+
+// Create creates a new SignalFx sink for metrics. This function
+// should match the signature of a value in veneur.MetricSinkTypes, and is
+// intended to be passed into veneur.NewFromConfig to be called based on the
+// provided configuration.
+func Create(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig interface{},
+) (sinks.MetricSink, error) {
+	signalFxConfig := sinkConfig.(SignalFxSinkConfig)
 
 	tracedHTTP := *server.HTTPClient
 	tracedHTTP.Transport = vhttp.NewTraceRoundTripper(

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -89,7 +89,9 @@ func TestMigrateConfig(t *testing.T) {
 	}
 	MigrateConfig(&config)
 	assert.Len(t, config.MetricSinks, 1)
-	signalFxConfig, ok := config.MetricSinks[0].Config.(SignalFxSinkConfig)
+	parsedConfig, err := ParseConfig(config.MetricSinks[0].Config)
+	assert.Nil(t, err)
+	signalFxConfig, ok := parsedConfig.(SignalFxSinkConfig)
 	assert.True(t, ok)
 	assert.Equal(t, "signalfx-api-key", signalFxConfig.APIKey.Value)
 }


### PR DESCRIPTION
#### Summary
This change overwrites the map config for sinks with the parsed config.

#### Motivation
This change prevents sensitive config fields from accidentally being logged.


#### Test plan
```
go test github.com/stripe/veneur/v14
```