### PR TITLE
Add marshaling support to sink_routing.go.

### DIFF
--- a/docs/dev.yaml
+++ b/docs/dev.yaml
@@ -18,6 +18,9 @@ percentiles:
   - 0.50
   - 0.90
 
+http_address: 0.0.0.0:9085
+http:
+  config: true
 debug: true
 debug_ingested_spans: true
 debug_flushed_metrics: true

--- a/sink_routing.go
+++ b/sink_routing.go
@@ -17,10 +17,21 @@ type MatcherConfig struct {
 	Tags []TagMatcher `yaml:"tags"`
 }
 
+type NameMatcherConfig struct {
+	Kind  string `yaml:"kind"`
+	Value string `yaml:"value"`
+}
+
 type NameMatcher struct {
 	Kind  string `yaml:"kind"`
 	match func(string) bool
 	regex *regexp.Regexp
+	Value string `yaml:"value"`
+}
+
+type TagMatcherConfig struct {
+	Kind  string `yaml:"kind"`
+	Unset bool   `yaml:"unset"`
 	Value string `yaml:"value"`
 }
 
@@ -42,11 +53,13 @@ type SinkRoutingSinks struct {
 func (matcher *NameMatcher) UnmarshalYAML(
 	unmarshal func(interface{}) error,
 ) error {
-	config := NameMatcher{}
+	config := NameMatcherConfig{}
 	err := unmarshal(&config)
 	if err != nil {
 		return err
 	}
+
+	matcher.Kind = config.Kind
 	switch config.Kind {
 	case "any":
 		matcher.match = matcher.matchAny
@@ -63,6 +76,8 @@ func (matcher *NameMatcher) UnmarshalYAML(
 	default:
 		return fmt.Errorf("unknown matcher kind \"%s\"", config.Kind)
 	}
+	matcher.Value = config.Value
+
 	return nil
 }
 
@@ -87,11 +102,13 @@ func (matcher *NameMatcher) matchRegex(value string) bool {
 func (matcher *TagMatcher) UnmarshalYAML(
 	unmarshal func(interface{}) error,
 ) error {
-	config := TagMatcher{}
+	config := TagMatcherConfig{}
 	err := unmarshal(&config)
 	if err != nil {
 		return err
 	}
+
+	matcher.Kind = config.Kind
 	switch config.Kind {
 	case "exact":
 		matcher.match = matcher.matchExact
@@ -106,6 +123,9 @@ func (matcher *TagMatcher) UnmarshalYAML(
 	default:
 		return fmt.Errorf("unknown matcher kind \"%s\"", config.Kind)
 	}
+	matcher.Unset = config.Unset
+	matcher.Value = config.Value
+
 	return nil
 }
 

--- a/sink_routing_test.go
+++ b/sink_routing_test.go
@@ -341,29 +341,7 @@ match:
 
 func TestMarshall(t *testing.T) {
 	config := veneur.SinkRoutingConfig{}
-	yamlString := []byte(`---
-name: test
-match:
-  - name:
-      kind: exact
-      value: aa
-    tags:
-      - kind: exact
-        value: ab
-  - name:
-      kind: exact
-      value: bb
-    tags:
-      - kind: prefix
-        value: aa
-        unset: true 
-`)
-
-	require.NoError(t, yaml.Unmarshal(yamlString, &config))
-	actualYaml, err := yaml.Marshal(config)
-	require.NoError(t, err)
-
-	expectedYaml := `name: test
+	yamlString := `name: test
 match:
     - name:
         kind: exact
@@ -380,8 +358,14 @@ match:
           unset: true
           value: aa
 sinks:
-    matched: []
-    not_matched: []
+    matched:
+        - sink1
+    not_matched:
+        - sink2
 `
-	assert.Equal(t, expectedYaml, string(actualYaml))
+
+	require.NoError(t, yaml.Unmarshal([]byte(yamlString), &config))
+	actualYaml, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	assert.Equal(t, yamlString, string(actualYaml))
 }

--- a/sink_routing_test.go
+++ b/sink_routing_test.go
@@ -338,3 +338,50 @@ match:
 	assert.True(t, config.Match("aa", []string{"ab", "baab"}))
 	assert.False(t, config.Match("bb", []string{"ab", "baab"}))
 }
+
+func TestMarshall(t *testing.T) {
+	config := veneur.SinkRoutingConfig{}
+	yamlString := []byte(`---
+name: test
+match:
+  - name:
+      kind: exact
+      value: aa
+    tags:
+      - kind: exact
+        value: ab
+  - name:
+      kind: exact
+      value: bb
+    tags:
+      - kind: prefix
+        value: aa
+        unset: true 
+`)
+
+	require.NoError(t, yaml.Unmarshal(yamlString, &config))
+	actualYaml, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	expectedYaml := `name: test
+match:
+    - name:
+        kind: exact
+        value: aa
+      tags:
+        - kind: exact
+          unset: false
+          value: ab
+    - name:
+        kind: exact
+        value: bb
+      tags:
+        - kind: prefix
+          unset: true
+          value: aa
+sinks:
+    matched: []
+    not_matched: []
+`
+	assert.Equal(t, expectedYaml, string(actualYaml))
+}


### PR DESCRIPTION
#### Summary
This change fixes displaying the sink routing rules when marshaling Veneur's configuration.
