### PR TITLE
implement Decode for StringSecret

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -174,3 +174,16 @@ trace_lightstep_num_clients: 2
 	assert.Equal(t, 1, c.LightstepMaximumSpans)
 	assert.Equal(t, 2, c.LightstepNumClients)
 }
+
+func TestReadConfigEnvironmentVariables(t *testing.T) {
+	const fakeApiKey = "fake_api_key"
+	defer os.Unsetenv("VENEUR_DATADOGAPIKEY")
+	os.Setenv("VENEUR_DATADOGAPIKEY", fakeApiKey)
+	// read in empty config
+	c, err := readConfig(strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure value was pulled from environment variable
+	assert.Equal(t, fakeApiKey, c.DatadogAPIKey.Value)
+}

--- a/util/string_secret.go
+++ b/util/string_secret.go
@@ -24,3 +24,9 @@ func (s StringSecret) String() string {
 func (s *StringSecret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal(&s.Value)
 }
+
+// implement Decode so that envconfig can read in StringSecrets
+func (s *StringSecret) Decode(value string) error {
+	s.Value = value
+	return nil
+}


### PR DESCRIPTION
#### Summary
This allows `StringSecret`s to be read in from environment variables via `envconfig`. 


#### Motivation (bug fix)
It seems this behavior has not worked as [documented](https://github.com/stripe/veneur#configuration-via-environment-variables) since `StringSecret`s were introduced in #837.

#### Tests
Wrote a test in `config_test.go`. confirmed working by commenting out `os.Setenv()` call and observing `go test` failure. When uncommented `go test` passes. This test should probably also cover non-`StringSecret` config values but that is probably outside the scope of this PR.

Also tested by logging `conf.DatadogAPIKey.Value` @ `cmd/veneur/main.go:38`.

before change:
```
$ go build -o veneur ./cmd/veneur
$ VENEUR_DATADOGAPIKEY=asdf ./veneur -f example.yaml
...
2021/09/27 11:11:08  # empty string
...
```

after change:

```
$ go build -o veneur ./cmd/veneur
$ VENEUR_DATADOGAPIKEY=asdf ./veneur -f example.yaml
...
2021/09/27 11:11:24 asdf
...
```