### PR TITLE
Migrate Kafka sinks to new config format.

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,47 +34,43 @@ type Config struct {
 		MigrateMetricSinks bool `yaml:"migrate_metric_sinks"`
 		MigrateSpanSinks   bool `yaml:"migrate_span_sinks"`
 	}
-	FlushFile                    string            `yaml:"flush_file"`
-	FlushMaxPerBody              int               `yaml:"flush_max_per_body"`
-	FlushWatchdogMissedFlushes   int               `yaml:"flush_watchdog_missed_flushes"`
-	ForwardAddress               string            `yaml:"forward_address"`
-	ForwardUseGrpc               bool              `yaml:"forward_use_grpc"`
-	GrpcAddress                  string            `yaml:"grpc_address"`
-	GrpcListenAddresses          []string          `yaml:"grpc_listen_addresses"`
-	Hostname                     string            `yaml:"hostname"`
-	HTTPAddress                  string            `yaml:"http_address"`
-	HTTPQuit                     bool              `yaml:"http_quit"`
-	IndicatorSpanTimerName       string            `yaml:"indicator_span_timer_name"`
-	Interval                     string            `yaml:"interval"`
-	KafkaBroker                  string            `yaml:"kafka_broker"`
-	KafkaCheckTopic              string            `yaml:"kafka_check_topic"`
-	KafkaEventTopic              string            `yaml:"kafka_event_topic"`
-	KafkaMetricBufferBytes       int               `yaml:"kafka_metric_buffer_bytes"`
-	KafkaMetricBufferFrequency   string            `yaml:"kafka_metric_buffer_frequency"`
-	KafkaMetricBufferMessages    int               `yaml:"kafka_metric_buffer_messages"`
-	KafkaMetricRequireAcks       string            `yaml:"kafka_metric_require_acks"`
-	KafkaMetricTopic             string            `yaml:"kafka_metric_topic"`
-	KafkaPartitioner             string            `yaml:"kafka_partitioner"`
-	KafkaRetryMax                int               `yaml:"kafka_retry_max"`
-	KafkaSpanBufferBytes         int               `yaml:"kafka_span_buffer_bytes"`
-	KafkaSpanBufferFrequency     string            `yaml:"kafka_span_buffer_frequency"`
-	KafkaSpanBufferMesages       int               `yaml:"kafka_span_buffer_mesages"`
-	KafkaSpanRequireAcks         string            `yaml:"kafka_span_require_acks"`
-	KafkaSpanSampleRatePercent   float64           `yaml:"kafka_span_sample_rate_percent"`
-	KafkaSpanSampleTag           string            `yaml:"kafka_span_sample_tag"`
-	KafkaSpanSerializationFormat string            `yaml:"kafka_span_serialization_format"`
-	KafkaSpanTopic               string            `yaml:"kafka_span_topic"`
-	LightstepAccessToken         util.StringSecret `yaml:"lightstep_access_token"`
-	LightstepCollectorHost       string            `yaml:"lightstep_collector_host"`
-	LightstepMaximumSpans        int               `yaml:"lightstep_maximum_spans"`
-	LightstepNumClients          int               `yaml:"lightstep_num_clients"`
-	LightstepReconnectPeriod     string            `yaml:"lightstep_reconnect_period"`
-	MetricMaxLength              int               `yaml:"metric_max_length"`
-	MetricSinks                  []struct {
-		Kind   string      `yaml:"kind"`
-		Name   string      `yaml:"name"`
-		Config interface{} `yaml:"config"`
-	} `yaml:"metric_sinks"`
+	FlushFile                                 string            `yaml:"flush_file"`
+	FlushMaxPerBody                           int               `yaml:"flush_max_per_body"`
+	FlushWatchdogMissedFlushes                int               `yaml:"flush_watchdog_missed_flushes"`
+	ForwardAddress                            string            `yaml:"forward_address"`
+	ForwardUseGrpc                            bool              `yaml:"forward_use_grpc"`
+	GrpcAddress                               string            `yaml:"grpc_address"`
+	GrpcListenAddresses                       []string          `yaml:"grpc_listen_addresses"`
+	Hostname                                  string            `yaml:"hostname"`
+	HTTPAddress                               string            `yaml:"http_address"`
+	HTTPQuit                                  bool              `yaml:"http_quit"`
+	IndicatorSpanTimerName                    string            `yaml:"indicator_span_timer_name"`
+	Interval                                  string            `yaml:"interval"`
+	KafkaBroker                               string            `yaml:"kafka_broker"`
+	KafkaCheckTopic                           string            `yaml:"kafka_check_topic"`
+	KafkaEventTopic                           string            `yaml:"kafka_event_topic"`
+	KafkaMetricBufferBytes                    int               `yaml:"kafka_metric_buffer_bytes"`
+	KafkaMetricBufferFrequency                time.Duration     `yaml:"kafka_metric_buffer_frequency"`
+	KafkaMetricBufferMessages                 int               `yaml:"kafka_metric_buffer_messages"`
+	KafkaMetricRequireAcks                    string            `yaml:"kafka_metric_require_acks"`
+	KafkaMetricTopic                          string            `yaml:"kafka_metric_topic"`
+	KafkaPartitioner                          string            `yaml:"kafka_partitioner"`
+	KafkaRetryMax                             int               `yaml:"kafka_retry_max"`
+	KafkaSpanBufferBytes                      int               `yaml:"kafka_span_buffer_bytes"`
+	KafkaSpanBufferFrequency                  time.Duration     `yaml:"kafka_span_buffer_frequency"`
+	KafkaSpanBufferMesages                    int               `yaml:"kafka_span_buffer_mesages"`
+	KafkaSpanRequireAcks                      string            `yaml:"kafka_span_require_acks"`
+	KafkaSpanSampleRatePercent                float64           `yaml:"kafka_span_sample_rate_percent"`
+	KafkaSpanSampleTag                        string            `yaml:"kafka_span_sample_tag"`
+	KafkaSpanSerializationFormat              string            `yaml:"kafka_span_serialization_format"`
+	KafkaSpanTopic                            string            `yaml:"kafka_span_topic"`
+	LightstepAccessToken                      util.StringSecret `yaml:"lightstep_access_token"`
+	LightstepCollectorHost                    string            `yaml:"lightstep_collector_host"`
+	LightstepMaximumSpans                     int               `yaml:"lightstep_maximum_spans"`
+	LightstepNumClients                       int               `yaml:"lightstep_num_clients"`
+	LightstepReconnectPeriod                  string            `yaml:"lightstep_reconnect_period"`
+	MetricMaxLength                           int               `yaml:"metric_max_length"`
+	MetricSinks                               []SinkConfig      `yaml:"metric_sinks"`
 	MutexProfileFraction                      int               `yaml:"mutex_profile_fraction"`
 	NewrelicAccountID                         int               `yaml:"newrelic_account_id"`
 	NewrelicCommonTags                        []string          `yaml:"newrelic_common_tags"`
