### PR TITLE
Fixes for cortex sink

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -43,6 +43,9 @@ type CortexMetricSink struct {
 	traceClient   *trace.Client
 }
 
+// TODO: implement queue config options, at least
+// max_samples_per_send, max_shards, and capacity
+// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 type CortexMetricSinkConfig struct {
 	URL           string        `yaml:"url"`
 	RemoteTimeout time.Duration `yaml:"remote_timeout"`
@@ -162,6 +165,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 	// Resource leak can occur if body isn't closed explicitly
 	defer r.Body.Close()
 
+	// TODO: retry on 400/500 (per remote-write spec)
 	if r.StatusCode >= 300 {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -187,6 +191,8 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 // FlushOtherSamples would forward non-metric sanples like spans. Prometheus
 // cannot receive them, so this is a no-op.
 func (s *CortexMetricSink) FlushOtherSamples(context.Context, []ssf.SSFSample) {
+	// TODO convert samples to metrics and send them
+	// as in FlushOtherSamples in the signalfx sink
 	return
 }
 

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -186,7 +186,7 @@ func metricToTimeSeries(metric samplers.InterMetric) *prompb.TimeSeries {
 	// send a single sample per write. Probably worth exploring this as an area
 	// for optimisation if we find the write path becomes contended
 	ts.Samples = []prompb.Sample{
-		prompb.Sample{Value: metric.Value, Timestamp: metric.Timestamp},
+		prompb.Sample{Value: metric.Value, Timestamp: metric.Timestamp * 1000},
 	}
 
 	return &ts

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -176,7 +176,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 	}
 
 	// Emit standard sink metrics
-	tags := map[string]string{"sink": s.name, "sink_type": "cortex"}
+	tags := map[string]string{"sink_type": "cortex"}
 	metricsCount := len(metrics)
 	flushCount := len(wr.Timeseries)
 	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsSkipped, float32(metricsCount-flushCount), tags))

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -91,7 +91,7 @@ func NewCortexMetricSink(URL string, timeout time.Duration, proxyURL string, log
 		RemoteTimeout: timeout,
 		ProxyURL:      proxyURL,
 		tags:          tags,
-		logger:        logger.WithFields(logrus.Fields{"sink": name, "sink_type": "cortex"}),
+		logger:        logger.WithFields(logrus.Fields{"sink_type": "cortex"}),
 		name:          name,
 	}, nil
 }
@@ -176,7 +176,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 	}
 
 	// Emit standard sink metrics
-	tags := map[string]string{"sink_type": "cortex"}
+	tags := map[string]string{"sink": s.name, "sink_type": "cortex"}
 	metricsCount := len(metrics)
 	flushCount := len(wr.Timeseries)
 	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsSkipped, float32(metricsCount-flushCount), tags))

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -177,11 +177,9 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 
 	// Emit standard sink metrics
 	tags := map[string]string{"sink": s.name, "sink_type": "cortex"}
-	metricsCount := len(metrics)
-	flushCount := len(wr.Timeseries)
-	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsSkipped, float32(metricsCount-flushCount), tags))
+	// We don't send sinks.MetricKeyTotalMetricsSkipped at present, as it would always be 0
 	span.Add(ssf.Timing(sinks.MetricKeyMetricFlushDuration, time.Since(flushStart), time.Nanosecond, tags))
-	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(flushCount), tags))
+	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(len(metrics)), tags))
 
 	s.logger.Info("Flush complete")
 

--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -23,7 +23,7 @@ import (
 func TestName(t *testing.T) {
 	// Implicitly test that CortexMetricsSink implements MetricSink
 	var sink sinks.MetricSink
-	sink, err := NewCortexMetricSink("https://localhost/", 30, "", logrus.NewEntry(logrus.New()), "cortex")
+	sink, err := NewCortexMetricSink("https://localhost/", 30, "", logrus.NewEntry(logrus.New()), "cortex", map[string]string{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, "cortex", sink.Name())
@@ -35,7 +35,7 @@ func TestFlush(t *testing.T) {
 	defer server.Close()
 
 	// Set up a sink
-	sink, err := NewCortexMetricSink(server.URL, 30, "", logrus.NewEntry(logrus.New()), "test")
+	sink, err := NewCortexMetricSink(server.URL, 30, "", logrus.NewEntry(logrus.New()), "test", map[string]string{"corge": "grault"})
 	assert.NoError(t, err)
 	assert.NoError(t, sink.Start(trace.DefaultClient))
 

--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/sinks"
@@ -22,7 +23,7 @@ import (
 func TestName(t *testing.T) {
 	// Implicitly test that CortexMetricsSink implements MetricSink
 	var sink sinks.MetricSink
-	sink, err := NewCortexMetricSink("https://localhost/", 30, "", "cortex")
+	sink, err := NewCortexMetricSink("https://localhost/", 30, "", logrus.NewEntry(logrus.New()), "cortex")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "cortex", sink.Name())
@@ -34,7 +35,7 @@ func TestFlush(t *testing.T) {
 	defer server.Close()
 
 	// Set up a sink
-	sink, err := NewCortexMetricSink(server.URL, 30, "", "")
+	sink, err := NewCortexMetricSink(server.URL, 30, "", logrus.NewEntry(logrus.New()), "test")
 	assert.NoError(t, err)
 	assert.NoError(t, sink.Start(trace.DefaultClient))
 

--- a/sinks/cortex/testdata/expected.json
+++ b/sinks/cortex/testdata/expected.json
@@ -18,7 +18,7 @@
       "samples": [
         {
           "value": 100,
-          "timestamp": 1
+          "timestamp": 1000
         }
       ]
     },
@@ -36,7 +36,7 @@
       "samples": [
         {
           "value": 2,
-          "timestamp": 1
+          "timestamp": 1000
         }
       ]
     },
@@ -50,7 +50,7 @@
       "samples": [
         {
           "value": 5,
-          "timestamp": 1
+          "timestamp": 1000
         }
       ]
     }

--- a/sinks/cortex/testdata/expected.json
+++ b/sinks/cortex/testdata/expected.json
@@ -13,6 +13,10 @@
         {
           "name": "baz",
           "value": "qux"
+        },
+        {
+          "name": "corge",
+          "value": "grault"
         }
       ],
       "samples": [
@@ -31,6 +35,10 @@
         {
           "name": "foo",
           "value": "bar"
+        },
+        {
+          "name": "corge",
+          "value": "grault"
         }
       ],
       "samples": [
@@ -45,6 +53,10 @@
         {
           "name": "__name__",
           "value": "a_b_status"
+        },
+        {
+          "name": "corge",
+          "value": "grault"
         }
       ],
       "samples": [


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Having had a chance to test the cortex sink in anger, I've discovered a couple of issues I'd like to remedy here. 

#### Motivation
<!-- Why are you making this change? -->
- fix bug where timestamps were sent in milliseconds, not seconds
- append common tags and hostname tag to metrics, as in the signalfx sink
- add logs (including logs indicating when the remote-write endpoint has returned an error, which would have helped debug the milliseconds issue!)
- add traces inline with other sinks

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
I wrote automated tests, additionally I tested the build end-to-end to ensure that it was working as I expected. 

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
