### PR TITLE
Add support for marshaling and unmarshaling regular expressions.

### DIFF
--- a/util/regexp.go
+++ b/util/regexp.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"fmt"
+	"encoding/json"
 	"regexp"
 )
 
@@ -16,7 +16,7 @@ func (r *Regexp) Decode(value string) error {
 }
 
 func (r Regexp) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", r.Value.String())), nil
+	return json.Marshal(r.Value.String())
 }
 
 func (r Regexp) MarshalYAML() (interface{}, error) {

--- a/util/regexp.go
+++ b/util/regexp.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type Regexp struct {
+	Value *regexp.Regexp
+}
+
+func (r *Regexp) Decode(value string) error {
+	var err error
+	r.Value, err = regexp.Compile(value)
+	return err
+}
+
+func (r Regexp) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", r.Value.String())), nil
+}
+
+func (r Regexp) MarshalYAML() (interface{}, error) {
+	return r.Value.String(), nil
+}
+
+func (r *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var value string
+	err := unmarshal(&value)
+	if err != nil {
+		return err
+	}
+	r.Value, err = regexp.Compile(value)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/util/regexp_test.go
+++ b/util/regexp_test.go
@@ -1,0 +1,53 @@
+package util_test
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/v14/util"
+	"gopkg.in/yaml.v3"
+)
+
+type regexpYamlStruct struct {
+	Regexp util.Regexp `yaml:"regexp"`
+}
+
+func TestRegexpMarshalJSON(t *testing.T) {
+	marshaledRegexp, err := json.Marshal(util.Regexp{
+		Value: regexp.MustCompile("^foo$"),
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "\"^foo$\"", string(marshaledRegexp))
+}
+
+func TestRegexpMarshalYAML(t *testing.T) {
+	marshaledRegexp, err := yaml.Marshal(util.Regexp{
+		Value: regexp.MustCompile("^foo$"),
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "^foo$\n", string(marshaledRegexp))
+}
+
+func TestRegexpUnmarshalYAML(t *testing.T) {
+	yamlFile := []byte(`regexp: ^foo$`)
+	data := regexpYamlStruct{}
+	err := yaml.Unmarshal(yamlFile, &data)
+	assert.Nil(t, err)
+	assert.True(t, data.Regexp.Value.MatchString("foo"))
+	assert.False(t, data.Regexp.Value.MatchString("bar"))
+}
+
+func TestRegexpDecode(t *testing.T) {
+	defer os.Unsetenv("ENVCONFIG_TEST_REGEXP")
+	os.Setenv("ENVCONFIG_TEST_REGEXP", "^foo$")
+
+	data := regexpYamlStruct{}
+	err := envconfig.Process("ENVCONFIG_TEST", &data)
+	assert.Nil(t, err)
+	assert.True(t, data.Regexp.Value.MatchString("foo"))
+	assert.False(t, data.Regexp.Value.MatchString("bar"))
+}

--- a/util/regexp_test.go
+++ b/util/regexp_test.go
@@ -24,6 +24,14 @@ func TestRegexpMarshalJSON(t *testing.T) {
 	assert.Equal(t, "\"^foo$\"", string(marshaledRegexp))
 }
 
+func TestRegexpMarshalJSONWithSpecialCharacters(t *testing.T) {
+	marshaledRegexp, err := json.Marshal(util.Regexp{
+		Value: regexp.MustCompile("^foo\"bar$"),
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "\"^foo\\\"bar$\"", string(marshaledRegexp))
+}
+
 func TestRegexpMarshalYAML(t *testing.T) {
 	marshaledRegexp, err := yaml.Marshal(util.Regexp{
 		Value: regexp.MustCompile("^foo$"),


### PR DESCRIPTION
#### Summary
This change add support for marshaling and unmarshaling regular expressions.

#### Motivation
This will be used in the openmetrics source.

#### Test plan
```
go test github.com/stripe/veneur/v14/util
```