### PR TITLE
Remove the global logger.

### DIFF
--- a/cmd/veneur-proxy/main.go
+++ b/cmd/veneur-proxy/main.go
@@ -19,12 +19,13 @@ func init() {
 
 func main() {
 	flag.Parse()
+	logger := logrus.StandardLogger()
 
 	if configFile == nil || *configFile == "" {
 		logrus.Fatal("You must specify a config file")
 	}
 
-	conf, err := veneur.ReadProxyConfig(*configFile)
+	conf, err := veneur.ReadProxyConfig(logrus.NewEntry(logger), *configFile)
 	if err != nil {
 		if _, ok := err.(*veneur.UnknownConfigKeys); ok {
 			logrus.WithError(err).Warn("Config contains invalid or deprecated keys")
@@ -33,9 +34,7 @@ func main() {
 		}
 	}
 
-	logger := logrus.StandardLogger()
 	proxy, err := veneur.NewProxyFromConfig(logger, conf)
-	veneur.SetLogger(logger)
 
 	ssf.NamePrefix = "veneur_proxy."
 

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -37,12 +37,13 @@ func init() {
 
 func main() {
 	flag.Parse()
+	logger := logrus.StandardLogger()
 
 	if configFile == nil || *configFile == "" {
 		logrus.Fatal("You must specify a config file")
 	}
 
-	conf, err := veneur.ReadConfig(*configFile)
+	conf, err := veneur.ReadConfig(logrus.NewEntry(logger), *configFile)
 	if err != nil {
 		if _, ok := err.(*veneur.UnknownConfigKeys); ok {
 			if *validateConfigStrict {
@@ -82,7 +83,6 @@ func main() {
 		xray.MigrateConfig(&conf)
 	}
 
-	logger := logrus.StandardLogger()
 	server, err := veneur.NewFromConfig(veneur.ServerConfig{
 		Config: conf,
 		Logger: logger,
@@ -167,7 +167,6 @@ func main() {
 			},
 		},
 	})
-	veneur.SetLogger(logger)
 	if err != nil {
 		e := err
 		if conf.SentryDsn.Value != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +19,8 @@ func TestReadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.applyDefaults()
+	logger := logrus.NewEntry(logrus.New())
+	c.applyDefaults(logger)
 
 	assert.Equal(t, "https://app.datadoghq.com", c.DatadogAPIHostname)
 	assert.Equal(t, 96, c.NumWorkers)
@@ -76,14 +78,15 @@ func TestHostname(t *testing.T) {
 	assert.Nil(t, err, "Should parsed valid config file: %s", noHostname)
 	currentHost, err := os.Hostname()
 	assert.Nil(t, err, "Could not get current hostname")
-	c.applyDefaults()
+	logger := logrus.NewEntry(logrus.New())
+	c.applyDefaults(logger)
 	assert.Equal(t, c.Hostname, currentHost, "Should have used current hostname in Config")
 
 	const omitHostname = "omit_empty_hostname: true"
 	r = strings.NewReader(omitHostname)
 	c, err = readConfig(r)
 	assert.Nil(t, err, "Should parsed valid config file: %s", omitHostname)
-	c.applyDefaults()
+	c.applyDefaults(logger)
 	assert.Equal(t, c.Hostname, "", "Should have respected omit_empty_hostname")
 }
 
@@ -98,7 +101,8 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Nil(t, err, "Could not get current hostname")
 	expectedConfig.Hostname = currentHost
 
-	c.applyDefaults()
+	logger := logrus.NewEntry(logrus.New())
+	c.applyDefaults(logger)
 	assert.Equal(t, c, expectedConfig, "Should have applied all config defaults")
 }
 
@@ -117,7 +121,8 @@ func TestProxyConfigDefaults(t *testing.T) {
 	assert.Nil(t, err, "Should parsed empty config file: %s", emptyConfig)
 
 	expectedConfig := defaultProxyConfig
-	c.applyDefaults()
+	logger := logrus.NewEntry(logrus.New())
+	c.applyDefaults(logger)
 	assert.Equal(t, c, expectedConfig, "Should have applied all config defaults")
 }
 
@@ -130,7 +135,8 @@ func TestVeneurExamples(t *testing.T) {
 		test := elt
 		t.Run(test, func(t *testing.T) {
 			t.Parallel()
-			_, err := ReadConfig(test)
+			logger := logrus.NewEntry(logrus.New())
+			_, err := ReadConfig(logger, test)
 			assert.NoError(t, err)
 		})
 	}
@@ -142,7 +148,8 @@ func TestProxyExamples(t *testing.T) {
 		test := elt
 		t.Run(test, func(t *testing.T) {
 			t.Parallel()
-			_, err := ReadProxyConfig(test)
+			logger := logrus.NewEntry(logrus.New())
+			_, err := ReadProxyConfig(logger, test)
 			assert.NoError(t, err)
 		})
 	}
@@ -160,7 +167,8 @@ trace_lightstep_maximum_spans: 1
 trace_lightstep_num_clients: 2
 `
 	c, err := readConfig(strings.NewReader(config))
-	c.applyDefaults()
+	logger := logrus.NewEntry(logrus.New())
+	c.applyDefaults(logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14/samplers"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
@@ -91,6 +92,7 @@ func forwardGRPCTestMetrics() []*samplers.UDPMetric {
 }
 
 func TestServerFlushGRPC(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	done := make(chan []string)
 	testServer := forwardtest.NewServer(func(ms []*metricpb.Metric) {
 		var names []string
@@ -127,11 +129,11 @@ func TestServerFlushGRPC(t *testing.T) {
 	// Wait until the running server has flushed out the metrics for us:
 	select {
 	case v := <-done:
-		log.Print("got the goods")
+		logger.Print("got the goods")
 		assert.ElementsMatch(t, expected, v,
 			"Flush didn't output the right metrics")
 	case <-time.After(time.Second):
-		log.Print("timed out")
+		logger.Print("timed out")
 		t.Fatal("Timed out waiting for the gRPC server to receive the flush")
 	}
 }

--- a/http.go
+++ b/http.go
@@ -43,7 +43,8 @@ func (s *Server) Handler() http.Handler {
 
 	if s.httpQuit {
 		mux.HandleFunc(pat.Post(httpQuitEndpoint), func(w http.ResponseWriter, r *http.Request) {
-			log.WithField("endpoint", httpQuitEndpoint).Info("Received shutdown request on HTTP quit endpoint")
+			s.logger.WithField("endpoint", httpQuitEndpoint).
+				Info("Received shutdown request on HTTP quit endpoint")
 			w.Write([]byte("Beginning graceful shutdown....\n"))
 			s.Shutdown()
 		})

--- a/http/http.go
+++ b/http/http.go
@@ -156,7 +156,11 @@ func mergeTags(tags map[string]string, k, v string) map[string]string {
 // this function - probably a static string for each callsite
 // you can disable compression with compress=false for endpoints that don't
 // support it
-func PostHelper(ctx context.Context, httpClient *http.Client, tc *trace.Client, method string, endpoint string, bodyObject interface{}, action string, compress bool, extraTags map[string]string, log *logrus.Logger) error {
+func PostHelper(
+	ctx context.Context, httpClient *http.Client, tc *trace.Client, method string,
+	endpoint string, bodyObject interface{}, action string, compress bool,
+	extraTags map[string]string, log *logrus.Entry,
+) error {
 	span, _ := trace.StartSpanFromContext(ctx, "")
 	span.SetTag("action", action)
 	for k, v := range extraTags {

--- a/http_test.go
+++ b/http_test.go
@@ -386,7 +386,9 @@ func BenchmarkNewSortableJSONMetrics(b *testing.B) {
 
 	w := httptest.NewRecorder()
 
-	_, jsonMetrics, err := unmarshalMetricsFromHTTP(context.Background(), trace.DefaultClient, w, r)
+	logger := logrus.NewEntry(logrus.New())
+	_, jsonMetrics, err := unmarshalMetricsFromHTTP(
+		context.Background(), trace.DefaultClient, w, r, logger)
 	assert.NoError(b, err)
 
 	b.ResetTimer()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -193,9 +193,6 @@ func TestConsistentForward(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	defer log.SetLevel(log.Level)
-	log.SetLevel(logrus.ErrorLevel)
-
 	cfg := generateProxyConfig()
 	cfg.ConsulTraceServiceName = ""
 	cfg.ConsulForwardServiceName = ""

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -200,7 +200,11 @@ func (dd *DatadogMetricSink) Flush(ctx context.Context, interMetrics []samplers.
 		// this endpoint is not documented to take an array... but it does
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey), checks, "flush_checks", false, map[string]string{"sink": "datadog"}, dd.log.Logger)
+		err := vhttp.PostHelper(
+			context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/check_run?api_key=%s", dd.DDHostname, dd.APIKey),
+			checks, "flush_checks", false, map[string]string{"sink": "datadog"},
+			dd.log)
 		if err == nil {
 			dd.log.WithField("checks", len(checks)).Info("Completed flushing service checks to Datadog")
 		} else {
@@ -310,11 +314,14 @@ func (dd *DatadogMetricSink) FlushOtherSamples(ctx context.Context, samples []ss
 		// the official dd-agent
 		// we don't actually pass all the body keys that dd-agent passes here... but
 		// it still works
-		err := vhttp.PostHelper(context.Background(), dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/intake?api_key=%s", dd.DDHostname, dd.APIKey), map[string]map[string][]DDEvent{
-			"events": {
-				"api": events,
-			},
-		}, "flush_events", true, map[string]string{"sink": "datadog"}, dd.log.Logger)
+		err := vhttp.PostHelper(
+			context.Background(), dd.HTTPClient, dd.traceClient, http.MethodPost,
+			fmt.Sprintf("%s/intake?api_key=%s", dd.DDHostname, dd.APIKey),
+			map[string]map[string][]DDEvent{
+				"events": {
+					"api": events,
+				},
+			}, "flush_events", true, map[string]string{"sink": "datadog"}, dd.log)
 
 		if err == nil {
 			dd.log.WithField("events", len(events)).Info("Completed flushing events to Datadog")
@@ -463,9 +470,11 @@ METRICLOOP:
 
 func (dd *DatadogMetricSink) flushPart(ctx context.Context, metricSlice []DDMetric, wg *sync.WaitGroup) {
 	defer wg.Done()
-	vhttp.PostHelper(ctx, dd.HTTPClient, dd.traceClient, http.MethodPost, fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.DDHostname, dd.APIKey), map[string][]DDMetric{
-		"series": metricSlice,
-	}, "flush", true, map[string]string{"sink": "datadog"}, dd.log.Logger)
+	vhttp.PostHelper(ctx, dd.HTTPClient, dd.traceClient, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/series?api_key=%s", dd.DDHostname, dd.APIKey),
+		map[string][]DDMetric{
+			"series": metricSlice,
+		}, "flush", true, map[string]string{"sink": "datadog"}, dd.log)
 }
 
 // DatadogTraceSpan represents a trace span as JSON for the
@@ -682,7 +691,10 @@ func (dd *DatadogSpanSink) Flush() {
 		// another curious constraint of this endpoint is that it does not
 		// support "Content-Encoding: deflate"
 
-		err := vhttp.PostHelper(context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut, fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces, "flush_traces", false, map[string]string{"sink": "datadog"}, dd.log.Logger)
+		err := vhttp.PostHelper(
+			context.TODO(), dd.HTTPClient, dd.traceClient, http.MethodPut,
+			fmt.Sprintf("%s/v0.3/traces", dd.traceAddress), finalTraces,
+			"flush_traces", false, map[string]string{"sink": "datadog"}, dd.log)
 		if err == nil {
 			dd.log.WithField("traces", len(finalTraces)).Info("Completed flushing traces to Datadog")
 		} else {

--- a/sources/openmetrics/demo/main.go
+++ b/sources/openmetrics/demo/main.go
@@ -54,7 +54,7 @@ func main() {
 		sampleSummary,
 	)
 
-	config, err := veneur.ReadConfig(*configFile)
+	config, err := veneur.ReadConfig(logrus.NewEntry(logger), *configFile)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -203,8 +203,11 @@ func TestSpanWorkerTagApplication(t *testing.T) {
 	spanChanNone := make(chan *ssf.SSFSpan)
 	spanChanFoo := make(chan *ssf.SSFSpan)
 
-	go NewSpanWorker([]sinks.SpanSink{fake}, cl, nil, spanChanNone, nil).Work()
-	go NewSpanWorker([]sinks.SpanSink{fake}, cl, nil, spanChanFoo, tags["foo"]()).Work()
+	logger := logrus.NewEntry(logrus.New())
+	go NewSpanWorker(
+		[]sinks.SpanSink{fake}, cl, nil, spanChanNone, nil, logger).Work()
+	go NewSpanWorker(
+		[]sinks.SpanSink{fake}, cl, nil, spanChanFoo, tags["foo"](), logger).Work()
 
 	sendAndWait := func(spanChan chan<- *ssf.SSFSpan, span *ssf.SSFSpan) {
 		fake.wg.Add(1)
@@ -410,7 +413,8 @@ func TestWorkerMetricsForwardableMetrics(t *testing.T) {
 				wm.Upsert(mk, m.scope, []string{})
 			}
 
-			ms := wm.ForwardableMetrics(nil)
+			logger := logrus.NewEntry(logrus.New())
+			ms := wm.ForwardableMetrics(nil, logger)
 
 			// Convert all of the forwardable metrics into testMetric's
 			// and then compare them


### PR DESCRIPTION
#### Summary
This change replace the global `log` instance with scoped loggers.

#### Motivation
Having multiple loggers with different settings adds unnecessary complexity.
