### PR TITLE
Migrate debug sinks to new config format.

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14"
+	"github.com/stripe/veneur/v14/sinks/debug"
 	"github.com/stripe/veneur/v14/sinks/kafka"
 	"github.com/stripe/veneur/v14/sinks/signalfx"
 	"github.com/stripe/veneur/v14/sinks/splunk"
@@ -48,6 +49,7 @@ func main() {
 		os.Exit(0)
 	}
 	if !conf.Features.MigrateMetricSinks {
+		debug.MigrateConfig(&conf)
 		err = signalfx.MigrateConfig(&conf)
 		if err != nil {
 			logrus.WithError(err).Fatal("error migrating signalfx config")
@@ -68,6 +70,10 @@ func main() {
 		Logger: logger,
 		MetricSinkTypes: veneur.MetricSinkTypes{
 			// TODO(arnavdugar): Migrate metric sink types.
+			"debug": {
+				Create:      debug.CreateMetricSink,
+				ParseConfig: debug.ParseMetricConfig,
+			},
 			"kafka": {
 				Create:      kafka.CreateMetricSink,
 				ParseConfig: kafka.ParseMetricConfig,
@@ -79,6 +85,10 @@ func main() {
 		},
 		SpanSinkTypes: veneur.SpanSinkTypes{
 			// TODO(arnavdugar): Migrate span sink types.
+			"debug": {
+				Create:      debug.CreateSpanSink,
+				ParseConfig: debug.ParseSpanConfig,
+			},
 			"kafka": {
 				Create:      kafka.CreateSpanSink,
 				ParseConfig: kafka.ParseSpanConfig,

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -67,7 +67,7 @@ func (b *debugMetricSink) Start(*trace.Client) error {
 }
 
 func (b *debugMetricSink) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
-	if len(metrics) == 0 || b.log.Level < logrus.DebugLevel {
+	if len(metrics) == 0 || b.log.Logger.Level < logrus.DebugLevel {
 		return nil
 	}
 	b.mtx.Lock()
@@ -85,7 +85,7 @@ func (b *debugMetricSink) Flush(ctx context.Context, metrics []samplers.InterMet
 }
 
 func (b *debugMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {
-	if len(samples) == 0 || b.log.Level < logrus.DebugLevel {
+	if len(samples) == 0 || b.log.Logger.Level < logrus.DebugLevel {
 		return
 	}
 	b.mtx.Lock()
@@ -113,7 +113,7 @@ func ParseSpanConfig(_ interface{}) (veneur.SpanSinkConfig, error) {
 	return nil, nil
 }
 
-// CreateSpanSink creates a new Kafka sink for spans. This function
+// CreateSpanSink creates a new debug sink for spans. This function
 // should match the signature of a value in veneur.SpanSinkTypes, and is
 // intended to be passed into veneur.NewFromConfig to be called based on the
 // provided configuration.
@@ -138,7 +138,7 @@ func (b *debugSpanSink) Start(*trace.Client) error {
 }
 
 func (b *debugSpanSink) Ingest(span *ssf.SSFSpan) error {
-	if b.log.Level < logrus.DebugLevel {
+	if b.log.Logger.Level < logrus.DebugLevel {
 		return nil
 	}
 	b.mtx.Lock()

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/v14"
 	"github.com/stripe/veneur/v14/protocol"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/sinks"
@@ -14,19 +15,51 @@ import (
 	"github.com/stripe/veneur/v14/trace"
 )
 
-type debugMetricSink struct {
-	log *logrus.Logger
-	mtx *sync.Mutex
+func MigrateConfig(conf *veneur.Config) {
+	if conf.DebugFlushedMetrics {
+		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
+			Kind: "debug",
+			Name: "debug",
+		})
+	}
+	if conf.DebugIngestedSpans {
+		conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
+			Kind: "debug",
+			Name: "debug",
+		})
+	}
 }
 
-var _ sinks.MetricSink = &debugMetricSink{}
+type debugMetricSink struct {
+	log  *logrus.Entry
+	mtx  *sync.Mutex
+	name string
+}
 
-func NewDebugMetricSink(mtx *sync.Mutex, log *logrus.Logger) sinks.MetricSink {
-	return &debugMetricSink{log, mtx}
+// Prevents debug sinks from logging at the same time.
+var mtx = sync.Mutex{}
+
+func ParseMetricConfig(_ interface{}) (veneur.MetricSinkConfig, error) {
+	return nil, nil
+}
+
+// CreateMetricSink creates a new debug sink for metrics. This function
+// should match the signature of a value in veneur.MetricSinkTypes, and is
+// intended to be passed into veneur.NewFromConfig to be called based on the
+// provided configuration.
+func CreateMetricSink(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig veneur.MetricSinkConfig,
+) (sinks.MetricSink, error) {
+	return &debugMetricSink{
+		log:  logger,
+		mtx:  &mtx,
+		name: name,
+	}, nil
 }
 
 func (b *debugMetricSink) Name() string {
-	return "blackhole"
+	return b.name
 }
 
 func (b *debugMetricSink) Start(*trace.Client) error {
@@ -71,18 +104,32 @@ func (b *debugMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.S
 }
 
 type debugSpanSink struct {
-	log *logrus.Logger
-	mtx *sync.Mutex
+	log  *logrus.Entry
+	mtx  *sync.Mutex
+	name string
 }
 
-var _ sinks.SpanSink = &debugSpanSink{}
+func ParseSpanConfig(_ interface{}) (veneur.SpanSinkConfig, error) {
+	return nil, nil
+}
 
-func NewDebugSpanSink(mtx *sync.Mutex, log *logrus.Logger) sinks.SpanSink {
-	return &debugSpanSink{log, mtx}
+// CreateSpanSink creates a new Kafka sink for spans. This function
+// should match the signature of a value in veneur.SpanSinkTypes, and is
+// intended to be passed into veneur.NewFromConfig to be called based on the
+// provided configuration.
+func CreateSpanSink(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+) (sinks.SpanSink, error) {
+	return &debugSpanSink{
+		log:  logger,
+		mtx:  &mtx,
+		name: name,
+	}, nil
 }
 
 func (b *debugSpanSink) Name() string {
-	return "debug"
+	return b.name
 }
 
 // Start performs final adjustments on the sink.


### PR DESCRIPTION
#### Summary
This change migrates the debug metric and span sinks to use the new config format.

#### Motivation
This work is part of enabling multi-sink routing.

#### Test plan
```
go test github.com/stripe/veneur/v14
```