### PR TITLE
Implement UnmarshalText for util.Rune.

### DIFF
--- a/util/rune.go
+++ b/util/rune.go
@@ -11,7 +11,11 @@ func (r *Rune) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	nativeRune, _ := utf8.DecodeRune([]byte(runeString))
+	return r.UnmarshalText([]byte(runeString))
+}
+
+func (r *Rune) UnmarshalText(text []byte) error {
+	nativeRune, _ := utf8.DecodeRune(text)
 	*r = Rune(nativeRune)
 	return nil
 }

--- a/util/rune_test.go
+++ b/util/rune_test.go
@@ -1,8 +1,10 @@
 package util_test
 
 import (
+	"os"
 	"testing"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/v14/util"
 	"gopkg.in/yaml.v3"
@@ -12,7 +14,7 @@ type runeYamlStruct struct {
 	Rune util.Rune `yaml:"rune"`
 }
 
-func TestRuneUnmarshalComma(t *testing.T) {
+func TestRuneUnmarshalYAMLComma(t *testing.T) {
 	yamlFile := []byte(`rune: ","`)
 	data := runeYamlStruct{}
 	err := yaml.Unmarshal(yamlFile, &data)
@@ -20,10 +22,30 @@ func TestRuneUnmarshalComma(t *testing.T) {
 	assert.Equal(t, ',', rune(data.Rune))
 }
 
-func TestRuneUnmarshalTab(t *testing.T) {
+func TestRuneUnmarshalYAMLTab(t *testing.T) {
 	yamlFile := []byte(`rune: "\t"`)
 	data := runeYamlStruct{}
 	err := yaml.Unmarshal(yamlFile, &data)
+	assert.Nil(t, err)
+	assert.Equal(t, '\t', rune(data.Rune))
+}
+
+func TestRuneUnmarshalTextComma(t *testing.T) {
+	defer os.Unsetenv("ENVCONFIG_TEST_RUNE")
+	os.Setenv("ENVCONFIG_TEST_RUNE", ",")
+
+	data := runeYamlStruct{}
+	err := envconfig.Process("ENVCONFIG_TEST", &data)
+	assert.Nil(t, err)
+	assert.Equal(t, ',', rune(data.Rune))
+}
+
+func TestRuneUnmarshalTextTab(t *testing.T) {
+	defer os.Unsetenv("ENVCONFIG_TEST_RUNE")
+	os.Setenv("ENVCONFIG_TEST_RUNE", "\t")
+
+	data := runeYamlStruct{}
+	err := envconfig.Process("ENVCONFIG_TEST", &data)
 	assert.Nil(t, err)
 	assert.Equal(t, '\t', rune(data.Rune))
 }


### PR DESCRIPTION
#### Summary
This change adds support for reading `util.Rune` config values from environment variables. The [`envconfig`](https://github.com/kelseyhightower/envconfig) package supports unmarshaling into values that implement [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler), so we implement that interface.

#### Motivation
Veneur should support reading config values from environment variables.


#### Test plan
```
go test github.com/stripe/veneur/v14/util
```
