### PR TITLE
Migrate Prometheus sink to new config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * A flag -print-secrets to disable redacting config secrets.
 * A prometheus remote-write sink compatible with Cortex and more. Thanks, [philipnrmn](https://github.com/philipnrmn)!
 * Some veneur-prometheus arguments to rename and add additional tags. Thanks, [christopherb-stripe](https://github.com/christopherb-stripe)!
+* Migrate Prometheus to new config format; part of multi-sink routing update. Thanks, [truong-stripe](https://github.com/truong-stripe)!
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stripe/veneur/v14/sinks/kafka"
 	"github.com/stripe/veneur/v14/sinks/localfile"
 	"github.com/stripe/veneur/v14/sinks/newrelic"
+	"github.com/stripe/veneur/v14/sinks/prometheus"
 	"github.com/stripe/veneur/v14/sinks/s3"
 	"github.com/stripe/veneur/v14/sinks/signalfx"
 	"github.com/stripe/veneur/v14/sinks/splunk"
@@ -70,6 +71,10 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("error migrating splunk config")
 		}
+		err = prometheus.MigrateConfig(&conf)
+		if err != nil {
+			logrus.WithError(err).Fatal("error migrating prometheus config")
+		}
 	}
 
 	logger := logrus.StandardLogger()
@@ -101,6 +106,10 @@ func main() {
 			"newrelic": {
 				Create:      newrelic.CreateMetricSink,
 				ParseConfig: newrelic.ParseMetricConfig,
+			},
+			"prometheus": {
+				Create:      prometheus.CreateMetricSink,
+				ParseConfig: prometheus.ParseMetricConfig,
 			},
 			"s3": {
 				Create:      s3.Create,

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -59,6 +59,7 @@ func main() {
 		localfile.MigrateConfig(&conf)
 		newrelic.MigrateConfig(&conf)
 		s3.MigrateConfig(&conf)
+		prometheus.MigrateConfig(&conf)
 		err = signalfx.MigrateConfig(&conf)
 		if err != nil {
 			logrus.WithError(err).Fatal("error migrating signalfx config")
@@ -70,10 +71,6 @@ func main() {
 		err = splunk.MigrateConfig(&conf)
 		if err != nil {
 			logrus.WithError(err).Fatal("error migrating splunk config")
-		}
-		err = prometheus.MigrateConfig(&conf)
-		if err != nil {
-			logrus.WithError(err).Fatal("error migrating prometheus config")
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -38,7 +38,6 @@ import (
 	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/falconer"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
-	"github.com/stripe/veneur/v14/sinks/prometheus"
 	"github.com/stripe/veneur/v14/sinks/ssfmetrics"
 	"github.com/stripe/veneur/v14/sinks/xray"
 	"github.com/stripe/veneur/v14/sources"
@@ -392,6 +391,8 @@ func (server *Server) createMetricSinks(
 		if err != nil {
 			return nil, err
 		}
+		fmt.Printf("debug createMetricSinks original config -> %+v\n", config)
+		fmt.Printf("debug createMetricSinks parsed -> %+v\n", parsedSinkConfig)
 		// Overwrite the map config with the parsed config. This prevents senstive
 		// fields in the map from accidentally being logged.
 		config.MetricSinks[index].Config = parsedSinkConfig
@@ -725,20 +726,6 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		if conf.NumSpanWorkers > 0 {
 			ret.SpanWorkerGoroutines = conf.NumSpanWorkers
 		}
-	}
-
-	if conf.PrometheusRepeaterAddress != "" {
-		prometheusMetricSink, err := prometheus.NewStatsdRepeater(
-			conf.PrometheusRepeaterAddress,
-			conf.PrometheusNetworkType,
-			log,
-		)
-		if err != nil {
-			return ret, err
-		}
-
-		ret.metricSinks = append(ret.metricSinks, prometheusMetricSink)
-		logger.Info("Configured Prometheus metric sink.")
 	}
 
 	customMetricSinks, err :=

--- a/server.go
+++ b/server.go
@@ -391,8 +391,6 @@ func (server *Server) createMetricSinks(
 		if err != nil {
 			return nil, err
 		}
-		fmt.Printf("debug createMetricSinks original config -> %+v\n", config)
-		fmt.Printf("debug createMetricSinks parsed -> %+v\n", parsedSinkConfig)
 		// Overwrite the map config with the parsed config. This prevents senstive
 		// fields in the map from accidentally being logged.
 		config.MetricSinks[index].Config = parsedSinkConfig

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
-	"github.com/stripe/veneur/v14/sinks/prometheus"
+
 	"github.com/stripe/veneur/v14/util"
 )
 
@@ -172,24 +172,4 @@ func TestNewDatadogMetricSinkConfig(t *testing.T) {
 	assert.Equal(t, "datadog", sink.Name())
 	// Verify that the values got set	assert.Equal(t, "apikey", sink.APIKey)
 	assert.Equal(t, "http://api", sink.DDHostname)
-}
-
-func TestNewPrometheusMetricSinkConfig(t *testing.T) {
-	config := Config{
-		PrometheusRepeaterAddress: "localhost:9125",
-		PrometheusNetworkType:     "tcp",
-
-		// Required or NewFromConfig fails.
-		Interval:     time.Duration(10 * time.Second),
-		StatsAddress: "localhost:62251",
-	}
-
-	server, err := NewFromConfig(ServerConfig{
-		Logger: logrus.New(),
-		Config: config,
-	})
-	assert.NoError(t, err)
-
-	sink := server.metricSinks[0].(*prometheus.StatsdRepeater)
-	assert.Equal(t, "prometheus", sink.Name())
 }

--- a/sinks/prometheus/prometheus.go
+++ b/sinks/prometheus/prometheus.go
@@ -164,16 +164,17 @@ func metricTypeEnc(metric samplers.InterMetric) string {
 	return ""
 }
 
-func MigrateConfig(conf *veneur.Config) error {
-	if conf.PrometheusRepeaterAddress != "" {
-		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
-			Kind: "prometheus",
-			Name: "prometheus",
-			Config: PrometheusMetricSinkConfig{
-				RepeaterAddress: conf.PrometheusRepeaterAddress,
-				NetworkType:     conf.PrometheusNetworkType,
-			},
-		})
+func MigrateConfig(conf *veneur.Config) {
+	if conf.PrometheusRepeaterAddress == "" {
+		return
 	}
-	return nil
+
+	conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
+		Kind: "prometheus",
+		Name: "prometheus",
+		Config: PrometheusMetricSinkConfig{
+			RepeaterAddress: conf.PrometheusRepeaterAddress,
+			NetworkType:     conf.PrometheusNetworkType,
+		},
+	})
 }

--- a/sinks/prometheus/prometheus.go
+++ b/sinks/prometheus/prometheus.go
@@ -46,12 +46,10 @@ type PrometheusMetricSink struct {
 
 func ParseMetricConfig(name string, config interface{}) (veneur.MetricSinkConfig, error) {
 	prometheusConfig := PrometheusMetricSinkConfig{}
-	fmt.Printf("debug prometheus.ParseMetricConfig config -> %+v\n", config)
 	err := util.DecodeConfig(name, config, &prometheusConfig)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("debug prometheus.ParseMetricConfig prom -> %+v\n", prometheusConfig)
 	return prometheusConfig, nil
 }
 


### PR DESCRIPTION
#### Summary
This change migrates Prometheus to use the new config format.


#### Motivation
This work is part of enabling multi-sink routing.


#### Test plan
Run unit tests `go test . ./sinks/prometheus`
and build and run the binary specifying prometheus as a metric sink in config
```
go build -o dist/veneur cmd/veneur/main.go
./dist/veneur -f dist/config.yaml
```
