### PR TITLE
Add logic for filtering metrics in order to route them to the configured sinks.

### DIFF
--- a/sink_routing.go
+++ b/sink_routing.go
@@ -1,0 +1,250 @@
+package veneur
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type SinkRoutingConfig struct {
+	Name         string          `yaml:"name"`
+	MatchConfigs []MatcherConfig `yaml:"match"`
+	Sinks        []string        `yaml:"sinks"`
+}
+
+type MatcherConfig struct {
+	Name NameMatcher  `yaml:"name"`
+	Tags []TagMatcher `yaml:"tags"`
+}
+
+type NameMatcher struct {
+	Kind  string `yaml:"kind"`
+	match func(string) bool
+	regex *regexp.Regexp
+	Value string `yaml:"value"`
+}
+
+type TagMatcher struct {
+	Key   TagKeyMatcher   `yaml:"key"`
+	Value TagValueMatcher `yaml:"value"`
+	match func(map[string]string) bool
+}
+
+type TagKeyMatcher struct {
+	Kind  string `yaml:"kind"`
+	regex *regexp.Regexp
+	Value string `yaml:"value"`
+}
+
+type TagValueMatcher struct {
+	Kind  string `yaml:"kind"`
+	match func(string) bool
+	regex *regexp.Regexp
+	Value string `yaml:"value"`
+}
+
+// UnmarshalYAML unmarshals and validates the yaml config for matching the name
+// of a metric.
+func (matcher *NameMatcher) UnmarshalYAML(
+	unmarshal func(interface{}) error) error {
+	err := unmarshal(matcher)
+	if err != nil {
+		return err
+	}
+	switch matcher.Kind {
+	case "any":
+		matcher.match = matcher.matchAny
+	case "exact":
+		matcher.match = matcher.matchExact
+	case "prefix":
+		matcher.match = matcher.matchPrefix
+	case "regex":
+		matcher.regex, err = regexp.Compile(matcher.Value)
+		if err != nil {
+			return err
+		}
+		matcher.match = matcher.matchRegex
+	default:
+		return fmt.Errorf("unknown matcher kind \"%s\"", matcher.Kind)
+	}
+	return nil
+}
+
+func (matcher *NameMatcher) matchAny(value string) bool {
+	return true
+}
+
+func (matcher *NameMatcher) matchExact(value string) bool {
+	return value == matcher.Value
+}
+
+func (matcher *NameMatcher) matchPrefix(value string) bool {
+	return strings.HasPrefix(value, matcher.Value)
+}
+
+func (matcher *NameMatcher) matchRegex(value string) bool {
+	return matcher.regex.MatchString(value)
+}
+
+// UnmarshalYAML unmarshals and validates the yaml config for matching tags
+// within a metric.
+func (matcher *TagMatcher) UnmarshalYAML(
+	unmarshal func(interface{}) error) error {
+	err := unmarshal(matcher)
+	if err != nil {
+		return err
+	}
+	switch matcher.Value.Kind {
+	case "any":
+		matcher.Value.match = matcher.matchValueAny
+	case "exact":
+		matcher.Value.match = matcher.matchValueExact
+	case "prefix":
+		matcher.Value.match = matcher.matchValuePrefix
+	case "regex":
+		matcher.Value.regex, err = regexp.Compile(matcher.Value.Value)
+		if err != nil {
+			return err
+		}
+		matcher.Value.match = matcher.matchValueRegex
+	case "unset":
+		switch matcher.Key.Kind {
+		case "any":
+			matcher.match = matcher.matchUnsetKeyAny
+		case "exact":
+			matcher.match = matcher.matchUnsetKeyExact
+		case "prefix":
+			matcher.match = matcher.matchUnsetKeyPrefix
+		case "regex":
+			matcher.Key.regex, err = regexp.Compile(matcher.Key.Value)
+			if err != nil {
+				return err
+			}
+			matcher.match = matcher.matchUnsetKeyRegex
+		default:
+			return fmt.Errorf("unknown key matcher kind \"%s\"", matcher.Key.Kind)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown value matcher kind \"%s\"", matcher.Value.Kind)
+	}
+	switch matcher.Key.Kind {
+	case "any":
+		matcher.match = matcher.matchKeyAny
+	case "exact":
+		matcher.match = matcher.matchKeyExact
+	case "prefix":
+		matcher.match = matcher.matchKeyPrefix
+	case "regex":
+		matcher.Key.regex, err = regexp.Compile(matcher.Key.Value)
+		if err != nil {
+			return err
+		}
+		matcher.match = matcher.matchKeyRegex
+	default:
+		return fmt.Errorf("unknown key matcher kind \"%s\"", matcher.Key.Kind)
+	}
+	return nil
+}
+
+func (matcher *TagMatcher) matchKeyAny(tags map[string]string) bool {
+	for _, value := range tags {
+		if matcher.Value.match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (matcher *TagMatcher) matchKeyExact(tags map[string]string) bool {
+	value, ok := tags[matcher.Key.Value]
+	if !ok {
+		return false
+	}
+	return matcher.Value.match(value)
+}
+
+func (matcher *TagMatcher) matchKeyPrefix(tags map[string]string) bool {
+	for key, value := range tags {
+		if !strings.HasPrefix(key, matcher.Key.Value) {
+			continue
+		}
+		if matcher.Value.match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (matcher *TagMatcher) matchKeyRegex(tags map[string]string) bool {
+	for key, value := range tags {
+		if !matcher.Key.regex.MatchString(key) {
+			continue
+		}
+		if matcher.Value.match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (matcher *TagMatcher) matchUnsetKeyAny(tags map[string]string) bool {
+	return len(tags) == 0
+}
+
+func (matcher *TagMatcher) matchUnsetKeyExact(tags map[string]string) bool {
+	_, ok := tags[matcher.Key.Value]
+	return !ok
+}
+
+func (matcher *TagMatcher) matchUnsetKeyPrefix(tags map[string]string) bool {
+	for key := range tags {
+		if strings.HasPrefix(key, matcher.Key.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+func (matcher *TagMatcher) matchUnsetKeyRegex(tags map[string]string) bool {
+	for key := range tags {
+		if matcher.Key.regex.MatchString(key) {
+			return false
+		}
+	}
+	return true
+}
+
+func (matcher *TagMatcher) matchValueAny(value string) bool {
+	return true
+}
+
+func (matcher *TagMatcher) matchValueExact(value string) bool {
+	return value == matcher.Value.Value
+}
+
+func (matcher *TagMatcher) matchValuePrefix(value string) bool {
+	return strings.HasPrefix(value, matcher.Value.Value)
+}
+
+func (matcher *TagMatcher) matchValueRegex(value string) bool {
+	return matcher.Value.regex.MatchString(value)
+}
+
+func (config *SinkRoutingConfig) Match(
+	name string, tags map[string]string,
+) bool {
+outer:
+	for _, matchConfig := range config.MatchConfigs {
+		if !matchConfig.Name.match(name) {
+			continue
+		}
+		for _, tagMatchConfig := range matchConfig.Tags {
+			if !tagMatchConfig.match(tags) {
+				continue outer
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/sink_routing_test.go
+++ b/sink_routing_test.go
@@ -1,0 +1,717 @@
+package veneur_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/veneur/v14"
+)
+
+func CreateNameMatcher(
+	t *testing.T, matcher *veneur.NameMatcher,
+) error {
+	return matcher.UnmarshalYAML(func(matcher interface{}) error {
+		assert.IsType(t, &veneur.NameMatcher{}, matcher)
+		return nil
+	})
+}
+
+func CreateTagMatcher(
+	t *testing.T, matcher *veneur.TagMatcher,
+) error {
+	return matcher.UnmarshalYAML(func(matcher interface{}) error {
+		assert.IsType(t, &veneur.TagMatcher{}, matcher)
+		return nil
+	})
+}
+
+func TestMatchNameAny(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	assert.True(t, config.Match("aaa", map[string]string{}))
+	assert.True(t, config.Match("aab", map[string]string{}))
+	assert.True(t, config.Match("aaba", map[string]string{}))
+	assert.True(t, config.Match("abb", map[string]string{}))
+}
+
+func TestMatchNameExact(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind:  "exact",
+				Value: "aab",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	assert.False(t, config.Match("aaa", map[string]string{}))
+	assert.True(t, config.Match("aab", map[string]string{}))
+	assert.False(t, config.Match("aaba", map[string]string{}))
+	assert.False(t, config.Match("abb", map[string]string{}))
+}
+
+func TestMatchNamePrefix(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind:  "prefix",
+				Value: "aa",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	assert.True(t, config.Match("aaa", map[string]string{}))
+	assert.True(t, config.Match("aab", map[string]string{}))
+	assert.True(t, config.Match("aaba", map[string]string{}))
+	assert.False(t, config.Match("abb", map[string]string{}))
+}
+
+func TestMatchNameRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind:  "regex",
+				Value: "ab+$",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	assert.False(t, config.Match("aaa", map[string]string{}))
+	assert.True(t, config.Match("aab", map[string]string{}))
+	assert.False(t, config.Match("aaba", map[string]string{}))
+	assert.True(t, config.Match("abb", map[string]string{}))
+}
+
+func TestMatchNameInvalidRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind:  "regex",
+				Value: "[",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	assert.Error(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+}
+
+func TestMatchNameInvalidKind(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "invalid",
+			},
+			Tags: []veneur.TagMatcher{},
+		}},
+	}
+
+	assert.Error(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+}
+
+func TestMatchTagNameAny(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameAnyUnset(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "unset",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameExact(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "exact",
+					Value: "aab",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameExactUnset(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "exact",
+					Value: "aab",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "unset",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNamePrefix(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNamePrefixUnset(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "unset",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "regex",
+					Value: "ab+$",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameRegexUnset(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "regex",
+					Value: "ab+$",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "unset",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaa": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"aab": "value",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaba": "value",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"abb": "value",
+	}))
+}
+
+func TestMatchTagNameInvalidRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "regex",
+					Value: "[",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Error(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+}
+
+func TestMatchTagNameInvalidKind(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "invalid",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "any",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Error(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+}
+
+func TestMatchTagValueExact(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "exact",
+					Value: "aab",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "aaa",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "aab",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "aaba",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "abb",
+	}))
+}
+
+func TestMatchTagValuePrefix(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "aaa",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "aab",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "aaba",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "abb",
+	}))
+}
+
+func TestMatchTagValueRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "regex",
+					Value: "ab+$",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "aaa",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "aab",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"key": "aaba",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"key": "abb",
+	}))
+}
+
+func TestMatchTagValueInvalidRegex(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "regex",
+					Value: "[",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Error(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+}
+
+func TestMatchTagValueInvalidKind(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind: "any",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind: "invalid",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Error(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+}
+
+func TestMatchMultipleTags(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "bb",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaab": "abab",
+		"baba": "bbab",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"aaba": "bbab",
+		"baba": "bbab",
+	}))
+}
+
+func TestMultipleTagMatchers(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind: "any",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "exact",
+					Value: "ab",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "ab",
+				},
+			}, {
+				Key: veneur.TagKeyMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "bb",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[1]))
+	assert.False(t, config.Match("name", map[string]string{
+		"aaab": "bbab",
+		"baba": "abab",
+	}))
+	assert.False(t, config.Match("name", map[string]string{
+		"ab":   "abab",
+		"baab": "bbab",
+	}))
+	assert.True(t, config.Match("name", map[string]string{
+		"ab":   "abab",
+		"aaab": "bbab",
+		"baba": "bbab",
+	}))
+}
+
+func TestMultipleMatcherConfigs(t *testing.T) {
+	config := veneur.SinkRoutingConfig{
+		MatchConfigs: []veneur.MatcherConfig{{
+			Name: veneur.NameMatcher{
+				Kind:  "exact",
+				Value: "aa",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "exact",
+					Value: "ab",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "ab",
+				},
+			}},
+		}, {
+			Name: veneur.NameMatcher{
+				Kind:  "exact",
+				Value: "bb",
+			},
+			Tags: []veneur.TagMatcher{{
+				Key: veneur.TagKeyMatcher{
+					Kind:  "prefix",
+					Value: "aa",
+				},
+				Value: veneur.TagValueMatcher{
+					Kind:  "prefix",
+					Value: "bb",
+				},
+			}},
+		}},
+	}
+
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[0].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[0].Tags[0]))
+	require.Nil(t, CreateNameMatcher(t, &config.MatchConfigs[1].Name))
+	require.Nil(t, CreateTagMatcher(t, &config.MatchConfigs[1].Tags[0]))
+	assert.False(t, config.Match("aa", map[string]string{
+		"aaab": "bbab",
+		"baba": "abab",
+	}))
+	assert.True(t, config.Match("bb", map[string]string{
+		"aaab": "bbab",
+		"baba": "abab",
+	}))
+	assert.True(t, config.Match("aa", map[string]string{
+		"ab":   "abab",
+		"baab": "bbab",
+	}))
+	assert.False(t, config.Match("bb", map[string]string{
+		"ab":   "abab",
+		"baab": "bbab",
+	}))
+}


### PR DESCRIPTION
#### Summary
This change adds logic to filter metrics using rules in a metric sink routing config in order to flush them to the specified sinks. This logic is currently unused, and will be incorporated in a followup change.


#### Motivation
This change works towards adding custom metric sink routing.


#### Test plan
```
go test github.com/stripe/veneur/v14
```
