### PR TITLE
Add signalfx_vary_key_by_favor_common_dimensions config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -105,38 +105,39 @@ type Config struct {
 		APIKey util.StringSecret `yaml:"api_key"`
 		Name   string            `yaml:"name"`
 	} `yaml:"signalfx_per_tag_api_keys"`
-	SignalfxVaryKeyBy                 string            `yaml:"signalfx_vary_key_by"`
-	Sources                           []SourceConfig    `yaml:"sources"`
-	SpanChannelCapacity               int               `yaml:"span_channel_capacity"`
-	SpanSinks                         []SinkConfig      `yaml:"span_sinks"`
-	SplunkHecAddress                  string            `yaml:"splunk_hec_address"`
-	SplunkHecBatchSize                int               `yaml:"splunk_hec_batch_size"`
-	SplunkHecConnectionLifetimeJitter time.Duration     `yaml:"splunk_hec_connection_lifetime_jitter"`
-	SplunkHecIngestTimeout            time.Duration     `yaml:"splunk_hec_ingest_timeout"`
-	SplunkHecMaxConnectionLifetime    time.Duration     `yaml:"splunk_hec_max_connection_lifetime"`
-	SplunkHecSendTimeout              time.Duration     `yaml:"splunk_hec_send_timeout"`
-	SplunkHecSubmissionWorkers        int               `yaml:"splunk_hec_submission_workers"`
-	SplunkHecTLSValidateHostname      string            `yaml:"splunk_hec_tls_validate_hostname"`
-	SplunkHecToken                    string            `yaml:"splunk_hec_token"`
-	SplunkSpanSampleRate              int               `yaml:"splunk_span_sample_rate"`
-	SsfBufferSize                     int               `yaml:"ssf_buffer_size"`
-	SsfListenAddresses                []util.Url        `yaml:"ssf_listen_addresses"`
-	StatsAddress                      string            `yaml:"stats_address"`
-	StatsdListenAddresses             []util.Url        `yaml:"statsd_listen_addresses"`
-	SynchronizeWithInterval           bool              `yaml:"synchronize_with_interval"`
-	Tags                              []string          `yaml:"tags"`
-	TagsExclude                       []string          `yaml:"tags_exclude"`
-	TLSAuthorityCertificate           string            `yaml:"tls_authority_certificate"`
-	TLSCertificate                    string            `yaml:"tls_certificate"`
-	TLSKey                            util.StringSecret `yaml:"tls_key"`
-	TraceLightstepAccessToken         util.StringSecret `yaml:"trace_lightstep_access_token"`
-	TraceLightstepCollectorHost       string            `yaml:"trace_lightstep_collector_host"`
-	TraceLightstepMaximumSpans        int               `yaml:"trace_lightstep_maximum_spans"`
-	TraceLightstepNumClients          int               `yaml:"trace_lightstep_num_clients"`
-	TraceLightstepReconnectPeriod     string            `yaml:"trace_lightstep_reconnect_period"`
-	TraceMaxLengthBytes               int               `yaml:"trace_max_length_bytes"`
-	VeneurMetricsAdditionalTags       []string          `yaml:"veneur_metrics_additional_tags"`
-	VeneurMetricsScopes               struct {
+	SignalfxVaryKeyBy                      string            `yaml:"signalfx_vary_key_by"`
+	SignalfxVaryKeyByFavorCommonDimensions bool              `yaml:"signalfx_vary_key_by_favor_common_dimensions"`
+	Sources                                []SourceConfig    `yaml:"sources"`
+	SpanChannelCapacity                    int               `yaml:"span_channel_capacity"`
+	SpanSinks                              []SinkConfig      `yaml:"span_sinks"`
+	SplunkHecAddress                       string            `yaml:"splunk_hec_address"`
+	SplunkHecBatchSize                     int               `yaml:"splunk_hec_batch_size"`
+	SplunkHecConnectionLifetimeJitter      time.Duration     `yaml:"splunk_hec_connection_lifetime_jitter"`
+	SplunkHecIngestTimeout                 time.Duration     `yaml:"splunk_hec_ingest_timeout"`
+	SplunkHecMaxConnectionLifetime         time.Duration     `yaml:"splunk_hec_max_connection_lifetime"`
+	SplunkHecSendTimeout                   time.Duration     `yaml:"splunk_hec_send_timeout"`
+	SplunkHecSubmissionWorkers             int               `yaml:"splunk_hec_submission_workers"`
+	SplunkHecTLSValidateHostname           string            `yaml:"splunk_hec_tls_validate_hostname"`
+	SplunkHecToken                         string            `yaml:"splunk_hec_token"`
+	SplunkSpanSampleRate                   int               `yaml:"splunk_span_sample_rate"`
+	SsfBufferSize                          int               `yaml:"ssf_buffer_size"`
+	SsfListenAddresses                     []util.Url        `yaml:"ssf_listen_addresses"`
+	StatsAddress                           string            `yaml:"stats_address"`
+	StatsdListenAddresses                  []util.Url        `yaml:"statsd_listen_addresses"`
+	SynchronizeWithInterval                bool              `yaml:"synchronize_with_interval"`
+	Tags                                   []string          `yaml:"tags"`
+	TagsExclude                            []string          `yaml:"tags_exclude"`
+	TLSAuthorityCertificate                string            `yaml:"tls_authority_certificate"`
+	TLSCertificate                         string            `yaml:"tls_certificate"`
+	TLSKey                                 util.StringSecret `yaml:"tls_key"`
+	TraceLightstepAccessToken              util.StringSecret `yaml:"trace_lightstep_access_token"`
+	TraceLightstepCollectorHost            string            `yaml:"trace_lightstep_collector_host"`
+	TraceLightstepMaximumSpans             int               `yaml:"trace_lightstep_maximum_spans"`
+	TraceLightstepNumClients               int               `yaml:"trace_lightstep_num_clients"`
+	TraceLightstepReconnectPeriod          string            `yaml:"trace_lightstep_reconnect_period"`
+	TraceMaxLengthBytes                    int               `yaml:"trace_max_length_bytes"`
+	VeneurMetricsAdditionalTags            []string          `yaml:"veneur_metrics_additional_tags"`
+	VeneurMetricsScopes                    struct {
 		Counter   string `yaml:"counter"`
 		Gauge     string `yaml:"gauge"`
 		Histogram string `yaml:"histogram"`

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -156,31 +156,33 @@ type SignalFxSinkConfig struct {
 		APIKey util.StringSecret `yaml:"api_key"`
 		Name   string            `yaml:"name"`
 	} `yaml:"per_tag_api_keys"`
-	VaryKeyBy string `yaml:"vary_key_by"`
+	VaryKeyBy                      string `yaml:"vary_key_by"`
+	VaryKeyByFavorCommonDimensions bool   `yaml:"vary_key_by_favor_common_dimensions"`
 }
 
 // SignalFxSink is a MetricsSink implementation.
 type SignalFxSink struct {
-	apiEndpoint               string
-	clientsByTagValue         map[string]DPClient
-	clientsByTagValueMu       *sync.RWMutex
-	commonDimensions          map[string]string
-	defaultClient             DPClient
-	defaultToken              string
-	dynamicKeyRefreshPeriod   time.Duration
-	enableDynamicPerTagTokens bool
-	excludedTags              map[string]struct{}
-	hostname                  string
-	hostnameTag               string
-	httpClient                *http.Client
-	log                       *logrus.Entry
-	maxPointsInBatch          int
-	metricNamePrefixDrops     []string
-	metricsEndpoint           string
-	metricTagPrefixDrops      []string
-	name                      string
-	traceClient               *trace.Client
-	varyBy                    string
+	apiEndpoint                 string
+	clientsByTagValue           map[string]DPClient
+	clientsByTagValueMu         *sync.RWMutex
+	commonDimensions            map[string]string
+	defaultClient               DPClient
+	defaultToken                string
+	dynamicKeyRefreshPeriod     time.Duration
+	enableDynamicPerTagTokens   bool
+	excludedTags                map[string]struct{}
+	hostname                    string
+	hostnameTag                 string
+	httpClient                  *http.Client
+	log                         *logrus.Entry
+	maxPointsInBatch            int
+	metricNamePrefixDrops       []string
+	metricsEndpoint             string
+	metricTagPrefixDrops        []string
+	name                        string
+	traceClient                 *trace.Client
+	varyBy                      string
+	varyByFavorCommonDimensions bool
 }
 
 // A DPClient is a client that can be used to submit signalfx data
@@ -234,6 +236,7 @@ func MigrateConfig(conf *veneur.Config) error {
 			MetricTagPrefixDrops:              conf.SignalfxMetricTagPrefixDrops,
 			PerTagAPIKeys:                     conf.SignalfxPerTagAPIKeys,
 			VaryKeyBy:                         conf.SignalfxVaryKeyBy,
+			VaryKeyByFavorCommonDimensions:    conf.SignalfxVaryKeyByFavorCommonDimensions,
 		},
 	})
 	return nil
