### PR TITLE
Add support for decoding URLs from configs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV GOPATH=/go
 ENV GO111MODULE=on
 RUN apt-get update
 RUN apt-get install -y zip
-RUN go get -u -v github.com/ChimeraCoder/gojson/gojson
 RUN go get -u -v github.com/gogo/protobuf/protoc-gen-gogofaster@v1.2.1
 RUN go get -u -v golang.org/x/tools/cmd/stringer
 WORKDIR /protoc

--- a/config.go
+++ b/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	ForwardAddress                            string              `yaml:"forward_address"`
 	ForwardUseGrpc                            bool                `yaml:"forward_use_grpc"`
 	GrpcAddress                               string              `yaml:"grpc_address"`
-	GrpcListenAddresses                       []string            `yaml:"grpc_listen_addresses"`
+	GrpcListenAddresses                       []util.Url          `yaml:"grpc_listen_addresses"`
 	Hostname                                  string              `yaml:"hostname"`
 	HTTPAddress                               string              `yaml:"http_address"`
 	HTTPQuit                                  bool                `yaml:"http_quit"`
@@ -118,9 +118,9 @@ type Config struct {
 	SplunkHecToken                    string            `yaml:"splunk_hec_token"`
 	SplunkSpanSampleRate              int               `yaml:"splunk_span_sample_rate"`
 	SsfBufferSize                     int               `yaml:"ssf_buffer_size"`
-	SsfListenAddresses                []string          `yaml:"ssf_listen_addresses"`
+	SsfListenAddresses                []util.Url        `yaml:"ssf_listen_addresses"`
 	StatsAddress                      string            `yaml:"stats_address"`
-	StatsdListenAddresses             []string          `yaml:"statsd_listen_addresses"`
+	StatsdListenAddresses             []util.Url        `yaml:"statsd_listen_addresses"`
 	SynchronizeWithInterval           bool              `yaml:"synchronize_with_interval"`
 	Tags                              []string          `yaml:"tags"`
 	TagsExclude                       []string          `yaml:"tags_exclude"`

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -1,27 +1,29 @@
 package veneur
 
+import "github.com/stripe/veneur/v14/util"
+
 type ProxyConfig struct {
-	ConsulForwardGrpcServiceName string `yaml:"consul_forward_grpc_service_name"`
-	ConsulForwardServiceName     string `yaml:"consul_forward_service_name"`
-	ConsulRefreshInterval        string `yaml:"consul_refresh_interval"`
-	ConsulTraceServiceName       string `yaml:"consul_trace_service_name"`
-	Debug                        bool   `yaml:"debug"`
-	EnableProfiling              bool   `yaml:"enable_profiling"`
-	ForwardAddress               string `yaml:"forward_address"`
-	ForwardTimeout               string `yaml:"forward_timeout"`
-	GrpcAddress                  string `yaml:"grpc_address"`
-	GrpcForwardAddress           string `yaml:"grpc_forward_address"`
-	HTTPAddress                  string `yaml:"http_address"`
-	IdleConnectionTimeout        string `yaml:"idle_connection_timeout"`
-	MaxIdleConns                 int    `yaml:"max_idle_conns"`
-	MaxIdleConnsPerHost          int    `yaml:"max_idle_conns_per_host"`
-	RuntimeMetricsInterval       string `yaml:"runtime_metrics_interval"`
-	SentryDsn                    string `yaml:"sentry_dsn"`
-	SsfDestinationAddress        string `yaml:"ssf_destination_address"`
-	StatsAddress                 string `yaml:"stats_address"`
-	TraceAddress                 string `yaml:"trace_address"`
-	TraceAPIAddress              string `yaml:"trace_api_address"`
-	TracingClientCapacity        int    `yaml:"tracing_client_capacity"`
-	TracingClientFlushInterval   string `yaml:"tracing_client_flush_interval"`
-	TracingClientMetricsInterval string `yaml:"tracing_client_metrics_interval"`
+	ConsulForwardGrpcServiceName string   `yaml:"consul_forward_grpc_service_name"`
+	ConsulForwardServiceName     string   `yaml:"consul_forward_service_name"`
+	ConsulRefreshInterval        string   `yaml:"consul_refresh_interval"`
+	ConsulTraceServiceName       string   `yaml:"consul_trace_service_name"`
+	Debug                        bool     `yaml:"debug"`
+	EnableProfiling              bool     `yaml:"enable_profiling"`
+	ForwardAddress               string   `yaml:"forward_address"`
+	ForwardTimeout               string   `yaml:"forward_timeout"`
+	GrpcAddress                  string   `yaml:"grpc_address"`
+	GrpcForwardAddress           string   `yaml:"grpc_forward_address"`
+	HTTPAddress                  string   `yaml:"http_address"`
+	IdleConnectionTimeout        string   `yaml:"idle_connection_timeout"`
+	MaxIdleConns                 int      `yaml:"max_idle_conns"`
+	MaxIdleConnsPerHost          int      `yaml:"max_idle_conns_per_host"`
+	RuntimeMetricsInterval       string   `yaml:"runtime_metrics_interval"`
+	SentryDsn                    string   `yaml:"sentry_dsn"`
+	SsfDestinationAddress        util.Url `yaml:"ssf_destination_address"`
+	StatsAddress                 string   `yaml:"stats_address"`
+	TraceAddress                 string   `yaml:"trace_address"`
+	TraceAPIAddress              string   `yaml:"trace_api_address"`
+	TracingClientCapacity        int      `yaml:"tracing_client_capacity"`
+	TracingClientFlushInterval   string   `yaml:"tracing_client_flush_interval"`
+	TracingClientMetricsInterval string   `yaml:"tracing_client_metrics_interval"`
 }

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -2,12 +2,14 @@ package veneur
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
+	"github.com/stripe/veneur/v14/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,7 +186,15 @@ func TestFlushResetsWorkerUniqueMTS(t *testing.T) {
 	config.CountUniqueTimeseries = true
 	config.NumWorkers = 2
 	config.Interval = time.Duration(time.Minute)
-	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}
+	config.StatsdListenAddresses = []util.Url{{
+		Value: &url.URL{
+			Scheme: "udp",
+			Host:   "127.0.0.1:0",
+		}}, {
+		Value: &url.URL{
+			Scheme: "udp",
+			Host:   "127.0.0.1:0",
+		}}}
 	ch := make(chan []samplers.InterMetric, 20)
 	sink, _ := NewChannelMetricSink(ch)
 	f := newFixture(t, config, sink, nil)
