### PR TITLE
Update golang and alpine versions in public docker images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For running Veneur under Docker, you probably want either the pre-built images
 # published at https://hub.docker.com/r/stripe/veneur/
 # or the Dockerfiles in https://github.com/stripe/veneur/tree/master/public-docker-images
-FROM golang:1.15
+FROM golang:1.17
 LABEL maintainer="The Stripe Observability Team <support@stripe.com>"
 
 ENV GOPATH=/go

--- a/public-docker-images/Dockerfile-alpine
+++ b/public-docker-images/Dockerfile-alpine
@@ -1,5 +1,5 @@
-FROM golang:1.13.5-alpine3.10 AS base
-MAINTAINER The Stripe Observability Team <support@stripe.com>
+FROM golang:1.17-alpine3.14 AS base
+LABEL maintainer="The Stripe Observability Team <support@stripe.com>"
 
 
 FROM base AS deps
@@ -45,7 +45,7 @@ RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse
 RUN go build -a -v -ldflags "-X github.com/stripe/veneur.VERSION=$(git rev-parse HEAD)" -o /build/veneur-proxy ./cmd/veneur-proxy
 
 
-FROM alpine:3.6 AS release
+FROM alpine:3.14 AS release
 RUN apk add --no-cache ca-certificates
 WORKDIR /veneur/
 EXPOSE 8126/UDP 8126/TCP 8127/TCP 8128/UDP

--- a/public-docker-images/Dockerfile-debian-sid
+++ b/public-docker-images/Dockerfile-debian-sid
@@ -1,5 +1,5 @@
-FROM golang:1.13.5 AS base
-MAINTAINER The Stripe Observability Team <support@stripe.com>
+FROM golang:1.17 AS base
+LABEL maintainer="The Stripe Observability Team <support@stripe.com>"
 
 
 FROM base AS deps


### PR DESCRIPTION
#### Summary
This change updates golang to 1.17 and alpine to 3.10 in the public docker images.

#### Motivation
fixes #868 
