### PR TITLE
Migrate the falconer/grpc sink to new config format.

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stripe/veneur/v14/sinks/attribution"
 	"github.com/stripe/veneur/v14/sinks/cortex"
 	"github.com/stripe/veneur/v14/sinks/debug"
+	"github.com/stripe/veneur/v14/sinks/falconer"
 	"github.com/stripe/veneur/v14/sinks/kafka"
 	"github.com/stripe/veneur/v14/sinks/localfile"
 	"github.com/stripe/veneur/v14/sinks/newrelic"
@@ -70,6 +71,10 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("error migrating splunk config")
 		}
+		err = falconer.MigrateConfig(&conf)
+		if err != nil {
+			logrus.WithError(err).Fatal("error migrating falconer config")
+		}
 	}
 
 	logger := logrus.StandardLogger()
@@ -116,6 +121,10 @@ func main() {
 			"debug": {
 				Create:      debug.CreateSpanSink,
 				ParseConfig: debug.ParseSpanConfig,
+			},
+			"falconer": {
+				Create:      falconer.Create,
+				ParseConfig: falconer.ParseConfig,
 			},
 			"kafka": {
 				Create:      kafka.CreateSpanSink,

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -120,7 +120,7 @@ func ParseSpanConfig(_ string, _ interface{}) (veneur.SpanSinkConfig, error) {
 // provided configuration.
 func CreateSpanSink(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig, ctx context.Context,
 ) (sinks.SpanSink, error) {
 	return &debugSpanSink{
 		log:  logger,

--- a/sinks/falconer/falconer.go
+++ b/sinks/falconer/falconer.go
@@ -3,11 +3,48 @@ package falconer
 import (
 	"context"
 
+	"github.com/stripe/veneur/v14"
+	"github.com/stripe/veneur/v14/sinks"
+	"github.com/stripe/veneur/v14/util"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14/sinks/grpsink"
-	"google.golang.org/grpc"
 )
 
-func NewSpanSink(ctx context.Context, target string, log *logrus.Logger, opts ...grpc.DialOption) (*grpsink.GRPCSpanSink, error) {
-	return grpsink.NewGRPCSpanSink(ctx, target, "falconer", log, opts...)
+type FalconerSpanSinkConfig struct {
+	Target string `yaml:"target"`
+}
+
+func MigrateConfig(conf *veneur.Config) error {
+	if conf.FalconerAddress == "" {
+		return nil
+	}
+	conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
+		Kind: "falconer",
+		Name: "falconer",
+		Config: FalconerSpanSinkConfig{
+			Target: conf.FalconerAddress,
+		},
+	})
+	return nil
+}
+
+func Create(
+	server *veneur.Server, name string, logger *logrus.Entry,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig, ctx context.Context,
+) (sinks.SpanSink, error) {
+	return grpsink.Create(server, name, logger, config, sinkConfig, ctx)
+}
+
+// ParseConfig decodes the map config for a Falconer sink into a FalconerSpanSinkConfig
+// struct.
+func ParseConfig(
+	name string, config interface{},
+) (veneur.SpanSinkConfig, error) {
+	falconerConfig := FalconerSpanSinkConfig{}
+	err := util.DecodeConfig(name, config, &falconerConfig)
+	if err != nil {
+		return nil, err
+	}
+	return falconerConfig, nil
 }

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -328,7 +328,7 @@ func ParseSpanConfig(
 // provided configuration.
 func CreateSpanSink(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig, ctx context.Context,
 ) (sinks.SpanSink, error) {
 	kafkaConfig := sinkConfig.(KafkaSpanSinkConfig)
 

--- a/sinks/kafka/kafka_test.go
+++ b/sinks/kafka/kafka_test.go
@@ -266,6 +266,7 @@ func TestCreateSpanSinkWithoutTopic(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "",
 		},
+		context.Background(),
 	)
 	assert.Error(t, err)
 }
@@ -291,6 +292,7 @@ func TestCreateSpanSinkWithoutBroker(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.Error(t, err)
 }
@@ -316,6 +318,7 @@ func TestCreateSpanSinkWithSampleRateTooLow(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.Error(t, err)
 }
@@ -341,6 +344,7 @@ func TestCreateSpanSinkWithSampleRateZero(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 }
@@ -366,6 +370,7 @@ func TestCreateSpanSinkWithSampleRateTooHigh(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.Error(t, err)
 }
@@ -391,6 +396,7 @@ func TestCreateSpanSinkWithRequireAcksNone(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -419,6 +425,7 @@ func TestCreateSpanSinkWithRequireAcksLocal(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -447,6 +454,7 @@ func TestCreateSpanSinkWithRequireAcksInvalid(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -475,6 +483,7 @@ func TestCreateSpanSink(t *testing.T) {
 			SpanSerializationFormat: "",
 			SpanTopic:               "veneur_spans",
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -522,6 +531,7 @@ func TestSpanTraceIdSampling(t *testing.T) {
 			SpanSampleTag:           "",
 			SpanSampleRatePercent:   50,
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -597,6 +607,7 @@ func TestSpanTagSampling(t *testing.T) {
 			SpanSampleTag:           "baz",
 			SpanSampleRatePercent:   50,
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -706,6 +717,7 @@ func TestSpanFlushJson(t *testing.T) {
 			SpanSampleTag:           "",
 			SpanSampleRatePercent:   100,
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)
@@ -764,6 +776,7 @@ func TestSpanFlushProtobuf(t *testing.T) {
 			SpanSampleTag:           "",
 			SpanSampleRatePercent:   100,
 		},
+		context.Background(),
 	)
 	assert.NoError(t, err)
 	kafkaSink, ok := sink.(*KafkaSpanSink)

--- a/sinks/newrelic/span.go
+++ b/sinks/newrelic/span.go
@@ -48,7 +48,7 @@ func ParseSpanConfig(
 // provided configuration.
 func CreateSpanSink(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig, ctx context.Context,
 ) (sinks.SpanSink, error) {
 	newRelicConfig := sinkConfig.(NewRelicSpanSinkConfig)
 

--- a/sinks/newrelic/span_test.go
+++ b/sinks/newrelic/span_test.go
@@ -1,6 +1,7 @@
 package newrelic
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -22,7 +23,9 @@ func TestCreateSpanSink(t *testing.T) {
 			CommonTags:       []string{},
 			InsertKey:        util.StringSecret{Value: testNewRelicApiKey},
 			TraceObserverURL: testNewRelicSpanURL,
-		})
+		},
+		context.Background(),
+	)
 
 	require.NotNil(t, sink)
 	assert.NoError(t, err)
@@ -45,7 +48,9 @@ func TestNewRelicSpanSink_Start(t *testing.T) {
 			CommonTags:       []string{},
 			InsertKey:        util.StringSecret{Value: testNewRelicApiKey},
 			TraceObserverURL: testNewRelicSpanURL,
-		})
+		},
+		context.Background(),
+	)
 
 	require.NotNil(t, sink)
 	require.NoError(t, err)
@@ -65,7 +70,9 @@ func TestNewRelicSpanSink_Ingest(t *testing.T) {
 			CommonTags:       []string{},
 			InsertKey:        util.StringSecret{Value: testNewRelicApiKey},
 			TraceObserverURL: testNewRelicSpanURL,
-		})
+		},
+		context.Background(),
+	)
 
 	require.NotNil(t, sink)
 	require.NoError(t, err)
@@ -86,7 +93,9 @@ func TestNewRelicSpanSink_Flush(t *testing.T) {
 			CommonTags:       []string{},
 			InsertKey:        util.StringSecret{Value: testNewRelicApiKey},
 			TraceObserverURL: testNewRelicSpanURL,
-		})
+		},
+		context.Background(),
+	)
 
 	require.NotNil(t, sink)
 	require.NoError(t, err)

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -147,7 +147,7 @@ func ParseConfig(
 // will be chosen, or none will.
 func Create(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	config veneur.Config, sinkConfig veneur.SpanSinkConfig,
+	config veneur.Config, sinkConfig veneur.SpanSinkConfig, ctx context.Context,
 ) (sinks.SpanSink, error) {
 	splunkConfig := sinkConfig.(SplunkSinkConfig)
 

--- a/sinks/splunk/splunk_internal_test.go
+++ b/sinks/splunk/splunk_internal_test.go
@@ -1,6 +1,7 @@
 package splunk
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -48,7 +49,9 @@ func TestWorkerCount(t *testing.T) {
 					HecTLSValidateHostname:      "",
 					HecToken:                    "00000000-0000-0000-0000-000000000000",
 					SpanSampleRate:              10,
-				})
+				},
+				context.Background(),
+			)
 			sss := sink.(*splunkSpanSink)
 			defer sss.Stop()
 			require.NoError(t, err)

