### PR TITLE
Fix infinite loop in parsing the sink routing config.

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -104,7 +104,8 @@ func (s *Server) Flush(ctx context.Context) {
 	}
 
 	if s.Config.Features.EnableMetricSinkRouting {
-		for _, metric := range finalMetrics {
+		for index := range finalMetrics {
+			metric := &finalMetrics[index]
 			metric.Sinks = make(samplers.RouteInformation)
 			for _, config := range s.Config.MetricSinkRouting {
 				var sinks []string


### PR DESCRIPTION
#### Summary
This change fixes infinite loop in parsing the sink routing config.

Calling `unmarshal` from within `UnmarshalYAML` calls `UnmarshalYAML` again, causing an infinite loop. Instead we need to call `unmarshal` on a different struct that does not have `UnmarshalYAML` defined.

#### Test plan
Updated unit tests to include yaml parsing.