@@ -215,7 +225,15 @@ func TestTallyTimeseries(t *testing.T) {
 	config.CountUniqueTimeseries = true
 	config.NumWorkers = 10
 	config.Interval = time.Duration(time.Minute)
-	config.StatsdListenAddresses = []string{"udp://127.0.0.1:0", "udp://127.0.0.1:0"}
+	config.StatsdListenAddresses = []util.Url{{
+		Value: &url.URL{
+			Scheme: "udp",
+			Host:   "127.0.0.1:0",
+		}}, {
+		Value: &url.URL{
+			Scheme: "udp",
+			Host:   "127.0.0.1:0",
+		}}}
 	ch := make(chan []samplers.InterMetric, 20)
 	sink, _ := NewChannelMetricSink(ch)
 	f := newFixture(t, config, sink, nil)

--- a/generate.go
+++ b/generate.go
@@ -7,6 +7,5 @@ package veneur
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=. tdigest/tdigest.proto
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=Mtdigest/tdigest.proto=github.com/stripe/veneur/v14/tdigest:. samplers/metricpb/metric.proto
 //go:generate protoc -I=. -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.2.1/protobuf --gogofaster_out=Mtdigest/tdigest.proto=github.com/stripe/veneur/v14/tdigest,Msamplers/metricpb/metric.proto=github.com/stripe/veneur/v14/samplers/metricpb,Mgoogle/protobuf/empty.proto=github.com/golang/protobuf/ptypes/empty,plugins=grpc:. forwardrpc/forward.proto
-//go:generate gojson -input example_proxy.yaml -o config_proxy.go -fmt yaml -pkg veneur -name ProxyConfig
 //go:generate stringer -type MetricType ./samplers
 //TODO(aditya) reenable go:generate gojson -input fixtures/datadog_trace.json -o datadog_trace_span.go -fmt json -pkg veneur -name DatadogTraceSpan

--- a/http_test.go
+++ b/http_test.go
@@ -295,7 +295,7 @@ func TestNoTracingConfiguredTraceHealthCheck(t *testing.T) {
 
 	config := localConfig()
 
-	config.SsfListenAddresses = []string{}
+	config.SsfListenAddresses = []util.Url{}
 	server, _ := NewFromConfig(ServerConfig{
 		Logger: logrus.New(),
 		Config: config,
@@ -315,7 +315,7 @@ func TestBuildDate(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/builddate", nil)
 
 	config := localConfig()
-	config.SsfListenAddresses = []string{}
+	config.SsfListenAddresses = []util.Url{}
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
@@ -347,7 +347,7 @@ func TestVersion(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/version", nil)
 
 	config := localConfig()
-	config.SsfListenAddresses = []string{}
+	config.SsfListenAddresses = []util.Url{}
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 

--- a/networking_test.go
+++ b/networking_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,10 @@ func TestMultipleListeners(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	addrNet, err := protocol.ResolveAddr(fmt.Sprintf("unix://%s/socket", dir))
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "unix",
+		Path:   fmt.Sprintf("/%s/socket", dir),
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.UnixAddr)
 	require.True(t, ok)
@@ -57,7 +61,10 @@ func TestConnectUNIX(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	addrNet, err := protocol.ResolveAddr(fmt.Sprintf("unix://%s/socket", dir))
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "unix",
+		Path:   fmt.Sprintf("/%s/socket", dir),
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.UnixAddr)
 	require.True(t, ok)
@@ -108,7 +115,10 @@ func TestConnectUNIXStatsd(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	addrNet, err := protocol.ResolveAddr(fmt.Sprintf("unixgram://%s/datagramsocket", dir))
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "unixgram",
+		Path:   fmt.Sprintf("/%s/datagramsocket", dir),
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.UnixAddr)
 	require.True(t, ok)
@@ -158,7 +168,10 @@ func TestConnectUNIXStatsd(t *testing.T) {
 func TestHealthCheckGRPC(t *testing.T) {
 	srv := &Server{}
 
-	addrNet, err := protocol.ResolveAddr("tcp://127.0.0.1:8181")
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "tcp",
+		Host:   "127.0.0.1:8181",
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.TCPAddr)
 	require.True(t, ok)
@@ -193,7 +206,10 @@ func TestConnectSSFGRPC(t *testing.T) {
 	srv := &Server{}
 	srv.SpanChan = make(chan *ssf.SSFSpan, 100)
 
-	addrNet, err := protocol.ResolveAddr("tcp://127.0.0.1:8181")
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "tcp",
+		Host:   "127.0.0.1:8181",
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.TCPAddr)
 	require.True(t, ok)
@@ -228,7 +244,10 @@ func TestConnectDogstatsdGRPC(t *testing.T) {
 	srv := &Server{}
 	srv.SpanChan = make(chan *ssf.SSFSpan, 100)
 
-	addrNet, err := protocol.ResolveAddr("tcp://127.0.0.1:8181")
+	addrNet, err := protocol.ResolveAddr(&url.URL{
+		Scheme: "tcp",
+		Host:   "127.0.0.1:8181",
+	})
 	require.NoError(t, err)
 	addr, ok := addrNet.(*net.TCPAddr)
 	require.True(t, ok)

--- a/protocol/addr.go
+++ b/protocol/addr.go
@@ -15,11 +15,7 @@ import (
 //   udp6://127.0.0.1:8000
 //   unix:///tmp/foo.sock
 //   tcp://127.0.0.1:9002
-func ResolveAddr(str string) (net.Addr, error) {
-	u, err := url.Parse(str)
-	if err != nil {
-		return nil, err
-	}
+func ResolveAddr(u *url.URL) (net.Addr, error) {
 	switch u.Scheme {
 	case "unix", "unixgram", "unixpacket":
 		var path string

--- a/protocol/addr_test.go
+++ b/protocol/addr_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,11 @@ func TestListenAddr(t *testing.T) {
 		{"unixpacket:///tmp/foo.sock", "unixpacket", "/tmp/foo.sock"},
 	}
 	for _, test := range tests {
-		addr, err := ResolveAddr(test.input)
+		u, err := url.Parse(test.input)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		addr, err := ResolveAddr(u)
 		if !assert.NoError(t, err) {
 			continue
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -229,7 +229,7 @@ func NewProxyFromConfig(
 	}
 
 	proxy.TraceClient = trace.DefaultClient
-	if conf.SsfDestinationAddress != "" {
+	if conf.SsfDestinationAddress.Value != nil {
 		stats, err := statsd.New(
 			conf.StatsAddress, statsd.WithoutTelemetry(),
 			statsd.WithMaxMessagesPerPayload(4096))
@@ -238,7 +238,7 @@ func NewProxyFromConfig(
 		}
 		stats.Namespace = "veneur_proxy."
 		format := "ssf_format:packet"
-		if strings.HasPrefix(conf.SsfDestinationAddress, "unix://") {
+		if conf.SsfDestinationAddress.Value.Scheme == "unix" {
 			format = "ssf_format:framed"
 		}
 
@@ -255,7 +255,7 @@ func NewProxyFromConfig(
 			return nil, err
 		}
 
-		proxy.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress,
+		proxy.TraceClient, err = trace.NewClient(conf.SsfDestinationAddress.Value,
 			trace.Buffered,
 			trace.Capacity(uint(conf.TracingClientCapacity)),
 			trace.FlushInterval(traceFlushInterval),

--- a/server.go
+++ b/server.go
@@ -529,7 +529,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	ret.spanSinks = append(ret.spanSinks, metricSink)
 
 	for _, addrStr := range conf.StatsdListenAddresses {
-		addr, err := protocol.ResolveAddr(addrStr)
+		addr, err := protocol.ResolveAddr(addrStr.Value)
 		if err != nil {
 			return ret, err
 		}
@@ -537,7 +537,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	}
 
 	for _, addrStr := range conf.SsfListenAddresses {
-		addr, err := protocol.ResolveAddr(addrStr)
+		addr, err := protocol.ResolveAddr(addrStr.Value)
 		if err != nil {
 			return ret, err
 		}
@@ -545,7 +545,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	}
 
 	for _, addrStr := range conf.GrpcListenAddresses {
-		addr, err := protocol.ResolveAddr(addrStr)
+		addr, err := protocol.ResolveAddr(addrStr.Value)
 		if err != nil {
 			return ret, err
 		}

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,7 +149,12 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 		DatadogAPIHostname:     "http://api",
 		DatadogTraceAPIAddress: "http://trace",
 		DatadogSpanBufferSize:  32,
-		SsfListenAddresses:     []string{"udp://127.0.0.1:99"},
+		SsfListenAddresses: []util.Url{{
+			Value: &url.URL{
+				Scheme: "udp",
+				Host:   "127.0.0.1:99",
+			},
+		}},
 
 		// required or NewFromConfig fails
 		Interval:     time.Duration(10 * time.Second),

--- a/trace/client.go
+++ b/trace/client.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"net/url"
 	"time"
 
 	"sync/atomic"
@@ -311,14 +312,14 @@ func newFlushNofifier(backend ClientBackend) flushNotifier {
 // NewClient constructs a new client that will attempt to connect
 // to addrStr (an address in veneur URL format) using the parameters
 // in opts. It returns the constructed client or an error.
-func NewClient(addrStr string, opts ...ClientParam) (*Client, error) {
+func NewClient(url *url.URL, opts ...ClientParam) (*Client, error) {
 	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
 	if err != nil {
 		return nil, err
 	}
 	rand.Seed(n.Int64())
 
-	addr, err := protocol.ResolveAddr(addrStr)
+	addr, err := protocol.ResolveAddr(url)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +445,10 @@ const DefaultParallelism = 8
 
 // DefaultVeneurAddress is the address that a reasonable veneur should
 // listen on. Currently it defaults to UDP port 8128.
-const DefaultVeneurAddress string = "udp://127.0.0.1:8128"
+var DefaultVeneurAddress = &url.URL{
+	Scheme: "udp",
+	Host:   "127.0.0.1:8128",
+}
 
 // ErrNoClient indicates that no client is yet initialized.
 var ErrNoClient = errors.New("client is not initialized")

--- a/trace/client_test.go
+++ b/trace/client_test.go
@@ -68,7 +68,10 @@ func TestUDP(t *testing.T) {
 	err = serverConn.SetReadBuffer(BufferSize)
 	assert.NoError(t, err)
 
-	client, err := trace.NewClient(fmt.Sprintf("udp://%s", serverConn.LocalAddr().String()), trace.Capacity(4))
+	client, err := trace.NewClient(&url.URL{
+		Scheme: "udp",
+		Host:   serverConn.LocalAddr().String(),
+	}, trace.Capacity(4))
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -108,10 +111,14 @@ func TestUNIX(t *testing.T) {
 	})
 	defer cleanup()
 
-	client, err := trace.NewClient((&url.URL{Scheme: "unix", Path: sockName}).String(), trace.Capacity(4))
+	client, err := trace.NewClient(
+		&url.URL{
+			Scheme: "unix",
+			Path:   sockName,
+		},
+		trace.Capacity(4))
 	require.NoError(t, err)
 	defer client.Close()
-
 	sentCh := make(chan error)
 	for i := 0; i < 4; i++ {
 		name := fmt.Sprintf("Testing-%d", i)
@@ -147,7 +154,11 @@ func TestUNIXBuffered(t *testing.T) {
 	})
 	defer cleanup()
 
-	client, err := trace.NewClient((&url.URL{Scheme: "unix", Path: sockName}).String(),
+	client, err := trace.NewClient(
+		&url.URL{
+			Scheme: "unix",
+			Path:   sockName,
+		},
 		trace.Capacity(4),
 		trace.ParallelBackends(1),
 		trace.Buffered)
@@ -202,7 +213,10 @@ func TestUDPError(t *testing.T) {
 	err = serverConn.SetReadBuffer(BufferSize)
 	assert.NoError(t, err)
 
-	client, err := trace.NewClient(fmt.Sprintf("udp://%s", serverConn.LocalAddr().String()), trace.Capacity(4))
+	client, err := trace.NewClient(&url.URL{
+		Scheme: "udp",
+		Host:   serverConn.LocalAddr().String(),
+	}, trace.Capacity(4))
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -253,7 +267,11 @@ func TestReconnectUNIX(t *testing.T) {
 	})
 	defer cleanup()
 
-	client, err := trace.NewClient((&url.URL{Scheme: "unix", Path: sockName}).String(),
+	client, err := trace.NewClient(
+		&url.URL{
+			Scheme: "unix",
+			Path:   sockName,
+		},
 		trace.Capacity(4),
 		trace.ParallelBackends(1),
 	)
@@ -321,7 +339,11 @@ func TestReconnectBufferedUNIX(t *testing.T) {
 	})
 	defer cleanup()
 
-	client, err := trace.NewClient((&url.URL{Scheme: "unix", Path: sockName}).String(),
+	client, err := trace.NewClient(
+		&url.URL{
+			Scheme: "unix",
+			Path:   sockName,
+		},
 		trace.Capacity(4),
 		trace.ParallelBackends(1),
 		trace.Buffered)

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -2,8 +2,8 @@ package trace
 
 import (
 	"context"
-	"fmt"
 	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -60,7 +60,10 @@ func testRecord(t *testing.T, trace *Trace, name string, tags map[string]string)
 		close(kill)
 	}()
 
-	client, err := NewClient(fmt.Sprintf("udp://%s", serverConn.LocalAddr().String()))
+	client, err := NewClient(&url.URL{
+		Scheme: "udp",
+		Host:   serverConn.LocalAddr().String(),
+	})
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -72,7 +75,7 @@ func testRecord(t *testing.T, trace *Trace, name string, tags map[string]string)
 		end = time.Now()
 
 		select {
-		case _ = <-kill:
+		case <-kill:
 			assert.Fail(t, "timed out waiting for socket read")
 		case resp := <-respChan:
 			// Because this is marshalled using protobuf,

--- a/util/url.go
+++ b/util/url.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"net/url"
+)
+
+type Url struct {
+	Value *url.URL
+}
+
+func (u *Url) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	u.Value, err = url.Parse(s)
+	return err
+}
+
+func (u *Url) Decode(s string) error {
+	var err error
+	u.Value, err = url.Parse(s)
+	return err
+}

--- a/util/url_test.go
+++ b/util/url_test.go
@@ -1,0 +1,42 @@
+package util_test
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/v14/util"
+	"gopkg.in/yaml.v3"
+)
+
+type urlYamlStruct struct {
+	Url util.Url `yaml:"url"`
+}
+
+func TestUrlUnmarshalYAML(t *testing.T) {
+	yamlFile := []byte(`url: https://example.com/path`)
+	data := urlYamlStruct{}
+	err := yaml.Unmarshal(yamlFile, &data)
+	assert.Nil(t, err)
+	assert.Equal(t, url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/path",
+	}, *data.Url.Value)
+}
+
+func TestUrlDecode(t *testing.T) {
+	defer os.Unsetenv("ENVCONFIG_TEST_URL")
+	os.Setenv("ENVCONFIG_TEST_URL", "https://example.com/path")
+
+	data := urlYamlStruct{}
+	err := envconfig.Process("ENVCONFIG_TEST", &data)
+	assert.Nil(t, err)
+	assert.Equal(t, url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/path",
+	}, *data.Url.Value)
+}


### PR DESCRIPTION
#### Summary
This change adds support for decoding URLs directly when loading the configuration.

#### Motivation
Configuration fields that should be URLs are annotated as such, and are validated at the time the configuration file is parsed.
