### PR TITLE
Move forward_grpc_test.go into a test package.

### DIFF
--- a/flusher_test.go
+++ b/flusher_test.go
@@ -17,6 +17,79 @@ import (
 	"github.com/stripe/veneur/v14/samplers/metricpb"
 )
 
+func forwardGRPCTestMetrics() []*samplers.UDPMetric {
+	return []*samplers.UDPMetric{{
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.histogram",
+			Type: HistogramTypeName,
+		},
+		Value:      20.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.MixedScope,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.histogram_global",
+			Type: HistogramTypeName,
+		},
+		Value:      20.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.gauge",
+			Type: GaugeTypeName,
+		},
+		Value:      1.0,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.counter",
+			Type: CounterTypeName,
+		},
+		Value:      2.0,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.timer_mixed",
+			Type: TimerTypeName,
+		},
+		Value:      100.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.MixedScope,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.timer",
+			Type: TimerTypeName,
+		},
+		Value:      100.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.set",
+			Type: SetTypeName,
+		},
+		Value:      "test",
+		SampleRate: 1.0,
+		Scope:      samplers.GlobalOnly,
+	}, {
+		MetricKey: samplers.MetricKey{
+			Name: "test.grpc.counter.local",
+			Type: CounterTypeName,
+		},
+		Value:      100.0,
+		Digest:     12345,
+		SampleRate: 1.0,
+		Scope:      samplers.MixedScope,
+	}}
+}
+
 func TestServerFlushGRPC(t *testing.T) {
 	done := make(chan []string)
 	testServer := forwardtest.NewServer(func(ms []*metricpb.Metric) {
@@ -42,13 +115,13 @@ func TestServerFlushGRPC(t *testing.T) {
 	}
 
 	expected := []string{
-		testGRPCMetric("histogram"),
-		testGRPCMetric("histogram_global"),
-		testGRPCMetric("timer"),
-		testGRPCMetric("timer_mixed"),
-		testGRPCMetric("counter"),
-		testGRPCMetric("gauge"),
-		testGRPCMetric("set"),
+		"test.grpc.histogram",
+		"test.grpc.histogram_global",
+		"test.grpc.timer",
+		"test.grpc.timer_mixed",
+		"test.grpc.counter",
+		"test.grpc.gauge",
+		"test.grpc.set",
 	}
 
 	// Wait until the running server has flushed out the metrics for us:

--- a/proxy.go
+++ b/proxy.go
@@ -697,7 +697,7 @@ func (p *Proxy) Shutdown() {
 	p.gRPCStop()
 }
 
-// isListeningHTTP returns if the Proxy is currently listening over HTTP
-func (p *Proxy) isListeningHTTP() bool {
+// IsListeningHTTP returns if the Proxy is currently listening over HTTP
+func (p *Proxy) IsListeningHTTP() bool {
 	return atomic.LoadInt32(p.numListeningHTTP) > 0
 }

--- a/server.go
+++ b/server.go
@@ -1496,8 +1496,8 @@ func (s *Server) IsLocal() bool {
 	return s.ForwardAddr != ""
 }
 
-// isListeningHTTP returns if the Server is currently listening over HTTP
-func (s *Server) isListeningHTTP() bool {
+// IsListeningHTTP returns if the Server is currently listening over HTTP
+func (s *Server) IsListeningHTTP() bool {
 	return atomic.LoadInt32(s.numListeningHTTP) > 0
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -152,9 +152,6 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if transport != nil {
-		server.HTTPClient.Transport = transport
-	}
 
 	if transport != nil {
 		server.HTTPClient.Transport = transport
@@ -1469,7 +1466,7 @@ func TestServeStopGRPC(t *testing.T) {
 }
 
 type testHTTPStarter interface {
-	isListeningHTTP() bool
+	IsListeningHTTP() bool
 }
 
 // waitForHTTPStart blocks until the Server's HTTP server is started, or until
@@ -1481,7 +1478,7 @@ func waitForHTTPStart(t testing.TB, s testHTTPStarter, timeout time.Duration) {
 	for {
 		select {
 		case <-tickCh:
-			if s.isListeningHTTP() {
+			if s.IsListeningHTTP() {
 				return
 			}
 		case <-timeoutCh:


### PR DESCRIPTION
#### Summary
This change moves the `forward_grpc_test.go` test into its own package.

#### Motivation
This change is in preparation for moving the `forward_grpc_test.go` test into a `sources/proxy` directory.

#### Test plan
```
go test github.com/stripe/veneur/v14
```