@@ -106,13 +102,9 @@ type Config struct {
 		APIKey util.StringSecret `yaml:"api_key"`
 		Name   string            `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`
-	SignalfxVaryKeyBy   string `yaml:"signalfx_vary_key_by"`
-	SpanChannelCapacity int    `yaml:"span_channel_capacity"`
-	SpanSinks           []struct {
-		Kind   string      `yaml:"kind"`
-		Name   string      `yaml:"name"`
-		Config interface{} `yaml:"config"`
-	} `yaml:"span_sinks"`
+	SignalfxVaryKeyBy                 string            `yaml:"signalfx_vary_key_by"`
+	SpanChannelCapacity               int               `yaml:"span_channel_capacity"`
+	SpanSinks                         []SinkConfig      `yaml:"span_sinks"`
 	SplunkHecAddress                  string            `yaml:"splunk_hec_address"`
 	SplunkHecBatchSize                int               `yaml:"splunk_hec_batch_size"`
 	SplunkHecConnectionLifetimeJitter string            `yaml:"splunk_hec_connection_lifetime_jitter"`
@@ -150,4 +142,10 @@ type Config struct {
 	XrayAddress          string   `yaml:"xray_address"`
 	XrayAnnotationTags   []string `yaml:"xray_annotation_tags"`
 	XraySamplePercentage float64  `yaml:"xray_sample_percentage"`
+}
+
+type SinkConfig struct {
+	Kind   string      `yaml:"kind"`
+	Name   string      `yaml:"name"`
+	Config interface{} `yaml:"config"`
 }

--- a/example.yaml
+++ b/example.yaml
@@ -498,7 +498,7 @@ kafka_metric_buffer_bytes: 0
 
 kafka_metric_buffer_messages: 0
 
-kafka_metric_buffer_frequency: ""
+kafka_metric_buffer_frequency: "10s"
 
 kafka_span_serialization_format: "protobuf"
 
@@ -515,7 +515,7 @@ kafka_span_buffer_bytes: 0
 
 kafka_span_buffer_mesages: 0
 
-kafka_span_buffer_frequency: ""
+kafka_span_buffer_frequency: "10s"
 
 # The number of retries before giving up.
 kafka_retry_max: 0

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -17,11 +16,13 @@ import (
 	"github.com/gogo/protobuf/proto"
 	gometrics "github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
+	veneur "github.com/stripe/veneur/v14"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/sinks"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+	"github.com/stripe/veneur/v14/util"
 )
 
 func init() {
@@ -30,86 +31,166 @@ func init() {
 
 const IngestTimeout = 5 * time.Second
 
-var IngestTimeoutError = errors.New("Timed out writing to Kafka producer")
+var ErrIngestTimeout = errors.New("timed out writing to Kafka producer")
 
-var _ sinks.MetricSink = &KafkaMetricSink{}
-var _ sinks.SpanSink = &KafkaSpanSink{}
+type KafkaMetricSinkConfig struct {
+	Broker                string        `yaml:"broker"`
+	CheckTopic            string        `yaml:"check_topic"`
+	EventTopic            string        `yaml:"event_topic"`
+	MetricBufferBytes     int           `yaml:"metric_buffer_bytes"`
+	MetricBufferFrequency time.Duration `yaml:"metric_buffer_frequency"`
+	MetricBufferMessages  int           `yaml:"metric_buffer_messages"`
+	MetricRequireAcks     string        `yaml:"metric_require_acks"`
+	MetricTopic           string        `yaml:"metric_topic"`
+	Partitioner           string        `yaml:"partitioner"`
+	RetryMax              int           `yaml:"retry_max"`
+}
 
 type KafkaMetricSink struct {
-	logger      *logrus.Entry
-	producer    sarama.AsyncProducer
-	checkTopic  string
-	eventTopic  string
-	metricTopic string
 	brokers     string
+	checkTopic  string
 	config      *sarama.Config
+	eventTopic  string
+	logger      *logrus.Entry
+	metricTopic string
+	name        string
+	producer    sarama.AsyncProducer
 	traceClient *trace.Client
 }
 
+type KafkaSpanSinkConfig struct {
+	Broker                  string        `yaml:"broker"`
+	Partitioner             string        `yaml:"partitioner"`
+	RetryMax                int           `yaml:"retry_max"`
+	SpanBufferBytes         int           `yaml:"span_buffer_bytes"`
+	SpanBufferFrequency     time.Duration `yaml:"span_buffer_frequency"`
+	SpanBufferMesages       int           `yaml:"span_buffer_mesages"`
+	SpanRequireAcks         string        `yaml:"span_require_acks"`
+	SpanSampleRatePercent   float64       `yaml:"span_sample_rate_percent"`
+	SpanSampleTag           string        `yaml:"span_sample_tag"`
+	SpanSerializationFormat string        `yaml:"span_serialization_format"`
+	SpanTopic               string        `yaml:"span_topic"`
+}
+
 type KafkaSpanSink struct {
-	logger          *logrus.Entry
-	producer        sarama.AsyncProducer
-	topic           string
 	brokers         string
-	serializer      string
+	config          *sarama.Config
+	logger          *logrus.Entry
+	name            string
+	producer        sarama.AsyncProducer
 	sampleTag       string
 	sampleThreshold uint32
-	config          *sarama.Config
+	serializer      string
 	spansFlushed    int64
+	topic           string
 	traceClient     *trace.Client
 }
 
-// NewKafkaMetricSink creates a new Kafka Plugin.
-func NewKafkaMetricSink(logger *logrus.Logger, cl *trace.Client, brokers string, checkTopic string, eventTopic string, metricTopic string, ackRequirement string, partitioner string, retries int, bufferBytes int, bufferMessages int, bufferDuration string) (*KafkaMetricSink, error) {
-	if logger == nil {
-		logger = &logrus.Logger{Out: ioutil.Discard}
+func MigrateConfig(conf *veneur.Config) error {
+	if conf.KafkaBroker == "" {
+		return nil
+	}
+	if conf.KafkaMetricTopic != "" ||
+		conf.KafkaCheckTopic != "" ||
+		conf.KafkaEventTopic != "" {
+		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
+			Kind: "kafka",
+			Name: "kafka",
+			Config: KafkaMetricSinkConfig{
+				Broker:                conf.KafkaBroker,
+				CheckTopic:            conf.KafkaCheckTopic,
+				EventTopic:            conf.KafkaEventTopic,
+				MetricBufferBytes:     conf.KafkaMetricBufferBytes,
+				MetricBufferFrequency: conf.KafkaMetricBufferFrequency,
+				MetricBufferMessages:  conf.KafkaMetricBufferMessages,
+				MetricRequireAcks:     conf.KafkaMetricRequireAcks,
+				MetricTopic:           conf.KafkaMetricTopic,
+				Partitioner:           conf.KafkaPartitioner,
+				RetryMax:              conf.KafkaRetryMax,
+			},
+		})
 	}
 
-	if checkTopic == "" && eventTopic == "" && metricTopic == "" {
-		return nil, errors.New("Unable to start Kafka sink with no valid topic names")
+	if conf.KafkaSpanTopic != "" {
+		conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
+			Kind: "kafka",
+			Name: "kafka",
+			Config: KafkaSpanSinkConfig{
+				Broker:                  conf.KafkaBroker,
+				Partitioner:             conf.KafkaPartitioner,
+				RetryMax:                conf.KafkaRetryMax,
+				SpanBufferBytes:         conf.KafkaSpanBufferBytes,
+				SpanBufferFrequency:     conf.KafkaSpanBufferFrequency,
+				SpanBufferMesages:       conf.KafkaSpanBufferMesages,
+				SpanRequireAcks:         conf.KafkaSpanRequireAcks,
+				SpanSampleRatePercent:   conf.KafkaSpanSampleRatePercent,
+				SpanSampleTag:           conf.KafkaSpanSampleTag,
+				SpanSerializationFormat: conf.KafkaSpanSerializationFormat,
+				SpanTopic:               conf.KafkaSpanTopic,
+			},
+		})
+	}
+	return nil
+}
+
+// ParseMetricConfig decodes the map config for a Kafka metric sink into a
+// KafkaMetricSinkConfig struct.
+func ParseMetricConfig(config interface{}) (veneur.MetricSinkConfig, error) {
+	kafkaConfig := KafkaMetricSinkConfig{}
+	err := util.DecodeConfig(config, &kafkaConfig)
+	if err != nil {
+		return nil, err
+	}
+	return kafkaConfig, nil
+}
+
+// CreateMetricSink creates a new Kafka sink for metrics. This function
+// should match the signature of a value in veneur.MetricSinkTypes, and is
+// intended to be passed into veneur.NewFromConfig to be called based on the
+// provided configuration.
+func CreateMetricSink(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig veneur.MetricSinkConfig,
+) (sinks.MetricSink, error) {
+	kafkaConfig := sinkConfig.(KafkaMetricSinkConfig)
+
+	if kafkaConfig.Broker == "" {
+		return nil, errors.New("cannot start Kafka metric sink with no broker")
+	}
+	if kafkaConfig.CheckTopic == "" &&
+		kafkaConfig.EventTopic == "" &&
+		kafkaConfig.MetricTopic == "" {
+		return nil, errors.New(
+			"cannot start Kafka metic sink with no valid topic names")
 	}
 
-	ll := logger.WithField("metric_sink", "kafka")
-
-	var finalBufferDuration time.Duration
-	if bufferDuration != "" {
-		var err error
-		finalBufferDuration, err = time.ParseDuration(bufferDuration)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	config, _ := newProducerConfig(ll, ackRequirement, partitioner, retries, bufferBytes, bufferMessages, finalBufferDuration)
-
-	ll.WithFields(logrus.Fields{
-		"brokers":         brokers,
-		"check_topic":     checkTopic,
-		"event_topic":     eventTopic,
-		"metric_topic":    metricTopic,
-		"partitioner":     partitioner,
-		"ack_requirement": ackRequirement,
-		"max_retries":     retries,
-		"buffer_bytes":    bufferBytes,
-		"buffer_messages": bufferMessages,
-		"buffer_duration": bufferDuration,
-	}).Info("Created Kafka metric sink")
+	logger.WithField("config", fmt.Sprintf("%+v", kafkaConfig)).
+		Info("Created Kafka metric sink")
 
 	return &KafkaMetricSink{
-		logger:      ll,
-		checkTopic:  checkTopic,
-		eventTopic:  eventTopic,
-		metricTopic: metricTopic,
-		brokers:     brokers,
-		config:      config,
-		traceClient: cl,
+		brokers:    kafkaConfig.Broker,
+		checkTopic: kafkaConfig.CheckTopic,
+		config: newProducerConfig(
+			kafkaConfig.MetricRequireAcks,
+			kafkaConfig.Partitioner,
+			kafkaConfig.RetryMax,
+			kafkaConfig.MetricBufferBytes,
+			kafkaConfig.MetricBufferMessages,
+			kafkaConfig.MetricBufferFrequency,
+		),
+		eventTopic:  kafkaConfig.EventTopic,
+		logger:      logger,
+		metricTopic: kafkaConfig.MetricTopic,
+		name:        name,
+		traceClient: server.TraceClient,
 	}, nil
 }
 
-func newProducerConfig(logger *logrus.Entry, ackRequirement string, partitioner string, retries int, bufferBytes int, bufferMessages int, bufferFrequency time.Duration) (*sarama.Config, error) {
-
+func newProducerConfig(
+	ackRequirement string, partitioner string, retries int, bufferBytes int,
+	bufferMessages int, bufferFrequency time.Duration,
+) *sarama.Config {
 	config := sarama.NewConfig()
-	// TODO Stringer?
 	switch ackRequirement {
 	case "all":
 		config.Producer.RequiredAcks = sarama.WaitForAll
@@ -118,7 +199,8 @@ func newProducerConfig(logger *logrus.Entry, ackRequirement string, partitioner 
 	case "local":
 		config.Producer.RequiredAcks = sarama.WaitForLocal
 	default:
-		logrus.WithField("ack_requirement", ackRequirement).Warn("Unknown ack requirement, defaulting to all")
+		logrus.WithField("ack_requirement", ackRequirement).
+			Warn("Unknown ack requirement, defaulting to all")
 		config.Producer.RequiredAcks = sarama.WaitForAll
 	}
 
@@ -137,7 +219,6 @@ func newProducerConfig(logger *logrus.Entry, ackRequirement string, partitioner 
 	}
 	if bufferFrequency != 0 {
 		config.Producer.Flush.Frequency = bufferFrequency
-
 	}
 
 	config.Producer.Retry.Max = retries
@@ -148,16 +229,18 @@ func newProducerConfig(logger *logrus.Entry, ackRequirement string, partitioner 
 	config.Producer.Return.Successes = false
 	config.Producer.Return.Errors = false
 
-	return config, nil
+	return config
 }
 
 // newConfiguredProducer returns a configured Sarama SyncProducer
-func newConfiguredProducer(logger *logrus.Entry, brokerString string, config *sarama.Config) (sarama.AsyncProducer, error) {
+func newConfiguredProducer(
+	logger *logrus.Entry, brokerString string, config *sarama.Config,
+) (sarama.AsyncProducer, error) {
 	brokerList := strings.Split(brokerString, ",")
 
 	if len(brokerList) < 1 {
 		logger.WithField("addrs", brokerString).Error("No brokers?")
-		return nil, errors.New("No brokers in broker list")
+		return nil, errors.New("no brokers in broker list")
 	}
 
 	logger.WithField("addrs", brokerList).Info("Connecting to Kafka")
@@ -172,7 +255,7 @@ func newConfiguredProducer(logger *logrus.Entry, brokerString string, config *sa
 
 // Name returns the name of this sink.
 func (k *KafkaMetricSink) Name() string {
-	return "kafka"
+	return k.name
 }
 
 // Start performs final adjustments on the sink.
@@ -224,70 +307,79 @@ func (k *KafkaMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.S
 	// TODO
 }
 
-// NewKafkaSpanSink creates a new Kafka Plugin.
-func NewKafkaSpanSink(logger *logrus.Logger, cl *trace.Client, brokers string, topic string, partitioner string, ackRequirement string, retries int, bufferBytes int, bufferMessages int, bufferDuration string, serializationFormat string, sampleTag string, sampleRatePercentage float64) (*KafkaSpanSink, error) {
-	if logger == nil {
-		logger = &logrus.Logger{Out: ioutil.Discard}
+// ParseSpanConfig decodes the map config for a Kafka span sink into a
+// KafkaSpanSinkConfig struct.
+func ParseSpanConfig(config interface{}) (veneur.SpanSinkConfig, error) {
+	kafkaConfig := KafkaSpanSinkConfig{}
+	err := util.DecodeConfig(config, &kafkaConfig)
+	if err != nil {
+		return nil, err
+	}
+	return kafkaConfig, nil
+}
+
+// CreateSpanSink creates a new Kafka sink for spans. This function
+// should match the signature of a value in veneur.SpanSinkTypes, and is
+// intended to be passed into veneur.NewFromConfig to be called based on the
+// provided configuration.
+func CreateSpanSink(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+) (sinks.SpanSink, error) {
+	kafkaConfig := sinkConfig.(KafkaSpanSinkConfig)
+
+	if kafkaConfig.Broker == "" {
+		return nil, errors.New("cannot start Kafka span sink with no broker")
+	}
+	if kafkaConfig.SpanTopic == "" {
+		return nil, errors.New("cannot start Kafka span sink with no span topic")
 	}
 
-	if topic == "" {
-		return nil, errors.New("Cannot start Kafka span sink with no span topic")
-	}
-
-	ll := logger.WithField("span_sink", "kafka")
-
-	serializer := serializationFormat
+	serializer := kafkaConfig.SpanSerializationFormat
 	if serializer != "json" && serializer != "protobuf" {
-		ll.WithField("serializer", serializer).Warn("Unknown serializer, defaulting to protobuf")
+		logger.WithField("serializer", serializer).
+			Warn("Unknown serializer, defaulting to protobuf")
 		serializer = "protobuf"
 	}
 
 	var sampleThreshold uint32
-	if sampleRatePercentage < 0 || sampleRatePercentage > 100 {
-		return nil, errors.New("Span sample rate percentage must be greater than 0%% and less than or equal to 100%%")
+	if kafkaConfig.SpanSampleRatePercent < 0 ||
+		kafkaConfig.SpanSampleRatePercent > 100 {
+		return nil, errors.New(
+			"span sample rate percentage must be between 0.0 and 100.0")
 	}
 
 	// Set the sample threshold to (sample rate) * (maximum value of uint32), so that
 	// we can store it as a uint32 instead of a float64 and compare apples-to-apples
 	// with the output of our hashing algorithm.
-	sampleThreshold = uint32(sampleRatePercentage * math.MaxUint32 / 100)
+	sampleThreshold = uint32(
+		kafkaConfig.SpanSampleRatePercent * math.MaxUint32 / 100)
 
-	var finalBufferDuration time.Duration
-	if bufferDuration != "" {
-		var err error
-		finalBufferDuration, err = time.ParseDuration(bufferDuration)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	config, _ := newProducerConfig(ll, ackRequirement, partitioner, retries, bufferBytes, bufferMessages, finalBufferDuration)
-
-	ll.WithFields(logrus.Fields{
-		"brokers":         brokers,
-		"topic":           topic,
-		"partitioner":     partitioner,
-		"ack_requirement": ackRequirement,
-		"max_retries":     retries,
-		"buffer_bytes":    bufferBytes,
-		"buffer_messages": bufferMessages,
-		"buffer_duration": bufferDuration,
-	}).Info("Started Kafka span sink")
+	logger.WithField("config", fmt.Sprintf("%+v", kafkaConfig)).
+		Info("Started Kafka span sink")
 
 	return &KafkaSpanSink{
-		logger:          ll,
-		topic:           topic,
-		brokers:         brokers,
-		config:          config,
-		serializer:      serializer,
-		sampleTag:       sampleTag,
+		brokers: kafkaConfig.Broker,
+		config: newProducerConfig(
+			kafkaConfig.SpanRequireAcks,
+			kafkaConfig.Partitioner,
+			kafkaConfig.RetryMax,
+			kafkaConfig.SpanBufferBytes,
+			kafkaConfig.SpanBufferMesages,
+			kafkaConfig.SpanBufferFrequency,
+		),
+		logger:          logger,
+		name:            name,
+		sampleTag:       kafkaConfig.SpanSampleTag,
 		sampleThreshold: sampleThreshold,
+		serializer:      serializer,
+		topic:           kafkaConfig.SpanTopic,
 	}, nil
 }
 
 // Name returns the name of this sink.
 func (k *KafkaSpanSink) Name() string {
-	return "kafka"
+	return k.name
 }
 
 // Start performs final adjustments on the sink.
@@ -368,7 +460,9 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 		}
 		enc = sarama.ByteEncoder(p)
 	default:
-		return fmt.Errorf("Unknown serialization format for encoding Kafka message: %s", k.serializer)
+		return fmt.Errorf(
+			"unknown serialization format for encoding Kafka message: %s",
+			k.serializer)
 	}
 
 	message := &sarama.ProducerMessage{
@@ -380,8 +474,8 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 	case k.producer.Input() <- message:
 		atomic.AddInt64(&k.spansFlushed, 1)
 		return nil
-	case _ = <-time.After(IngestTimeout):
-		return IngestTimeoutError
+	case <-time.After(IngestTimeout):
+		return ErrIngestTimeout
 	}
 }
 


### PR DESCRIPTION
#### Summary
This change migrates the Kafka sink to use the new config format.

#### Motivation
This work is part of enabling multi-sink routing.

#### Test plan
```
go test github.com/stripe/veneur/v14
```