### PR TITLE
Migrate Datadog sink to new config format

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stripe/veneur/v14"
 	"github.com/stripe/veneur/v14/sinks/attribution"
 	"github.com/stripe/veneur/v14/sinks/cortex"
+	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/debug"
 	"github.com/stripe/veneur/v14/sinks/kafka"
 	"github.com/stripe/veneur/v14/sinks/localfile"
@@ -54,6 +55,7 @@ func main() {
 		os.Exit(0)
 	}
 	if !conf.Features.MigrateMetricSinks {
+		datadog.MigrateConfig(&conf)
 		debug.MigrateConfig(&conf)
 		localfile.MigrateConfig(&conf)
 		newrelic.MigrateConfig(&conf)
@@ -86,6 +88,10 @@ func main() {
 				Create:      cortex.Create,
 				ParseConfig: cortex.ParseConfig,
 			},
+			"datadog": {
+				Create:      datadog.CreateMetricSink,
+				ParseConfig: datadog.ParseMetricConfig,
+			},
 			"debug": {
 				Create:      debug.CreateMetricSink,
 				ParseConfig: debug.ParseMetricConfig,
@@ -113,6 +119,10 @@ func main() {
 		},
 		SpanSinkTypes: veneur.SpanSinkTypes{
 			// TODO(arnavdugar): Migrate span sink types.
+			"datadog": {
+				Create:      datadog.CreateSpanSink,
+				ParseConfig: datadog.ParseSpanConfig,
+			},
 			"debug": {
 				Create:      debug.CreateSpanSink,
 				ParseConfig: debug.ParseSpanConfig,

--- a/flusher.go
+++ b/flusher.go
@@ -250,7 +250,7 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 	finalMetrics := make([]samplers.InterMetric, 0, ms.totalLength)
 	for _, wm := range tempMetrics {
 		for _, c := range wm.counters {
-			finalMetrics = append(finalMetrics, c.Flush(s.interval)...)
+			finalMetrics = append(finalMetrics, c.Flush(s.Interval)...)
 		}
 		for _, g := range wm.gauges {
 			finalMetrics = append(finalMetrics, g.Flush()...)
@@ -260,10 +260,10 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 		//
 		// if we're a global veneur, aggregates will be nil.
 		for _, h := range wm.histograms {
-			finalMetrics = append(finalMetrics, h.Flush(s.interval, percentiles, s.HistogramAggregates, false)...)
+			finalMetrics = append(finalMetrics, h.Flush(s.Interval, percentiles, s.HistogramAggregates, false)...)
 		}
 		for _, t := range wm.timers {
-			finalMetrics = append(finalMetrics, t.Flush(s.interval, percentiles, s.HistogramAggregates, false)...)
+			finalMetrics = append(finalMetrics, t.Flush(s.Interval, percentiles, s.HistogramAggregates, false)...)
 		}
 
 		// local-only samplers should be flushed in their entirety, since they
@@ -271,13 +271,13 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 		// we still want percentiles for these, even if we're a local veneur, so
 		// we use the original percentile list when flushing them
 		for _, h := range wm.localHistograms {
-			finalMetrics = append(finalMetrics, h.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates, false)...)
+			finalMetrics = append(finalMetrics, h.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates, false)...)
 		}
 		for _, s := range wm.localSets {
 			finalMetrics = append(finalMetrics, s.Flush()...)
 		}
 		for _, t := range wm.localTimers {
-			finalMetrics = append(finalMetrics, t.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates, false)...)
+			finalMetrics = append(finalMetrics, t.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates, false)...)
 		}
 
 		for _, status := range wm.localStatusChecks {
@@ -297,7 +297,7 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 			// global counters have no local parts, so if we're a local veneur,
 			// there's nothing to flush
 			for _, gc := range wm.globalCounters {
-				finalMetrics = append(finalMetrics, gc.Flush(s.interval)...)
+				finalMetrics = append(finalMetrics, gc.Flush(s.Interval)...)
 			}
 
 			// and global gauges
@@ -306,10 +306,10 @@ func (s *Server) generateInterMetrics(ctx context.Context, percentiles []float64
 			}
 
 			for _, h := range wm.globalHistograms {
-				finalMetrics = append(finalMetrics, h.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates, true)...)
+				finalMetrics = append(finalMetrics, h.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates, true)...)
 			}
 			for _, h := range wm.globalTimers {
-				finalMetrics = append(finalMetrics, h.Flush(s.interval, s.HistogramPercentiles, s.HistogramAggregates, true)...)
+				finalMetrics = append(finalMetrics, h.Flush(s.Interval, s.HistogramPercentiles, s.HistogramAggregates, true)...)
 			}
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -35,7 +35,6 @@ import (
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/scopedstatsd"
 	"github.com/stripe/veneur/v14/sinks"
-	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/falconer"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/sinks/prometheus"
@@ -138,7 +137,7 @@ type Server struct {
 	GRPCListenAddrs   []net.Addr
 	RcvbufBytes       int
 
-	interval            time.Duration
+	Interval            time.Duration
 	synchronizeInterval bool
 	numReaders          int
 	metricMaxLength     int
@@ -415,7 +414,7 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 
 	ret := &Server{
 		Config:   conf,
-		interval: conf.Interval,
+		Interval: conf.Interval,
 	}
 
 	ret.Hostname = conf.Hostname
@@ -439,12 +438,12 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	ret.stuckIntervals = conf.FlushWatchdogMissedFlushes
 
 	transport := &http.Transport{
-		IdleConnTimeout: ret.interval * 2, // If we're idle more than one interval something is up
+		IdleConnTimeout: ret.Interval * 2, // If we're idle more than one interval something is up
 	}
 
 	ret.HTTPClient = &http.Client{
 		// make sure that POSTs to datadog do not overflow the flush interval
-		Timeout:   ret.interval * 9 / 10,
+		Timeout:   ret.Interval * 9 / 10,
 		Transport: transport,
 	}
 
@@ -633,42 +632,10 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		}
 	}
 
-	if conf.DatadogAPIKey.Value != "" && conf.DatadogAPIHostname != "" {
-		excludeTagsPrefixByPrefixMetric := map[string][]string{}
-		for _, m := range conf.DatadogExcludeTagsPrefixByPrefixMetric {
-			excludeTagsPrefixByPrefixMetric[m.MetricPrefix] = m.Tags
-		}
-
-		ddSink, err := datadog.NewDatadogMetricSink(
-			ret.interval.Seconds(), conf.DatadogFlushMaxPerBody, conf.Hostname,
-			ret.Tags, conf.DatadogAPIHostname, conf.DatadogAPIKey.Value,
-			ret.HTTPClient, log, conf.DatadogMetricNamePrefixDrops,
-			excludeTagsPrefixByPrefixMetric,
-		)
-		if err != nil {
-			return ret, err
-		}
-		ret.metricSinks = append(ret.metricSinks, ddSink)
-	}
-
 	// Configure tracing sinks if we are listening for ssf
 	if len(conf.SsfListenAddresses) > 0 || len(conf.GrpcListenAddresses) > 0 {
 
 		trace.Enable()
-
-		// configure Datadog as a Span sink
-		if conf.DatadogAPIKey.Value != "" && conf.DatadogTraceAPIAddress != "" {
-			ddSink, err := datadog.NewDatadogSpanSink(
-				conf.DatadogTraceAPIAddress, conf.DatadogSpanBufferSize,
-				ret.HTTPClient, log,
-			)
-			if err != nil {
-				return ret, err
-			}
-
-			ret.spanSinks = append(ret.spanSinks, ddSink)
-			logger.Info("Configured Datadog span sink")
-		}
 
 		if conf.XrayAddress != "" {
 			if conf.XraySamplePercentage == 0 {
@@ -934,7 +901,7 @@ func (s *Server) Start() {
 		if s.synchronizeInterval {
 			// We want to align our ticker to a multiple of its duration for
 			// convenience of bucketing.
-			<-time.After(CalculateTickDelay(s.interval, time.Now()))
+			<-time.After(CalculateTickDelay(s.Interval, time.Now()))
 		}
 
 		// We aligned the ticker to our interval above. It's worth noting that just
@@ -942,7 +909,7 @@ func (s *Server) Start() {
 		// subsequent tick. This code is small, however, and should service the
 		// incoming tick signal fast enough that the amount we are "off" is
 		// negligible.
-		ticker := time.NewTicker(s.interval)
+		ticker := time.NewTicker(s.Interval)
 		for {
 			select {
 			case <-s.shutdown:
@@ -950,7 +917,7 @@ func (s *Server) Start() {
 				ticker.Stop()
 				return
 			case triggered := <-ticker.C:
-				ctx, cancel := context.WithDeadline(ctx, triggered.Add(s.interval))
+				ctx, cancel := context.WithDeadline(ctx, triggered.Add(s.Interval))
 				s.Flush(ctx)
 				cancel()
 			}
@@ -976,7 +943,7 @@ func (s *Server) FlushWatchdog() {
 	}
 	atomic.StoreInt64(&s.lastFlushUnix, time.Now().UnixNano())
 
-	ticker := time.NewTicker(s.interval)
+	ticker := time.NewTicker(s.Interval)
 	for {
 		select {
 		case <-s.shutdown:
@@ -989,7 +956,7 @@ func (s *Server) FlushWatchdog() {
 			// If no flush was kicked off in the last N
 			// times, we're stuck - panic because that's a
 			// bug.
-			if since > time.Duration(s.stuckIntervals)*s.interval {
+			if since > time.Duration(s.stuckIntervals)*s.Interval {
 				rtdebug.SetTraceback("all")
 				log.WithFields(logrus.Fields{
 					"last_flush":       last,

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -2,18 +2,12 @@ package veneur
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/util"

--- a/server_sinks_test.go
+++ b/server_sinks_test.go
@@ -2,12 +2,8 @@ package veneur
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +11,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/veneur/v14/sinks/datadog"
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/sinks/prometheus"
 	"github.com/stripe/veneur/v14/util"
@@ -51,69 +46,12 @@ func TestFlushTracesBySink(t *testing.T) {
 			assert.NoError(t, err)
 			defer js.Close()
 
-			testFlushTraceDatadog(t, pb, js)
-		})
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			pb, err := os.Open(tc.ProtobufFile)
-			assert.NoError(t, err)
-			defer pb.Close()
-
-			js, err := os.Open(tc.JSONFile)
-			assert.NoError(t, err)
-			defer js.Close()
-
 			testFlushTraceLightstep(t, pb, js)
 		})
 	}
 }
 
-func testFlushTraceDatadog(t *testing.T, protobuf, jsn io.Reader) {
-	var expected [][]DatadogTraceSpan
-	err := json.NewDecoder(jsn).Decode(&expected)
-	assert.NoError(t, err)
-
-	remoteResponseChan := make(chan [][]DatadogTraceSpan, 1)
-	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var actual [][]DatadogTraceSpan
-		err = json.NewDecoder(r.Body).Decode(&actual)
-		assert.NoError(t, err)
-
-		w.WriteHeader(http.StatusAccepted)
-		remoteResponseChan <- actual
-	}))
-	defer remoteServer.Close()
-
-	config := globalConfig()
-	config.DatadogAPIKey = util.StringSecret{Value: "secret"}
-	config.DatadogTraceAPIAddress = remoteServer.URL
-
-	server := setupVeneurServer(t, config, nil, nil, nil, nil)
-	defer server.Shutdown()
-
-	ddSink, err := datadog.NewDatadogSpanSink("http://example.com", 100, server.HTTPClient, logrus.New())
-
-	server.TraceClient = nil
-	server.spanSinks = append(server.spanSinks, ddSink)
-
-	packet, err := ioutil.ReadAll(protobuf)
-	assert.NoError(t, err)
-
-	server.HandleTracePacket(packet, SSF_UNIX)
-	server.Flush(context.Background())
-
-	// wait for remoteServer to process the POST
-	select {
-	case actual := <-remoteResponseChan:
-		assert.Equal(t, expected, actual)
-		// all is safe
-		break
-	case <-time.After(2 * time.Second):
-		assert.Fail(t, "Global server did not complete all responses before test terminated!")
-	}
-}
+// TODO(jcrpaquin): Replace testFlushTraceDatadog with testing of main.go init code
 
 // testFlushTraceLightstep tests that the Lightstep sink can be initialized correctly
 // and that the flushSpansLightstep function executes without error.
@@ -138,40 +76,6 @@ func testFlushTraceLightstep(t *testing.T, protobuf, jsn io.Reader) {
 
 	assert.NoError(t, err)
 	server.Flush(context.Background())
-}
-
-// This test lives here because is tests the server's behavior when making a
-// datadog metric sink
-func TestNewDatadogMetricSinkConfig(t *testing.T) {
-	// test the variables that have been renamed
-	config := Config{
-		DatadogAPIKey:          util.StringSecret{Value: "apikey"},
-		DatadogAPIHostname:     "http://api",
-		DatadogTraceAPIAddress: "http://trace",
-		DatadogSpanBufferSize:  32,
-		SsfListenAddresses: []util.Url{{
-			Value: &url.URL{
-				Scheme: "udp",
-				Host:   "127.0.0.1:99",
-			},
-		}},
-
-		// required or NewFromConfig fails
-		Interval:     time.Duration(10 * time.Second),
-		StatsAddress: "localhost:62251",
-	}
-	server, err := NewFromConfig(ServerConfig{
-		Logger: logrus.New(),
-		Config: config,
-	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	sink := server.metricSinks[0].(*datadog.DatadogMetricSink)
-	assert.Equal(t, "datadog", sink.Name())
-	// Verify that the values got set	assert.Equal(t, "apikey", sink.APIKey)
-	assert.Equal(t, "http://api", sink.DDHostname)
 }
 
 func TestNewPrometheusMetricSinkConfig(t *testing.T) {

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -36,7 +36,7 @@ const datadogSpanBufferSize = 1 << 14
 
 type DatadogMetricSinkConfig struct {
 	APIKey                          string   `yaml:"api_key"`
-	APIHostname                     string   `yaml:"pi_hostname"`
+	APIHostname                     string   `yaml:"api_hostname"`
 	FlushMaxPerBody                 int      `yaml:"flush_max_per_body"`
 	MetricNamePrefixDrops           []string `yaml:"metric_name_prefix_drops"`
 	ExcludeTagsPrefixByPrefixMetric []struct {

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -35,14 +35,14 @@ const datadogSpanType = "web"
 const datadogSpanBufferSize = 1 << 14
 
 type DatadogMetricSinkConfig struct {
-	APIKey                          string   `yaml:"datadog_api_key"`
-	APIHostname                     string   `yaml:"datadog_api_hostname"`
-	FlushMaxPerBody                 int      `yaml:"datadog_flush_max_per_body"`
-	MetricNamePrefixDrops           []string `yaml:"datadog_metric_name_prefix_drops"`
+	APIKey                          string   `yaml:"api_key"`
+	APIHostname                     string   `yaml:"pi_hostname"`
+	FlushMaxPerBody                 int      `yaml:"flush_max_per_body"`
+	MetricNamePrefixDrops           []string `yaml:"metric_name_prefix_drops"`
 	ExcludeTagsPrefixByPrefixMetric []struct {
 		MetricPrefix string   `yaml:"metric_prefix"`
 		Tags         []string `yaml:"tags"`
-	} `yaml:"datadog_exclude_tags_prefix_by_prefix_metric"`
+	} `yaml:"exclude_tags_prefix_by_prefix_metric"`
 }
 
 type DatadogMetricSink struct {

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -526,10 +526,15 @@ func CreateSpanSink(
 		return nil, errors.New("invalid sink config type")
 	}
 
+	bufferSize := datadogConfig.SpanBufferSize
+	if bufferSize == 0 {
+		bufferSize = datadogSpanBufferSize
+	}
+
 	return &DatadogSpanSink{
 		HTTPClient:   server.HTTPClient,
-		bufferSize:   datadogConfig.SpanBufferSize,
-		buffer:       ring.New(datadogConfig.SpanBufferSize),
+		bufferSize:   bufferSize,
+		buffer:       ring.New(bufferSize),
 		mutex:        &sync.Mutex{},
 		traceAddress: datadogConfig.TraceAPIAddress,
 		log:          logger,

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -418,10 +418,9 @@ func TestDatadogFlushOtherMetricsForServiceChecks(t *testing.T) {
 func TestDatadogFlushServiceCheck(t *testing.T) {
 	transport := &DatadogRoundTripper{Endpoint: "/api/v1/check_run", Contains: ""}
 	logger := logrus.NewEntry(logrus.New())
-	interval, _ := time.ParseDuration("10s")
 	sink, err := CreateMetricSink(&veneur.Server{
 		HTTPClient: &http.Client{Transport: transport},
-		Interval:   interval,
+		Interval:   10 * time.Second,
 		Tags:       []string{"gloobles:toots"},
 	},
 		"datadog", logger, veneur.Config{Hostname: "example.com"},

--- a/sinks/datadog/datadog_test.go
+++ b/sinks/datadog/datadog_test.go
@@ -554,3 +554,33 @@ func TestDataDogDropTagsByMetricPrefix(t *testing.T) {
 	}
 
 }
+
+func TestParseMetricConfig(t *testing.T) {
+	testConfigValues := map[string]interface{}{
+		"datadog_api_key":                  "KEY",
+		"datadog_api_hostname":             "HOSTNAME",
+		"datadog_flush_max_per_body":       9001,
+		"datadog_metric_name_prefix_drops": []string{"prefix1", "prefix2"},
+	}
+
+	parsedConfig, err := ParseMetricConfig("datadog", testConfigValues)
+	datadogConfig := parsedConfig.(DatadogMetricSinkConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, datadogConfig.APIKey, testConfigValues["datadog_api_key"])
+	assert.Equal(t, datadogConfig.APIHostname, testConfigValues["datadog_api_hostname"])
+	assert.Equal(t, datadogConfig.FlushMaxPerBody, testConfigValues["datadog_flush_max_per_body"])
+	assert.Equal(t, datadogConfig.MetricNamePrefixDrops, testConfigValues["datadog_metric_name_prefix_drops"])
+}
+
+func TestParseSpanConfig(t *testing.T) {
+	testConfigValues := map[string]interface{}{
+		"datadog_span_buffer_size":  1337,
+		"datadog_trace_api_address": "0.0.0.0",
+	}
+
+	parsedConfig, err := ParseSpanConfig("datadog", testConfigValues)
+	datadogConfig := parsedConfig.(DatadogSpanSinkConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, datadogConfig.SpanBufferSize, testConfigValues["datadog_span_buffer_size"])
+	assert.Equal(t, datadogConfig.TraceAPIAddress, testConfigValues["datadog_trace_api_address"])
+}


### PR DESCRIPTION
This PR still needs more comments on the new methods (to match docs attached to other, similar methods for other sinks), as well as more tests around config parsing (to catch issues similar to those surfaced by @truong-stripe).

#### Summary
This change migrates the Datadog metric/span sinks to use the new config format.


#### Motivation
This work is part of enabling multi-sink routing.


#### Test plan
- [x] Maintain passing status on existing unit tests
- [x] Add new unit test for config parsing
- [x] Run manual integration test using the final binary & modified config.


#### PR Tasks
- [x] Migrate configs (Add `ParseConfig`, `MigrateConfig` and `Create*Sink` functions)
- [x] Add `name` field
- [x] Integrate new config functions into the main Veneur command
- [x] Document new config functions
- [x] Test config parsing
