### PR TITLE
Use time.Duration for the server interval.

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	HTTPAddress                               string              `yaml:"http_address"`
 	HTTPQuit                                  bool                `yaml:"http_quit"`
 	IndicatorSpanTimerName                    string              `yaml:"indicator_span_timer_name"`
-	Interval                                  string              `yaml:"interval"`
+	Interval                                  time.Duration       `yaml:"interval"`
 	KafkaBroker                               string              `yaml:"kafka_broker"`
 	KafkaCheckTopic                           string              `yaml:"kafka_check_topic"`
 	KafkaEventTopic                           string              `yaml:"kafka_event_topic"`

--- a/config_parse.go
+++ b/config_parse.go
@@ -14,7 +14,7 @@ import (
 var defaultConfig = Config{
 	Aggregates:                     []string{"min", "max", "count"},
 	DatadogFlushMaxPerBody:         25000,
-	Interval:                       "10s",
+	Interval:                       time.Duration(10 * time.Second),
 	MetricMaxLength:                4096,
 	PrometheusNetworkType:          "tcp",
 	ReadBufferSizeBytes:            1048576 * 2, // 2 MiB
@@ -157,7 +157,7 @@ func (c *Config) applyDefaults() {
 	if c.Hostname == "" && !c.OmitEmptyHostname {
 		c.Hostname, _ = os.Hostname()
 	}
-	if c.Interval == "" {
+	if c.Interval == 0 {
 		c.Interval = defaultConfig.Interval
 	}
 	if c.MetricMaxLength == 0 {
@@ -227,9 +227,4 @@ func (c *Config) applyDefaults() {
 	if c.SplunkHecMaxConnectionLifetime == 0 {
 		c.SplunkHecMaxConnectionLifetime = defaultConfig.SplunkHecMaxConnectionLifetime
 	}
-}
-
-// ParseInterval handles parsing the flush interval as a time.Duration
-func (c Config) ParseInterval() (time.Duration, error) {
-	return time.ParseDuration(c.Interval)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -23,9 +23,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, "https://app.datadoghq.com", c.DatadogAPIHostname)
 	assert.Equal(t, 96, c.NumWorkers)
 
-	interval, err := c.ParseInterval()
-	assert.NoError(t, err)
-	assert.Equal(t, interval, 10*time.Second)
+	assert.Equal(t, c.Interval, 10*time.Second)
 }
 
 func TestReadBadConfig(t *testing.T) {
@@ -105,10 +103,8 @@ func TestConfigDefaults(t *testing.T) {
 }
 
 func TestDefaultConfigEquivalence(t *testing.T) {
-	defaultInterval, err := time.ParseDuration(defaultConfig.Interval)
-	assert.Nil(t, err)
 	assert.Equal(t,
-		defaultInterval,
+		defaultConfig.Interval,
 		defaultConfig.SplunkHecMaxConnectionLifetime,
 		"splunk_hec_max_connection_lifetime should default to interval")
 

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -88,7 +88,7 @@ func TestServerFlushGRPCTimeout(t *testing.T) {
 	}()
 
 	localCfg := localConfig()
-	localCfg.Interval = "20us"
+	localCfg.Interval = time.Duration(20 * time.Microsecond)
 	localCfg.DebugFlushedMetrics = true
 	localCfg.ForwardAddress = testServer.Addr().String()
 	localCfg.ForwardUseGrpc = true
@@ -183,7 +183,7 @@ func TestFlushResetsWorkerUniqueMTS(t *testing.T) {
 	config := localConfig()
 	config.CountUniqueTimeseries = true
 	config.NumWorkers = 2
-	config.Interval = "60s"
+	config.Interval = time.Duration(time.Minute)
 	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}
 	ch := make(chan []samplers.InterMetric, 20)
 	sink, _ := NewChannelMetricSink(ch)
@@ -214,7 +214,7 @@ func TestTallyTimeseries(t *testing.T) {
 	config := localConfig()
 	config.CountUniqueTimeseries = true
 	config.NumWorkers = 10
-	config.Interval = "60s"
+	config.Interval = time.Duration(time.Minute)
 	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}
 	ch := make(chan []samplers.InterMetric, 20)
 	sink, _ := NewChannelMetricSink(ch)

--- a/server.go
+++ b/server.go
@@ -383,7 +383,8 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	conf := config.Config
 
 	ret := &Server{
-		Config: conf,
+		Config:   conf,
+		interval: conf.Interval,
 	}
 
 	ret.Hostname = conf.Hostname
@@ -403,12 +404,6 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		ret.HistogramAggregates.Value += samplers.AggregatesLookup[agg]
 	}
 	ret.HistogramAggregates.Count = len(conf.Aggregates)
-
-	var err error
-	ret.interval, err = conf.ParseInterval()
-	if err != nil {
-		return ret, err
-	}
 
 	ret.stuckIntervals = conf.FlushWatchdogMissedFlushes
 

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -151,7 +151,7 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		SsfListenAddresses:     []string{"udp://127.0.0.1:99"},
 
 		// required or NewFromConfig fails
-		Interval:     "10s",
+		Interval:     time.Duration(10 * time.Second),
 		StatsAddress: "localhost:62251",
 	}
 	server, err := NewFromConfig(ServerConfig{
@@ -174,7 +174,7 @@ func TestNewPrometheusMetricSinkConfig(t *testing.T) {
 		PrometheusNetworkType:     "tcp",
 
 		// Required or NewFromConfig fails.
-		Interval:     "10s",
+		Interval:     time.Duration(10 * time.Second),
 		StatsAddress: "localhost:62251",
 	}
 


### PR DESCRIPTION
#### Summary
Use `time.Duration` for the server interval in the config.

#### Motivation
Cleanup.