@@ -321,24 +324,25 @@ func newSignalFxSink(
 	}
 
 	return &SignalFxSink{
-		apiEndpoint:               endpointStr,
-		clientsByTagValue:         perTagClients,
-		clientsByTagValueMu:       &sync.RWMutex{},
-		commonDimensions:          commonDimensions,
-		defaultClient:             client,
-		defaultToken:              config.APIKey.Value,
-		dynamicKeyRefreshPeriod:   config.DynamicPerTagAPIKeysRefreshPeriod,
-		enableDynamicPerTagTokens: config.DynamicPerTagAPIKeysEnable,
-		hostname:                  hostname,
-		hostnameTag:               config.HostnameTag,
-		httpClient:                httpClient,
-		log:                       log,
-		maxPointsInBatch:          config.FlushMaxPerBody,
-		metricNamePrefixDrops:     config.MetricNamePrefixDrops,
-		metricsEndpoint:           config.EndpointBase,
-		metricTagPrefixDrops:      config.MetricTagPrefixDrops,
-		name:                      name,
-		varyBy:                    config.VaryKeyBy,
+		apiEndpoint:                 endpointStr,
+		clientsByTagValue:           perTagClients,
+		clientsByTagValueMu:         &sync.RWMutex{},
+		commonDimensions:            commonDimensions,
+		defaultClient:               client,
+		defaultToken:                config.APIKey.Value,
+		dynamicKeyRefreshPeriod:     config.DynamicPerTagAPIKeysRefreshPeriod,
+		enableDynamicPerTagTokens:   config.DynamicPerTagAPIKeysEnable,
+		hostname:                    hostname,
+		hostnameTag:                 config.HostnameTag,
+		httpClient:                  httpClient,
+		log:                         log,
+		maxPointsInBatch:            config.FlushMaxPerBody,
+		metricNamePrefixDrops:       config.MetricNamePrefixDrops,
+		metricsEndpoint:             config.EndpointBase,
+		metricTagPrefixDrops:        config.MetricTagPrefixDrops,
+		name:                        name,
+		varyBy:                      config.VaryKeyBy,
+		varyByFavorCommonDimensions: config.VaryKeyByFavorCommonDimensions,
 	}, nil
 }
 
