### PR TITLE
Add option to flush sinks on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * A prometheus remote-write sink compatible with Cortex and more. Thanks, [philipnrmn](https://github.com/philipnrmn)!
 * Some veneur-prometheus arguments to rename and add additional tags. Thanks, [christopherb-stripe](https://github.com/christopherb-stripe)!
 * Migrate Prometheus to new config format; part of multi-sink routing update. Thanks, [truong-stripe](https://github.com/truong-stripe)!
-* Authentication support for Cortex remote-write sink. Thanks,
-[oscil8](https://github.com/oscil8)!
+* Authentication support for Cortex remote-write sink. Thanks, [oscil8](https://github.com/oscil8)!
+* Option to flush sinks on shutdown. Thanks, [csolidum](https://github.com/csolidum)!
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	} `yaml:"features"`
 	FlushFile                                 string              `yaml:"flush_file"`
 	FlushMaxPerBody                           int                 `yaml:"flush_max_per_body"`
+	FlushOnShutdown                           bool                `yaml:"flush_on_shutdown"`
 	FlushWatchdogMissedFlushes                int                 `yaml:"flush_watchdog_missed_flushes"`
 	ForwardAddress                            string              `yaml:"forward_address"`
 	ForwardUseGrpc                            bool                `yaml:"forward_use_grpc"`

--- a/example.yaml
+++ b/example.yaml
@@ -66,6 +66,9 @@ interval: "10s"
 # watchdog.
 flush_watchdog_missed_flushes: 0
 
+# Whether to flush sinks on shutdown. Defaults to false
+flush_on_shutdown: false
+
 # Veneur can "sychronize" it's flushes with the system clock, flushing at even
 # intervals i.e. 0, 10, 20… to align with the `interval`. This is disabled by
 # default for now, as it can cause thundering herds in large installations.

--- a/server.go
+++ b/server.go
@@ -1376,7 +1376,7 @@ func (s *Server) Shutdown() {
 	s.logger.Info("Shutting down server gracefully")
 	close(s.shutdown)
 	if s.FlushOnShutdown {
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.Interval))
+		ctx, cancel := context.WithTimeout(context.Background(), s.Interval)
 		s.Flush(ctx)
 		cancel()
 	}

--- a/testdata/http_test_config.json
+++ b/testdata/http_test_config.json
@@ -30,6 +30,7 @@
   },
   "FlushFile": "",
   "FlushMaxPerBody": 0,
+  "FlushOnShutdown": false,
   "FlushWatchdogMissedFlushes": 0,
   "ForwardAddress": "",
   "ForwardUseGrpc": false,

--- a/testdata/http_test_config.yaml
+++ b/testdata/http_test_config.yaml
@@ -27,6 +27,7 @@ features:
   migrate_span_sinks: false
 flush_file: ""
 flush_max_per_body: 0
+flush_on_shutdown: false
 flush_watchdog_missed_flushes: 0
 forward_address: ""
 forward_use_grpc: false


### PR DESCRIPTION
#### Summary
Add a new config option flush_on_shutdown which when enabled, flushes sinks as part of a graceful shutdown

#### Motivation
This is useful for when veneur is run as a sidecar for short lived pods like cronjobs so that we can clean up resources without having to wait for an entire flush interval. Related issue is https://github.com/stripe/veneur/issues/806 


#### Test plan
Tested a build with this locally and observed that sinks where flushed when we hit the quitquitquit endpoint.

#### Rollout/monitoring/revert plan
Setting the flush_on_shutdown config option as true for veneur will enable this behavior. Removing/setting this value to false will revert this. 
