### PR TITLE
Modifications to timeout handler in cortex sink

### DIFF
--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -89,7 +89,7 @@ func TestCorrectlySetTimeout(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, time.Duration(to), sink.Client.Timeout)
-  }
+	}
 }
 
 func TestMetricToTimeSeries(t *testing.T) {


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
* Previously http client timeout was being set to a larger number than expected because of how it was being multiplied. Fixed & added regression test to catch this. 


#### Motivation
<!-- Why are you making this change? -->
The previous behavior was causing very large timeouts to be set, our desired timeout is shorter than veneur's flush interval.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Added regression tests to catch this & tested behavior locally.


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
