### PR TITLE
Add arguments for tag addition and renaming to veneur-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * A flag -print-secrets to disable redacting config secrets.
 * A prometheus remote-write sink compatible with Cortex and more. Thanks, [philipnrmn](https://github.com/philipnrmn)!
+* Some veneur-prometheus arguments to rename and add additional tags. Thanks, [christopherb-stripe](https://github.com/christopherb-stripe)!
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/cmd/veneur-prometheus/README.md
+++ b/cmd/veneur-prometheus/README.md
@@ -32,11 +32,13 @@ Buckets are defined explicitly by the application. If the definition of bucket b
 
 ```
 Usage of ./veneur-prometheus:
+  -a string
+    	A comma-seperated list of tags to add. (e.g. "newtag=newtagvalue,othernewtag=othernewtagvalue"
   -cacert string
     	The path to a CA cert used to validate the server certificate. Only used if using mTLS.
   -cert string
     	The path to a client cert to present to the server. Only used if using mTLS.
-  -d    Enable debug mode
+  -d	Enable debug mode
   -h string
     	The full URL — like 'http://localhost:9090/metrics' to query for Prometheus metrics. (default "http://localhost:9090/metrics")
   -i string
@@ -49,6 +51,10 @@ Usage of ./veneur-prometheus:
     	The path to a private key to use for mTLS. Only used if using mTLS.
   -p string
     	A prefix to append to any metrics emitted. Include a trailing period. (e.g. "myservice.")
+  -r string
+    	A comma-seperated list of rename rules for tags. (e.g. "oldtag=newtag,otheroldtag=othernewtag"
   -s string
     	The host and port — like '127.0.0.1:8126' — to send our metrics to. (default "127.0.0.1:8126")
+  -socket string
+    	The path to a unix socket to use for transport. Useful for certains styles of proxy.
 ```

--- a/cmd/veneur-prometheus/config.go
+++ b/cmd/veneur-prometheus/config.go
@@ -15,6 +15,8 @@ type prometheusConfig struct {
 	httpClient     *http.Client
 	ignoredLabels  []*regexp.Regexp
 	ignoredMetrics []*regexp.Regexp
+	addedLabels    map[string]string
+	renameLabels   map[string]string
 }
 
 func prometheusConfigFromArguments() (prometheusConfig, error) {
@@ -25,6 +27,8 @@ func prometheusConfigFromArguments() (prometheusConfig, error) {
 		httpClient:     client,
 		ignoredLabels:  getIgnoredFromArg(*ignoredLabelsStr),
 		ignoredMetrics: getIgnoredFromArg(*ignoredMetricsStr),
+		addedLabels:    getAddedFromArg(*addLabelsStr),
+		renameLabels:   getRenamedFromArg(*renameLabelsStr),
 	}, err
 }
 
@@ -37,6 +41,38 @@ func getIgnoredFromArg(arg string) []*regexp.Regexp {
 	}
 
 	return ignore
+}
+
+func getRenamedFromArg(arg string) map[string]string {
+	renamed := make(map[string]string)
+	for _, renameStr := range strings.Split(arg, ",") {
+		if len(renameStr) <= 0 {
+			continue
+		}
+
+		parts := strings.SplitN(renameStr, "=", 2)
+		if len(parts) == 2 {
+			renamed[parts[0]] = parts[1]
+		}
+	}
+
+	return renamed
+}
+
+func getAddedFromArg(arg string) map[string]string {
+	added := make(map[string]string)
+	for _, addStr := range strings.Split(arg, ",") {
+		if len(addStr) <= 0 {
+			continue
+		}
+
+		parts := strings.SplitN(addStr, "=", 2)
+		if len(parts) == 2 {
+			added[parts[0]] = parts[1]
+		}
+	}
+
+	return added
 }
 
 func newHTTPClient(socket, certPath, keyPath, caCertPath string) (*http.Client, error) {

--- a/cmd/veneur-prometheus/config_test.go
+++ b/cmd/veneur-prometheus/config_test.go
@@ -52,3 +52,62 @@ func TestGetHTTPClientHTTPS(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 }
+
+func TestParseLabelRenamingAndAddingFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     string
+		expected map[string]string
+	}{
+		{
+			name:     "empty",
+			args:     "",
+			expected: map[string]string{},
+		},
+		{
+			name: "single",
+			args: "old=new",
+			expected: map[string]string{
+				"old": "new",
+			},
+		},
+		{
+			name: "multiple",
+			args: "old=new,aged=pristine",
+			expected: map[string]string{
+				"old":  "new",
+				"aged": "pristine",
+			},
+		},
+		{
+			name:     "empty value (ignored)",
+			args:     "old",
+			expected: map[string]string{},
+		},
+		{
+			name: "one empty value",
+			args: "old,aged=pristine",
+			expected: map[string]string{
+				"aged": "pristine",
+			},
+		},
+		{
+			name: "multiple equals signs",
+			args: "old=aged=pristine",
+			expected: map[string]string{
+				"old": "aged=pristine",
+			},
+		},
+	} {
+		// Added and renaming have the same parsing logic for arguments.
+		t.Run("added "+tc.name, func(t *testing.T) {
+			result := getAddedFromArg(tc.args)
+			assert.Equal(t, tc.expected, result)
+		})
+
+		t.Run("renamed "+tc.name, func(t *testing.T) {
+			result := getRenamedFromArg(tc.args)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	cache := new(countCache)
 	ticker := time.NewTicker(i)
-	for _ = range ticker.C {
+	for range ticker.C {
 		statsdStats := collect(cfg, cache)
 		sendToStatsd(statsClient, *statsHost, statsdStats)
 	}

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -16,8 +16,8 @@ var (
 	ignoredMetricsStr = flag.String("ignored-metrics", "", "A comma-seperated list of metric name regexes to not export")
 	prefix            = flag.String("p", "", "A prefix to append to any metrics emitted. Include a trailing period. (e.g. \"myservice.\")")
 	statsHost         = flag.String("s", "127.0.0.1:8126", "The host and port — like '127.0.0.1:8126' — to send our metrics to.")
-	renameTags        = flag.String("r", "", "A comma-seperated list of rename rules for tags. (e.g. \"oldtag=newtag,otheroldtag=othernewtag\"")
-	addTags           = flag.String("a", "", "A comma-seperated list of tags to add. (e.g. \"newtag=newtagvalue,othernewtag=othernewtagvalue\"")
+	renameLabelsStr   = flag.String("r", "", "A comma-seperated list of rename rules for tags. (e.g. \"oldtag=newtag,otheroldtag=othernewtag\"")
+	addLabelsStr      = flag.String("a", "", "A comma-seperated list of tags to add. (e.g. \"newtag=newtagvalue,othernewtag=othernewtagvalue\"")
 
 	// mTLS params for collecting metrics
 	cert   = flag.String("cert", "", "The path to a client cert to present to the server. Only used if using mTLS.")

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -68,7 +68,7 @@ func collect(cfg prometheusConfig, cache *countCache) <-chan []statsdStat {
 	}).Debug("beginning collection")
 
 	prometheus := queryPrometheus(cfg.httpClient, cfg.metricsHost, cfg.ignoredMetrics)
-	return translatePrometheus(cfg.ignoredLabels, cache, prometheus)
+	return translatePrometheus(cfg, cache, prometheus)
 }
 
 func sendToStatsd(client *statsd.Client, host string, stats <-chan []statsdStat) {

--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -16,6 +16,8 @@ var (
 	ignoredMetricsStr = flag.String("ignored-metrics", "", "A comma-seperated list of metric name regexes to not export")
 	prefix            = flag.String("p", "", "A prefix to append to any metrics emitted. Include a trailing period. (e.g. \"myservice.\")")
 	statsHost         = flag.String("s", "127.0.0.1:8126", "The host and port — like '127.0.0.1:8126' — to send our metrics to.")
+	renameTags        = flag.String("r", "", "A comma-seperated list of rename rules for tags. (e.g. \"oldtag=newtag,otheroldtag=othernewtag\"")
+	addTags           = flag.String("a", "", "A comma-seperated list of tags to add. (e.g. \"newtag=newtagvalue,othernewtag=othernewtagvalue\"")
 
 	// mTLS params for collecting metrics
 	cert   = flag.String("cert", "", "The path to a client cert to present to the server. Only used if using mTLS.")

--- a/cmd/veneur-prometheus/translate_test.go
+++ b/cmd/veneur-prometheus/translate_test.go
@@ -51,3 +51,52 @@ func TestTranslateTags(t *testing.T) {
 
 	assert.Equal(t, expectedTags, tags)
 }
+
+func TestAddTags(t *testing.T) {
+	name := "originalName"
+	value := "originalValue"
+	pair := &dto.LabelPair{
+		Name:  &name,
+		Value: &value,
+	}
+	labels := []*dto.LabelPair{pair}
+
+	tr := translator{
+		added: map[string]string{
+			"new": "tags",
+			"so":  "good",
+		},
+	}
+
+	tags := tr.Tags(labels)
+	expectedTags := []string{
+		"originalName:originalValue",
+		"new:tags",
+		"so:good",
+	}
+
+	assert.ElementsMatch(t, expectedTags, tags)
+}
+
+func TestReplaceTags(t *testing.T) {
+	name := "originalName"
+	value := "originalValue"
+	pair := &dto.LabelPair{
+		Name:  &name,
+		Value: &value,
+	}
+	labels := []*dto.LabelPair{pair}
+
+	tr := translator{
+		renamed: map[string]string{
+			"originalName": "newName",
+		},
+	}
+
+	tags := tr.Tags(labels)
+	expectedTags := []string{
+		"newName:originalValue",
+	}
+
+	assert.ElementsMatch(t, expectedTags, tags)
+}

--- a/cmd/veneur-prometheus/translate_test.go
+++ b/cmd/veneur-prometheus/translate_test.go
@@ -39,7 +39,11 @@ func TestTranslateTags(t *testing.T) {
 		regexp.MustCompile(".*abel1.*"),
 	}
 
-	tags := translator(ignoredLabels).Tags(labels)
+	tr := translator{
+		ignored: ignoredLabels,
+	}
+
+	tags := tr.Tags(labels)
 	expectedTags := []string{
 		"label2Name:label2Value",
 		"label3Name:label3Value",


### PR DESCRIPTION
#### Summary

Add new arguments for adding and renaming labels from Prometheus endpoints before sending them on through the pipeline as tags.

#### Motivation

We have a tag name conflict between a standard internal tag name and one being emitted from a third party piece of software that's difficult to change. We'd like to rename that tag and add another one for identifying canary instances.

https://jira.corp.stripe.com/browse/RUN_OBS-22018
https://jira.corp.stripe.com/browse/WOFLO-340

#### Test plan

I've added automated tests for the argument parsing and tag mutations.

#### Rollout/monitoring/revert plan

No changes will be made without adding additional arguments so this should be safe to add for all consumers.