### PR TITLE
Rename metric name constants.

### DIFF
--- a/flusher_test.go
+++ b/flusher_test.go
@@ -128,7 +128,7 @@ func TestServerFlushGRPCBadAddress(t *testing.T) {
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
 			Name: "counter",
-			Type: counterTypeName,
+			Type: CounterTypeName,
 		},
 		Value:      20.0,
 		Digest:     12345,
@@ -162,7 +162,7 @@ func TestGlobalAcceptsHistogramsOverUDP(t *testing.T) {
 	m := samplers.UDPMetric{
 		MetricKey: samplers.MetricKey{
 			Name: "histo",
-			Type: histogramTypeName,
+			Type: HistogramTypeName,
 		},
 		Value:      20.0,
 		Digest:     12345,

--- a/forward_grpc_test.go
+++ b/forward_grpc_test.go
@@ -98,7 +98,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("histogram"),
-				Type: histogramTypeName,
+				Type: HistogramTypeName,
 			},
 			Value:      20.0,
 			Digest:     12345,
@@ -108,7 +108,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("histogram_global"),
-				Type: histogramTypeName,
+				Type: HistogramTypeName,
 			},
 			Value:      20.0,
 			Digest:     12345,
@@ -118,7 +118,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("gauge"),
-				Type: gaugeTypeName,
+				Type: GaugeTypeName,
 			},
 			Value:      1.0,
 			SampleRate: 1.0,
@@ -127,7 +127,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("counter"),
-				Type: counterTypeName,
+				Type: CounterTypeName,
 			},
 			Value:      2.0,
 			SampleRate: 1.0,
@@ -136,7 +136,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("timer_mixed"),
-				Type: timerTypeName,
+				Type: TimerTypeName,
 			},
 			Value:      100.0,
 			Digest:     12345,
@@ -146,7 +146,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("timer"),
-				Type: timerTypeName,
+				Type: TimerTypeName,
 			},
 			Value:      100.0,
 			Digest:     12345,
@@ -156,7 +156,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("set"),
-				Type: setTypeName,
+				Type: SetTypeName,
 			},
 			Value:      "test",
 			SampleRate: 1.0,
@@ -166,7 +166,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 		&samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: testGRPCMetric("counter.local"),
-				Type: counterTypeName,
+				Type: CounterTypeName,
 			},
 			Value:      100.0,
 			Digest:     12345,

--- a/worker_test.go
+++ b/worker_test.go
@@ -360,12 +360,12 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 				testMetric{
 					name:  "test.gauge",
 					scope: samplers.MixedScope,
-					mType: gaugeTypeName,
+					mType: GaugeTypeName,
 				},
 				testMetric{
 					name:  "test.counter",
 					scope: samplers.LocalOnly,
-					mType: counterTypeName,
+					mType: CounterTypeName,
 				},
 			},
 			expected: []testMetric{},
@@ -376,19 +376,19 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 				testMetric{
 					name:  "test.gauge",
 					scope: samplers.MixedScope,
-					mType: gaugeTypeName,
+					mType: GaugeTypeName,
 				},
 				testMetric{
 					name:  "test.mixed.histo",
 					scope: samplers.MixedScope,
-					mType: histogramTypeName,
+					mType: HistogramTypeName,
 				},
 			},
 			expected: []testMetric{
 				testMetric{
 					name:  "test.mixed.histo",
 					scope: samplers.MixedScope,
-					mType: histogramTypeName,
+					mType: HistogramTypeName,
 				},
 			},
 		},
@@ -512,7 +512,7 @@ func BenchmarkWork(b *testing.B) {
 		m := samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: "counter",
-				Type: counterTypeName,
+				Type: CounterTypeName,
 			},
 			Value:      20.0,
 			Digest:     12345,
@@ -522,14 +522,14 @@ func BenchmarkWork(b *testing.B) {
 
 		switch r := i % 5; r {
 		case 1:
-			m.MetricKey.Type = gaugeTypeName
+			m.MetricKey.Type = GaugeTypeName
 		case 2:
-			m.MetricKey.Type = histogramTypeName
+			m.MetricKey.Type = HistogramTypeName
 		case 3:
-			m.MetricKey.Type = setTypeName
+			m.MetricKey.Type = SetTypeName
 			m.Value = "a value here!"
 		case 4:
-			m.MetricKey.Type = timerTypeName
+			m.MetricKey.Type = TimerTypeName
 		default:
 			// do nothing
 		}
@@ -554,7 +554,7 @@ func BenchmarkWorkWithCountUniqueTimeseries(b *testing.B) {
 		m := samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: "counter",
-				Type: counterTypeName,
+				Type: CounterTypeName,
 			},
 			Value:      20.0,
 			Digest:     12345,
@@ -564,14 +564,14 @@ func BenchmarkWorkWithCountUniqueTimeseries(b *testing.B) {
 
 		switch r := i % 5; r {
 		case 1:
-			m.MetricKey.Type = gaugeTypeName
+			m.MetricKey.Type = GaugeTypeName
 		case 2:
-			m.MetricKey.Type = histogramTypeName
+			m.MetricKey.Type = HistogramTypeName
 		case 3:
-			m.MetricKey.Type = setTypeName
+			m.MetricKey.Type = SetTypeName
 			m.Value = "a value here!"
 		case 4:
-			m.MetricKey.Type = timerTypeName
+			m.MetricKey.Type = TimerTypeName
 		default:
 			// do nothing
 		}
@@ -595,7 +595,7 @@ func BenchmarkSampleTimeseries(b *testing.B) {
 		m := samplers.UDPMetric{
 			MetricKey: samplers.MetricKey{
 				Name: "counter",
-				Type: counterTypeName,
+				Type: CounterTypeName,
 			},
 			Value:      20.0,
 			Digest:     12345,
@@ -605,14 +605,14 @@ func BenchmarkSampleTimeseries(b *testing.B) {
 
 		switch r := i % 5; r {
 		case 1:
-			m.MetricKey.Type = gaugeTypeName
+			m.MetricKey.Type = GaugeTypeName
 		case 2:
-			m.MetricKey.Type = histogramTypeName
+			m.MetricKey.Type = HistogramTypeName
 		case 3:
-			m.MetricKey.Type = setTypeName
+			m.MetricKey.Type = SetTypeName
 			m.Value = "a value here!"
 		case 4:
-			m.MetricKey.Type = timerTypeName
+			m.MetricKey.Type = TimerTypeName
 		default:
 			// do nothing
 		}


### PR DESCRIPTION
#### Summary
Rename metric name constants so that they can be used outside of the `veneur` package.

#### Test plan
```
go test github.com/stripe/veneur/v14
```

#### Deploy
N/A