--- a/sinks/splunk/splunk_test.go
+++ b/sinks/splunk/splunk_test.go
@@ -1,6 +1,7 @@
 package splunk_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -92,7 +93,9 @@ func TestSinkName(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              1,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	splunkSink := sink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -122,7 +125,9 @@ func TestSpanIngestBatch(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              1,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -211,7 +216,9 @@ func TestTimeout(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              1,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -286,7 +293,9 @@ func BenchmarkBatchIngest(b *testing.B) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              1,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(b, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 
@@ -345,7 +354,9 @@ func TestSampling(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              10,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -427,7 +438,9 @@ func TestSamplingIndicators(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              10,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)
@@ -513,7 +526,9 @@ func TestExcludedTagsIndicators(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              10,
-		})
+		},
+		context.Background(),
+	)
 
 	gesink := gsink.(excludableSink)
 	// no farts allowed
@@ -613,7 +628,9 @@ func TestClosedIngestionEndpoint(t *testing.T) {
 			HecTLSValidateHostname:      "",
 			HecToken:                    "00000000-0000-0000-0000-000000000000",
 			SpanSampleRate:              10,
-		})
+		},
+		context.Background(),
+	)
 	require.NoError(t, err)
 	sink := gsink.(splunk.TestableSplunkSpanSink)
 	err = sink.Start(nil)


### PR DESCRIPTION
#### Summary

This change migrates the falconer/grpc span sink to use the new config format.

#### Motivation
This work is part of enabling multi-sink routing.

#### Test plan
go test github.com/stripe/veneur/v14
go test github.com/stripe/veneur/v14/sinks/grpc