### PR TITLE
Disable datadog-go telemetry metrics in veneur-emit

### DIFF
--- a/cmd/veneur-emit/main.go
+++ b/cmd/veneur-emit/main.go
@@ -754,17 +754,17 @@ func sendStatsd(netAddr net.Addr, addr string, span *ssf.SSFSpan, useGrpc bool, 
 	if useGrpc {
 		writer, err := newDatadogGrpcWriter(netAddr, addr, proxyAddr)
 		if err == nil {
-			client, err = statsd.NewWithWriter(writer)
+			client, err = statsd.NewWithWriter(writer, statsd.WithoutTelemetry())
 		}
 	} else {
 		network := netAddr.Network()
 		switch network {
 		case "udp":
-			client, err = statsd.New(netAddr.String())
+			client, err = statsd.New(netAddr.String(), statsd.WithoutTelemetry())
 		case "tcp":
 			writer, err := newDatadogTCPWriter(netAddr.String())
 			if err == nil {
-				client, err = statsd.NewWithWriter(writer)
+				client, err = statsd.NewWithWriter(writer, statsd.WithoutTelemetry())
 			}
 		default:
 			err = fmt.Errorf("%s is not supported for sending statsd metrics", network)


### PR DESCRIPTION
r? @arnavdugar-stripe @rma-stripe 
cc @stripe/observability 

#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Disable the datadog-go client's automatic telemetry metrics in veneur-emit. Without this, the client automatically adds extra telemetry metrics to the outgoing metrics stream. Datadog enables this telemetry automatically because when you use datadog as your provider, they don't bill you for these metrics. However, using any other provider will mean you are being billed for telemetry metrics that you probably won't use (or want).

#### Motivation
<!-- Why are you making this change? -->

We recently noticed that these metrics exist but are not being used.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

The `WithoutTelemetry()` option is documented in the datadog-go readme: https://github.com/DataDog/datadog-go

- [ ] Deploy to Stripe's QA environment and verify that these telemetry metrics are no longer being emitted.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

This is safe to revert. A normal merge and deploy of veneur-emit should roll this change out.
