### PR TITLE
Improve logging errors to Sentry.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -94,16 +94,16 @@ func NewProxyFromConfig(
 
 	if conf.SentryDsn != "" {
 		err = sentry.Init(sentry.ClientOptions{
-			Dsn: conf.SentryDsn,
+			Dsn:        conf.SentryDsn,
+			ServerName: hostname,
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	logger.AddHook(sentryHook{
-		hostname: hostname,
-		lv: []logrus.Level{
+	logger.AddHook(SentryHook{
+		Level: []logrus.Level{
 			logrus.ErrorLevel,
 			logrus.FatalLevel,
 			logrus.PanicLevel,

--- a/sentry.go
+++ b/sentry.go
@@ -64,24 +64,22 @@ func ConsumePanic(cl *trace.Client, hostname string, err interface{}) {
 }
 
 // logrus hook to send error/fatal/panic messages to sentry
-type sentryHook struct {
-	hostname string
-	lv       []logrus.Level
+type SentryHook struct {
+	Level []logrus.Level
 }
 
-var _ logrus.Hook = sentryHook{}
+var _ logrus.Hook = SentryHook{}
 
-func (s sentryHook) Levels() []logrus.Level {
-	return s.lv
+func (s SentryHook) Levels() []logrus.Level {
+	return s.Level
 }
 
-func (s sentryHook) Fire(e *logrus.Entry) error {
+func (s SentryHook) Fire(e *logrus.Entry) error {
 	if sentry.CurrentHub().Client() == nil {
 		return nil
 	}
 
 	event := sentry.NewEvent()
-	event.ServerName = s.hostname
 
 	packetExtraLength := len(e.Data)
 	if err, ok := e.Data[logrus.ErrorKey].(error); ok {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -78,7 +78,7 @@ func TestConsumePanicWithSentry(t *testing.T) {
 
 func TestHookWithoutSentry(t *testing.T) {
 	// hook with a nil sentry client is used when sentry is disabled
-	hook := &sentryHook{}
+	hook := &SentryHook{}
 
 	entry := &logrus.Entry{}
 	// must use Fatal so the call to Fire blocks and we can check the result
@@ -90,7 +90,7 @@ func TestHookWithoutSentry(t *testing.T) {
 }
 
 func TestHook(t *testing.T) {
-	hook := &sentryHook{}
+	hook := &SentryHook{}
 	transport := &transportMock{}
 	err := sentry.Init(sentry.ClientOptions{
 		Transport: transport,

--- a/server_test.go
+++ b/server_test.go
@@ -90,8 +90,8 @@ func generateConfig(forwardAddr string) Config {
 				Host:   "localhost:0",
 			},
 		}},
-		HTTPAddress:    fmt.Sprintf("localhost:0"),
-		GrpcAddress:    fmt.Sprintf("localhost:0"),
+		HTTPAddress:    "localhost:0",
+		GrpcAddress:    "localhost:0",
 		ForwardAddress: forwardAddr,
 		NumWorkers:     4,
 		FlushFile:      "",
@@ -209,7 +209,7 @@ func (c *channelMetricSink) Flush(ctx context.Context, metrics []samplers.InterM
 }
 
 func (c *channelMetricSink) FlushOtherSamples(ctx context.Context, events []ssf.SSFSample) {
-	return
+	// Do nothing.
 }
 
 // fixture sets up a mock Datadog API server and Veneur
@@ -589,7 +589,6 @@ func TestUDPMetrics(t *testing.T) {
 }
 
 func TestUnixSocketMetrics(t *testing.T) {
-	ctx := context.TODO()
 	tdir, err := ioutil.TempDir("", "unixmetrics_statsd")
 	require.NoError(t, err)
 	defer os.RemoveAll(tdir)
@@ -1214,7 +1213,6 @@ func BenchmarkSendSSFUDP(b *testing.B) {
 	}
 	l.Close()
 	close(s.shutdown)
-	return
 }
 
 func BenchmarkServerFlush(b *testing.B) {
@@ -1414,7 +1412,7 @@ func TestGenerateExcludeTags(t *testing.T) {
 
 func generateSSFPackets(tb testing.TB, length int) [][]byte {
 	input := make([][]byte, length)
-	for i, _ := range input {
+	for i := range input {
 		p := make([]byte, 10)
 		_, err := rand.Read(p)
 		if err != nil {
@@ -1642,7 +1640,7 @@ func BenchmarkHandleSSF(b *testing.B) {
 	packets := generateSSFPackets(b, LEN)
 	spans := make([]*ssf.SSFSpan, len(packets))
 
-	for i, _ := range spans {
+	for i := range spans {
 		span, err := protocol.ParseSSF(packets[i])
 		assert.NoError(b, err)
 		spans[i] = span


### PR DESCRIPTION
#### Summary
This change
- initializes the Sentry client earlier in Veneur's startup logic
- includes the build commit hash when reporting errors to Sentry
- cleans up logic in `server.go`

#### Test plan
```
go test github.com/stripe/veneur/v14/...
```
