### PR TITLE
Forward metrics from local Veneur via GRPC streaming.

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,9 +31,10 @@ type Config struct {
 	ExtendTags                   []string `yaml:"extend_tags"`
 	FalconerAddress              string   `yaml:"falconer_address"`
 	Features                     struct {
-		EnableMetricSinkRouting bool `yaml:"enable_metric_sink_routing"`
-		MigrateMetricSinks      bool `yaml:"migrate_metric_sinks"`
-		MigrateSpanSinks        bool `yaml:"migrate_span_sinks"`
+		EnableMetricSinkRouting bool   `yaml:"enable_metric_sink_routing"`
+		MigrateMetricSinks      bool   `yaml:"migrate_metric_sinks"`
+		MigrateSpanSinks        bool   `yaml:"migrate_span_sinks"`
+		ProxyProtocol           string `yaml:"proxy_protocol"`
 	} `yaml:"features"`
 	FlushFile                                 string              `yaml:"flush_file"`
 	FlushMaxPerBody                           int                 `yaml:"flush_max_per_body"`

--- a/flusher.go
+++ b/flusher.go
@@ -78,15 +78,17 @@ func (s *Server) Flush(ctx context.Context) {
 	s.reportMetricsFlushCounts(ms)
 
 	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
 	if s.IsLocal() {
 		wg.Add(1)
-		// Forward over gRPC or HTTP depending on the configuration
-		if s.forwardUseGRPC {
+		switch s.proxyProtocol {
+		case ProxyProtocolGrpcStream, ProxyProtocolGrpcSingle:
 			go func() {
-				s.forwardGRPC(span.Attach(ctx), tempMetrics)
+				s.forwardGRPC(span.Attach(ctx), tempMetrics, s.proxyProtocol)
 				wg.Done()
 			}()
-		} else {
+		case ProxyProtocolRest:
 			go func() {
 				s.flushForward(span.Attach(ctx), tempMetrics)
 				wg.Done()
@@ -169,7 +171,6 @@ func (s *Server) Flush(ctx context.Context) {
 			wg.Done()
 		}(sink)
 	}
-	wg.Wait()
 }
 
 func (s *Server) tallyTimeseries() int64 {
@@ -538,7 +539,9 @@ func (s *Server) flushTraces(ctx context.Context) {
 }
 
 // forwardGRPC forwards all input metrics to a downstream Veneur, over gRPC.
-func (s *Server) forwardGRPC(ctx context.Context, wms []WorkerMetrics) {
+func (s *Server) forwardGRPC(
+	ctx context.Context, wms []WorkerMetrics, protocol ProxyProtocol,
+) {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	span.SetTag("protocol", "grpc")
 	defer span.ClientFinish(s.TraceClient)
@@ -574,7 +577,12 @@ func (s *Server) forwardGRPC(ctx context.Context, wms []WorkerMetrics) {
 	c := forwardrpc.NewForwardClient(s.grpcForwardConn)
 
 	grpcStart := time.Now()
-	_, err := c.SendMetrics(ctx, &forwardrpc.MetricList{Metrics: metrics})
+	var err error
+	if protocol == ProxyProtocolGrpcSingle {
+		err = ForwardGrpcSingle(ctx, c, metrics)
+	} else {
+		err = ForwardGrpcStream(ctx, c, metrics)
+	}
 	if err != nil {
 		if ctx.Err() != nil {
 			// We exceeded the deadline of the flush context.
@@ -598,4 +606,27 @@ func (s *Server) forwardGRPC(ctx context.Context, wms []WorkerMetrics) {
 			map[string]string{"part": "grpc"}),
 		ssf.Count("forward.error_total", 0, nil),
 	)
+}
+
+func ForwardGrpcSingle(
+	ctx context.Context, client forwardrpc.ForwardClient,
+	metrics []*metricpb.Metric,
+) error {
+	_, err := client.SendMetrics(ctx, &forwardrpc.MetricList{Metrics: metrics})
+	return err
+}
+
+func ForwardGrpcStream(
+	ctx context.Context, client forwardrpc.ForwardClient,
+	metrics []*metricpb.Metric,
+) error {
+	sendMetricsClient, err := client.SendMetricsV2(ctx)
+	if err != nil {
+		return err
+	}
+	for _, metric := range metrics {
+		sendMetricsClient.Send(metric)
+	}
+	_, err = sendMetricsClient.CloseAndRecv()
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	golang.org/x/net v0.0.0-20211008194852-3b03d305991f
 	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.18.6

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"stathat.com/c/consistent"
 
 	"github.com/stripe/veneur/v14/forwardrpc"
@@ -204,7 +205,10 @@ func (s *Server) SendMetricsV2(
 	_, err := s.SendMetrics(context.Background(), &forwardrpc.MetricList{
 		Metrics: metrics,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return server.SendAndClose(&emptypb.Empty{})
 }
 
 func (s *Server) sendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) error {

--- a/server.go
+++ b/server.go
@@ -103,6 +103,15 @@ type ServerConfig struct {
 	SpanSinkTypes   SpanSinkTypes
 }
 
+type ProxyProtocol int64
+
+const (
+	ProxyProtocolUnknown ProxyProtocol = iota
+	ProxyProtocolRest
+	ProxyProtocolGrpcSingle
+	ProxyProtocolGrpcStream
+)
+
 // A Server is the actual veneur instance that will be run.
 type Server struct {
 	Config                Config
@@ -125,8 +134,8 @@ type Server struct {
 	HTTPAddr         string
 	numListeningHTTP *int32 // An atomic boolean for whether or not the HTTP server is running
 
-	ForwardAddr    string
-	forwardUseGRPC bool
+	ForwardAddr   string
+	proxyProtocol ProxyProtocol
 
 	StatsdListenAddrs []net.Addr
 	SSFListenAddrs    []net.Addr
@@ -450,7 +459,6 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		// workers with state from *Server.IsWorker.
 		enableProfiling:      conf.EnableProfiling,
 		ForwardAddr:          conf.ForwardAddress,
-		forwardUseGRPC:       conf.ForwardUseGrpc,
 		grpcListenAddress:    conf.GrpcAddress,
 		Hostname:             conf.Hostname,
 		HistogramPercentiles: conf.Percentiles,
@@ -657,6 +665,22 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		ret.httpQuit = true
 	}
 
+	switch conf.Features.ProxyProtocol {
+	case "grpc-stream":
+		ret.proxyProtocol = ProxyProtocolGrpcStream
+	case "grpc-single":
+		ret.proxyProtocol = ProxyProtocolGrpcSingle
+	case "json":
+		ret.proxyProtocol = ProxyProtocolRest
+	default:
+		// TODO(arnavdugar): Remove conf.ForwardUseGrpc.
+		if conf.ForwardUseGrpc {
+			ret.proxyProtocol = ProxyProtocolGrpcSingle
+		} else {
+			ret.proxyProtocol = ProxyProtocolRest
+		}
+	}
+
 	ret.sources, err = ret.createSources(logger, &conf, config.SourceTypes)
 	if err != nil {
 		return nil, err
@@ -807,7 +831,8 @@ func (s *Server) Start() {
 	}
 
 	// Initialize a gRPC connection for forwarding
-	if s.forwardUseGRPC {
+	if s.proxyProtocol == ProxyProtocolGrpcSingle ||
+		s.proxyProtocol == ProxyProtocolGrpcStream {
 		var err error
 		s.grpcForwardConn, err = grpc.Dial(s.ForwardAddr, grpc.WithInsecure())
 		if err != nil {

--- a/testdata/http_test_config.json
+++ b/testdata/http_test_config.json
@@ -26,7 +26,8 @@
   "Features": {
     "EnableMetricSinkRouting": false,
     "MigrateMetricSinks": false,
-    "MigrateSpanSinks": false
+    "MigrateSpanSinks": false,
+    "ProxyProtocol": ""
   },
   "FlushFile": "",
   "FlushMaxPerBody": 0,

--- a/testdata/http_test_config.yaml
+++ b/testdata/http_test_config.yaml
@@ -25,6 +25,7 @@ features:
   enable_metric_sink_routing: false
   migrate_metric_sinks: false
   migrate_span_sinks: false
+  proxy_protocol: ""
 flush_file: ""
 flush_max_per_body: 0
 flush_on_shutdown: false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -459,6 +459,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # google.golang.org/protobuf v1.24.0
+## explicit
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire


### PR DESCRIPTION
#### Summary
This change adds and implements a feature flag to forward metrics from local Veneur instances to Veneur proxy via GRPC streaming instead of individual GRPC messages.

#### Motivation
This is a followup to #873.
