### PR TITLE
Set log level for "Could not parse packet" to debug.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1168,7 +1168,7 @@ func (s *Server) HandleMetricPacket(packet []byte, protocolType ProtocolType) er
 			log.WithFields(logrus.Fields{
 				logrus.ErrorKey: err,
 				"packet":        string(packet),
-			}).Warn("Could not parse packet")
+			}).Debug("Could not parse packet")
 			samples.Add(ssf.Count("packet.error_total", 1, map[string]string{"packet_type": "event", "reason": "parse"}))
 			return err
 		}
@@ -1179,7 +1179,7 @@ func (s *Server) HandleMetricPacket(packet []byte, protocolType ProtocolType) er
 			log.WithFields(logrus.Fields{
 				logrus.ErrorKey: err,
 				"packet":        string(packet),
-			}).Warn("Could not parse packet")
+			}).Debug("Could not parse packet")
 			samples.Add(ssf.Count("packet.error_total", 1, map[string]string{"packet_type": "service_check", "reason": "parse"}))
 			return err
 		}
@@ -1190,7 +1190,7 @@ func (s *Server) HandleMetricPacket(packet []byte, protocolType ProtocolType) er
 			log.WithFields(logrus.Fields{
 				logrus.ErrorKey: err,
 				"packet":        string(packet),
-			}).Warn("Could not parse packet")
+			}).Debug("Could not parse packet")
 			samples.Add(ssf.Count("packet.error_total", 1, map[string]string{"packet_type": "metric", "reason": "parse"}))
 			return err
 		}


### PR DESCRIPTION
#### Summary
Set the log level for `Could not parse packet` logs to debug.

#### Motivation
This log line does not have much value in production.
