### PR TITLE
Move logic for querying openmetrics into an openmetrics source.

### DIFF
--- a/cmd/veneur-prometheus/main.go
+++ b/cmd/veneur-prometheus/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/veneur/v14/sources/openmetrics"
 )
 
 var (
@@ -78,7 +79,7 @@ func collect(
 		"ignored_metrics": cfg.ignoredMetrics,
 	}).Debug("beginning collection")
 
-	prometheus, err := QueryPrometheus(
+	prometheus, err := openmetrics.Query(
 		ctx, cfg.httpClient, cfg.metricsHost, cfg.ignoredMetrics)
 	if err != nil {
 		statsClient.Incr("veneur.prometheus.connect_errors_total", nil, 1.0)

--- a/cmd/veneur-prometheus/prometheus_test.go
+++ b/cmd/veneur-prometheus/prometheus_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,23 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestShouldExportMetric(t *testing.T) {
-	metric1Name := "metric1Name"
-
-	mf := dto.MetricFamily{
-		Name: &metric1Name,
-	}
-
-	ignoredMetrics1 := []*regexp.Regexp{
-		regexp.MustCompile(".*0.*"),
-		regexp.MustCompile(".*1.*"),
-	}
-	ignoredMetrics2 := []*regexp.Regexp{regexp.MustCompile(".*2.*")}
-
-	assert.False(t, shouldExportMetric(mf, ignoredMetrics1))
-	assert.True(t, shouldExportMetric(mf, ignoredMetrics2))
-}
 
 func TestPrometheusCounterIsEverIncreasing(t *testing.T) {
 

--- a/cmd/veneur-prometheus/translate.go
+++ b/cmd/veneur-prometheus/translate.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stripe/veneur/v14/sources/openmetrics"
 )
 
 var (
@@ -15,7 +16,7 @@ var (
 	flushedMetricsID        = statID{"veneur.prometheus.metrics_flushed_total", nil}
 )
 
-func translatePrometheus(cfg prometheusConfig, cache *countCache, prometheus <-chan PrometheusResults) <-chan []statsdStat {
+func translatePrometheus(cfg prometheusConfig, cache *countCache, prometheus <-chan openmetrics.PrometheusResults) <-chan []statsdStat {
 	statsd := make(chan []statsdStat)
 	s := sender{statsd, cache}
 	t := translator{
@@ -28,7 +29,7 @@ func translatePrometheus(cfg prometheusConfig, cache *countCache, prometheus <-c
 	return statsd
 }
 
-func sendTranslated(prometheus <-chan PrometheusResults, translate translator, s sender) {
+func sendTranslated(prometheus <-chan openmetrics.PrometheusResults, translate translator, s sender) {
 
 	count := int64(0)
 	unknown := int64(0)

--- a/sources/openmetrics/openmetrics.go
+++ b/sources/openmetrics/openmetrics.go
@@ -1,4 +1,4 @@
-package main
+package openmetrics
 
 import (
 	"context"
@@ -16,7 +16,7 @@ type PrometheusResults struct {
 	Error        error
 }
 
-func QueryPrometheus(
+func Query(
 	ctx context.Context, httpClient *http.Client, host string,
 	ignoredMetrics []*regexp.Regexp,
 ) (<-chan PrometheusResults, error) {

--- a/sources/openmetrics/prometheus_test.go
+++ b/sources/openmetrics/prometheus_test.go
@@ -1,0 +1,26 @@
+package openmetrics
+
+import (
+	"regexp"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldExportMetric(t *testing.T) {
+	metric1Name := "metric1Name"
+
+	mf := dto.MetricFamily{
+		Name: &metric1Name,
+	}
+
+	ignoredMetrics1 := []*regexp.Regexp{
+		regexp.MustCompile(".*0.*"),
+		regexp.MustCompile(".*1.*"),
+	}
+	ignoredMetrics2 := []*regexp.Regexp{regexp.MustCompile(".*2.*")}
+
+	assert.False(t, shouldExportMetric(mf, ignoredMetrics1))
+	assert.True(t, shouldExportMetric(mf, ignoredMetrics2))
+}


### PR DESCRIPTION
#### Summary
Move logic for querying openmetrics into an openmetrics source.

#### Motivation
This is a step towards creating an explicit openmetrics source.
