### PR TITLE
Move importsrv into the sources directory.

### DIFF
--- a/server.go
+++ b/server.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/pkg/profile"
 
-	"github.com/stripe/veneur/v14/importsrv"
 	"github.com/stripe/veneur/v14/protocol"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/scopedstatsd"
@@ -39,6 +38,7 @@ import (
 	"github.com/stripe/veneur/v14/sinks/lightstep"
 	"github.com/stripe/veneur/v14/sinks/ssfmetrics"
 	"github.com/stripe/veneur/v14/sources"
+	"github.com/stripe/veneur/v14/sources/proxy"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/tagging"
 	"github.com/stripe/veneur/v14/trace"
@@ -165,7 +165,7 @@ type Server struct {
 
 	// gRPC server
 	grpcListenAddress string
-	grpcServer        *importsrv.Server
+	grpcServer        *proxy.Server
 
 	// gRPC forward clients
 	grpcForwardConn *grpc.ClientConn
@@ -706,13 +706,13 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 	ret.grpcListenAddress = conf.GrpcAddress
 	if ret.grpcListenAddress != "" {
 		// convert all the workers to the proper interface
-		ingesters := make([]importsrv.MetricIngester, len(ret.Workers))
+		ingesters := make([]proxy.MetricIngester, len(ret.Workers))
 		for i, worker := range ret.Workers {
 			ingesters[i] = worker
 		}
 
-		ret.grpcServer = importsrv.New(ingesters,
-			importsrv.WithTraceClient(ret.TraceClient))
+		ret.grpcServer = proxy.New(ingesters,
+			proxy.WithTraceClient(ret.TraceClient))
 	}
 
 	ret.sources, err = ret.createSources(logger, &conf, config.SourceTypes)

--- a/server_test.go
+++ b/server_test.go
@@ -1456,7 +1456,9 @@ func TestServeStopGRPC(t *testing.T) {
 	}()
 
 	// Stop the gRPC server only.  This should cause Serve to exit
-	s.gRPCStop()
+	assert.Len(t, s.sources, 1)
+	assert.Equal(t, s.sources[0].Name(), "proxy")
+	s.sources[0].Stop()
 
 	select {
 	case <-done:

--- a/sources/proxy/options.go
+++ b/sources/proxy/options.go
@@ -1,4 +1,4 @@
-package importsrv
+package proxy
 
 import "github.com/stripe/veneur/v14/trace"
 

--- a/sources/proxy/server.go
+++ b/sources/proxy/server.go
@@ -3,7 +3,7 @@
 // The Server wraps a grpc.Server, and implements the forwardrpc.Forward
 // service.  It receives batches of metrics, then hashes them to a specific
 // "MetricIngester" and forwards them on.
-package importsrv
+package proxy
 
 import (
 	"fmt"

--- a/sources/proxy/server.go
+++ b/sources/proxy/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/segmentio/fasthash/fnv1a"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
 	"github.com/stripe/veneur/v14/forwardrpc"
@@ -37,6 +38,7 @@ type MetricIngester interface {
 // should always be routed to the same MetricIngester.
 type Server struct {
 	*grpc.Server
+	address    string
 	metricOuts []MetricIngester
 	opts       *options
 }
@@ -51,8 +53,9 @@ type Option func(*options)
 
 // New creates an unstarted Server with the input MetricIngester's to send
 // output to.
-func New(metricOuts []MetricIngester, opts ...Option) *Server {
+func New(address string, metricOuts []MetricIngester, opts ...Option) *Server {
 	res := &Server{
+		address:    address,
 		Server:     grpc.NewServer(),
 		metricOuts: metricOuts,
 		opts:       &options{},
@@ -71,17 +74,38 @@ func New(metricOuts []MetricIngester, opts ...Option) *Server {
 	return res
 }
 
-// Serve starts a gRPC listener on the specified address and blocks while
+func (s *Server) Name() string {
+	return "proxy"
+}
+
+// Start starts a gRPC listener on the specified address and blocks while
 // listening for requests. If listening is interrupted by some means other
 // than Stop or GracefulStop being called, it returns a non-nil error.
-func (s *Server) Serve(addr string) error {
-	ln, err := net.Listen("tcp", addr)
+//
+// TODO this doesn't handle SIGUSR2 and SIGHUP on it's own, unlike HTTPServe
+// As long as both are running this is actually fine, as Start will stop
+// the gRPC server when the HTTP one exits.  When running just gRPC however,
+// the signal handling won't work.
+func (s *Server) Start() error {
+	entry := logrus.WithFields(logrus.Fields{"address": s.address})
+	entry.Info("Starting gRPC server")
+
+	listener, err := net.Listen("tcp", s.address)
 	if err != nil {
 		return fmt.Errorf("failed to bind the import server to '%s': %v",
-			addr, err)
+			s.address, err)
 	}
 
-	return s.Server.Serve(ln)
+	err = s.Server.Serve(listener)
+	if err != nil {
+		entry.WithError(err).Error("gRPC server was not shut down cleanly")
+	}
+	entry.Info("Stopped gRPC server")
+	return err
+}
+
+func (s *Server) Stop() {
+	s.GracefulStop()
 }
 
 // Static maps of tags used in the SendMetrics handler

--- a/sources/proxy/server_test.go
+++ b/sources/proxy/server_test.go
@@ -35,7 +35,7 @@ func TestSendMetrics_ConsistentHash(t *testing.T) {
 	for i, ingester := range ingesters {
 		casted[i] = ingester
 	}
-	s := New(casted)
+	s := New("localhost", casted)
 
 	inputs := []*metricpb.Metric{{
 		Name: "test.counter",
@@ -73,7 +73,7 @@ func TestSendMetrics_ConsistentHash(t *testing.T) {
 
 func TestSendMetrics_Empty(t *testing.T) {
 	ingester := &testMetricIngester{}
-	s := New([]MetricIngester{ingester})
+	s := New("localhost", []MetricIngester{ingester})
 	s.SendMetrics(context.Background(), &forwardrpc.MetricList{})
 
 	assert.Empty(t, ingester.metrics,
@@ -86,7 +86,7 @@ func TestOptions_WithTraceClient(t *testing.T) {
 		t.Fatalf("failed to initialize a trace client: %v", err)
 	}
 
-	s := New([]MetricIngester{}, WithTraceClient(c))
+	s := New("localhost", []MetricIngester{}, WithTraceClient(c))
 	assert.Equal(t, c, s.opts.traceClient,
 		"WithTraceClient didn't correctly set the trace client")
 }
@@ -135,7 +135,7 @@ func BenchmarkImportServerSendMetrics(b *testing.B) {
 			defer ingester.stop()
 			ingesters[i] = ingester
 		}
-		s := New(ingesters)
+		s := New("localhost", ingesters)
 		ctx := context.Background()
 		input := &forwardrpc.MetricList{Metrics: metrics[:inputSize]}
 

--- a/sources/proxy/server_test.go
+++ b/sources/proxy/server_test.go
@@ -1,4 +1,4 @@
-package importsrv
+package proxy
 
 import (
 	"context"
@@ -29,7 +29,7 @@ func (mi *testMetricIngester) clear() {
 // Test that sending the same metric to a Veneur results in it being hashed
 // to the same worker every time
 func TestSendMetrics_ConsistentHash(t *testing.T) {
-	ingesters := []*testMetricIngester{&testMetricIngester{}, &testMetricIngester{}}
+	ingesters := []*testMetricIngester{{}, {}}
 
 	casted := make([]MetricIngester, len(ingesters))
 	for i, ingester := range ingesters {
@@ -37,17 +37,28 @@ func TestSendMetrics_ConsistentHash(t *testing.T) {
 	}
 	s := New(casted)
 
-	inputs := []*metricpb.Metric{
-		&metricpb.Metric{Name: "test.counter", Type: metricpb.Type_Counter, Tags: []string{"tag:1"}},
-		&metricpb.Metric{Name: "test.gauge", Type: metricpb.Type_Gauge},
-		&metricpb.Metric{Name: "test.histogram", Type: metricpb.Type_Histogram, Tags: []string{"type:histogram"}},
-		&metricpb.Metric{Name: "test.set", Type: metricpb.Type_Set},
-		&metricpb.Metric{Name: "test.gauge3", Type: metricpb.Type_Gauge},
-	}
+	inputs := []*metricpb.Metric{{
+		Name: "test.counter",
+		Type: metricpb.Type_Counter,
+		Tags: []string{"tag:1"},
+	}, {
+		Name: "test.gauge",
+		Type: metricpb.Type_Gauge,
+	}, {
+		Name: "test.histogram",
+		Type: metricpb.Type_Histogram,
+		Tags: []string{"type:histogram"},
+	}, {
+		Name: "test.set",
+		Type: metricpb.Type_Set,
+	}, {
+		Name: "test.gauge3",
+		Type: metricpb.Type_Gauge,
+	}}
 
 	// Send the same inputs many times
 	for i := 0; i < 10; i++ {
-		s.SendMetrics(context.Background(), &forwardrpc.MetricList{inputs})
+		s.SendMetrics(context.Background(), &forwardrpc.MetricList{Metrics: inputs})
 
 		assert.Equal(t, []*metricpb.Metric{inputs[0], inputs[4]},
 			ingesters[0].metrics, "Ingester 0 has the wrong metrics")
@@ -65,8 +76,8 @@ func TestSendMetrics_Empty(t *testing.T) {
 	s := New([]MetricIngester{ingester})
 	s.SendMetrics(context.Background(), &forwardrpc.MetricList{})
 
-	assert.Empty(t, ingester.metrics, "The server shouldn't have submitted "+
-		"any metrics")
+	assert.Empty(t, ingester.metrics,
+		"The server shouldn't have submitted any metrics")
 }
 
 func TestOptions_WithTraceClient(t *testing.T) {
@@ -76,8 +87,8 @@ func TestOptions_WithTraceClient(t *testing.T) {
 	}
 
 	s := New([]MetricIngester{}, WithTraceClient(c))
-	assert.Equal(t, c, s.opts.traceClient, "WithTraceClient didn't correctly "+
-		"set the trace client")
+	assert.Equal(t, c, s.opts.traceClient,
+		"WithTraceClient didn't correctly set the trace client")
 }
 
 type noopChannelMetricIngester struct {


### PR DESCRIPTION
#### Summary
This change creates a source for `veneur-proxy` in the sources directory.

#### Motivation
This change helps establish a rigid abstraction barrier between metrics sources and Veneur's core logic.
