### PR TITLE
Fix MigrateConfig in SignalFx sink.

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -205,7 +205,7 @@ func NewClient(endpoint, apiKey string, client *http.Client) DPClient {
 // TODO(arnavdugar): Remove this once the old configuration format has been
 // removed.
 func MigrateConfig(conf *veneur.Config) error {
-	if conf.SignalfxAPIKey.Value != "" {
+	if conf.SignalfxAPIKey.Value == "" {
 		return nil
 	}
 	// To maintain compatability, set the default value of

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	veneur "github.com/stripe/veneur/v14"
 	"github.com/stripe/veneur/v14/protocol/dogstatsd"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/ssf"
@@ -80,6 +81,17 @@ func newDerivedProcessor() *testDerivedSink {
 	return &testDerivedSink{
 		samples: []*ssf.SSFSample{},
 	}
+}
+
+func TestMigrateConfig(t *testing.T) {
+	config := veneur.Config{
+		SignalfxAPIKey: util.StringSecret{Value: "signalfx-api-key"},
+	}
+	MigrateConfig(&config)
+	assert.Len(t, config.MetricSinks, 1)
+	signalFxConfig, ok := config.MetricSinks[0].Config.(SignalFxSinkConfig)
+	assert.True(t, ok)
+	assert.Equal(t, "signalfx-api-key", signalFxConfig.APIKey.Value)
 }
 
 func TestNewSignalFxSink(t *testing.T) {


### PR DESCRIPTION
#### Summary
Fix a bug where the SignalFx sink is not created.

#### Test plan
Added a unit test to verify this is correct.
```
go test github.com/stripe/veneur/v14/sinks/signalfx
```