@@ -557,26 +561,22 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 
 		metricKey := ""
 
-		// Metric-specified API key, if present, should override the common dimension
+		// Datapoint-specified vary_key_by value, if present, should override the common dimension unless
+		// vary_key_by_favor_common_dimensions is set to true
 		metricOverrodeVaryBy := false
 		if sfx.varyBy != "" {
-			if _, ok := dims[sfx.varyBy]; ok {
+			if val, ok := dims[sfx.varyBy]; ok {
 				metricOverrodeVaryBy = true
+				metricKey = val
 			}
 		}
 
-		// Copy common dimensions, except for sfx.varyBy
+		// Copy applicable common dimensions
 		for k, v := range sfx.commonDimensions {
-			if metricOverrodeVaryBy && k == sfx.varyBy {
+			if metricOverrodeVaryBy && k == sfx.varyBy && !sfx.varyByFavorCommonDimensions {
 				continue
 			}
 			dims[k] = v
-		}
-
-		if sfx.varyBy != "" {
-			if val, ok := dims[sfx.varyBy]; ok {
-				metricKey = val
-			}
 		}
 
 		for k := range sfx.excludedTags {

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -579,6 +579,12 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 			dims[k] = v
 		}
 
+		if sfx.varyBy != "" && metricKey == "" {
+			if val, ok := dims[sfx.varyBy]; ok {
+				metricKey = val
+			}
+		}
+
 		for k := range sfx.excludedTags {
 			delete(dims, k)
 		}

--- a/testdata/http_test_config.json
+++ b/testdata/http_test_config.json
@@ -1,5 +1,9 @@
 {
-  "Aggregates": ["min", "max", "count"],
+  "Aggregates": [
+    "min",
+    "max",
+    "count"
+  ],
   "AwsAccessKeyID": "",
   "AwsRegion": "",
   "AwsS3Bucket": "",
@@ -78,7 +82,11 @@
   "NumWorkers": 0,
   "ObjectiveSpanTimerName": "",
   "OmitEmptyHostname": false,
-  "Percentiles": [0.5, 0.75, 0.99],
+  "Percentiles": [
+    0.5,
+    0.75,
+    0.99
+  ],
   "PrometheusNetworkType": "",
   "PrometheusRepeaterAddress": "",
   "ReadBufferSizeBytes": 2097152,
@@ -94,7 +102,7 @@
   "SignalfxMetricTagPrefixDrops": null,
   "SignalfxPerTagAPIKeys": null,
   "SignalfxVaryKeyBy": "",
-  "SignalfxVaryKeyByFavorCommonDimensions": "",
+  "SignalfxVaryKeyByFavorCommonDimensions": false,
   "Sources": null,
   "SpanChannelCapacity": 0,
   "SpanSinks": null,

--- a/testdata/http_test_config.json
+++ b/testdata/http_test_config.json
@@ -1,9 +1,5 @@
 {
-  "Aggregates": [
-    "min",
-    "max",
-    "count"
-  ],
+  "Aggregates": ["min", "max", "count"],
   "AwsAccessKeyID": "",
   "AwsRegion": "",
   "AwsS3Bucket": "",
@@ -82,11 +78,7 @@
   "NumWorkers": 0,
   "ObjectiveSpanTimerName": "",
   "OmitEmptyHostname": false,
-  "Percentiles": [
-    0.5,
-    0.75,
-    0.99
-  ],
+  "Percentiles": [0.5, 0.75, 0.99],
   "PrometheusNetworkType": "",
   "PrometheusRepeaterAddress": "",
   "ReadBufferSizeBytes": 2097152,
@@ -102,6 +94,7 @@
   "SignalfxMetricTagPrefixDrops": null,
   "SignalfxPerTagAPIKeys": null,
   "SignalfxVaryKeyBy": "",
+  "SignalfxVaryKeyByFavorCommonDimensions": "",
   "Sources": null,
   "SpanChannelCapacity": 0,
   "SpanSinks": null,

--- a/testdata/http_test_config.yaml
+++ b/testdata/http_test_config.yaml
@@ -97,6 +97,7 @@ signalfx_metric_name_prefix_drops: []
 signalfx_metric_tag_prefix_drops: []
 signalfx_per_tag_api_keys: []
 signalfx_vary_key_by: ""
+signalfx_vary_key_by_favor_common_dimensions: false
 sources: []
 span_channel_capacity: 0
 span_sinks: []


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

cc @stripe/observability @arnavdugar-stripe 

Adds a `signalfx_vary_key_by_favor_common_dimensions` config option for the SignalFx sink. This flag modifies the behavior of the existing `signalfx_vary_key_by` option, which is used to declare a dimension key for which the dimension's values determine which SignalFx API key is used to submit datapoints to SignalFx. **This PR is fully backwards compatible with previous versions of Veneur - it is functionally a no-op unless the new config option is specified**.

If `signalfx_vary_key_by` is set to a dimension key that is also set with `tags` (i.e. `common_dimensions`), then the value of the common dimension will not override the value set by a datapoint that explicitly sets the dimension. With this PR, if `signalfx_vary_key_by_favor_common_dimensions` is set to false (as it is by default, if this config option is not specified), then this behavior is preserved.

However, if the value is set to true, then the value of the common dimension will override the value set on the datapoint for the purposes of the _dimension value, as submitted to SignalFx_. The datapoint itself will still be submitted under the API key set on the datapoint, as is the existing behavior.

#### Motivation
<!-- Why are you making this change? -->
Allows additional expressiveness for SignalFx attribution, billing, and rate limiting use cases.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
- [x] Wrote new automated test
- [x] Amended existing varyBy automated test
- [x] Rolled out and serving traffic within Stripe environment

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Merge and cut new release