### PR TITLE
Add tags when ingesting metrics.

### DIFF
--- a/config.go
+++ b/config.go
@@ -160,6 +160,7 @@ type SourceConfig struct {
 	Kind   string      `yaml:"kind"`
 	Name   string      `yaml:"name"`
 	Config interface{} `yaml:"config"`
+	Tags   []string    `yaml:"tags"`
 }
 
 type SinkConfig struct {

--- a/server_test.go
+++ b/server_test.go
@@ -1461,8 +1461,8 @@ func TestServeStopGRPC(t *testing.T) {
 
 	// Stop the gRPC server only.  This should cause Serve to exit
 	assert.Len(t, s.sources, 1)
-	assert.Equal(t, s.sources[0].Name(), "proxy")
-	s.sources[0].Stop()
+	assert.Equal(t, s.sources[0].source.Name(), "proxy")
+	s.sources[0].source.Stop()
 
 	select {
 	case <-done:

--- a/sources/mock/factory.go
+++ b/sources/mock/factory.go
@@ -14,7 +14,7 @@ type MockSourceFactory struct {
 
 func (factory *MockSourceFactory) Create(
 	server *veneur.Server, name string, logger *logrus.Entry,
-	sourceConfig veneur.ParsedSourceConfig,
+	sourceConfig veneur.ParsedSourceConfig, ingest sources.Ingest,
 ) (sources.Source, error) {
 	source := NewMockSource(factory.Controller)
 	// Have the mock Name method always return the passed in name, since each

--- a/sources/mock/mock.go
+++ b/sources/mock/mock.go
@@ -8,6 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	samplers "github.com/stripe/veneur/v14/samplers"
+	sources "github.com/stripe/veneur/v14/sources"
 )
 
 // MockSourceConfig is a mock of SourceConfig interface.
@@ -71,17 +73,17 @@ func (mr *MockSourceMockRecorder) Name() *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockSource) Start() error {
+func (m *MockSource) Start(ingest sources.Ingest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", ingest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockSourceMockRecorder) Start() *gomock.Call {
+func (mr *MockSourceMockRecorder) Start(ingest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSource)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSource)(nil).Start), ingest)
 }
 
 // Stop mocks base method.
@@ -94,4 +96,39 @@ func (m *MockSource) Stop() {
 func (mr *MockSourceMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockSource)(nil).Stop))
+}
+
+// MockIngest is a mock of Ingest interface.
+type MockIngest struct {
+	ctrl     *gomock.Controller
+	recorder *MockIngestMockRecorder
+}
+
+// MockIngestMockRecorder is the mock recorder for MockIngest.
+type MockIngestMockRecorder struct {
+	mock *MockIngest
+}
+
+// NewMockIngest creates a new mock instance.
+func NewMockIngest(ctrl *gomock.Controller) *MockIngest {
+	mock := &MockIngest{ctrl: ctrl}
+	mock.recorder = &MockIngestMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIngest) EXPECT() *MockIngestMockRecorder {
+	return m.recorder
+}
+
+// IngestMetric mocks base method.
+func (m *MockIngest) IngestMetric(metric *samplers.UDPMetric) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IngestMetric", metric)
+}
+
+// IngestMetric indicates an expected call of IngestMetric.
+func (mr *MockIngestMockRecorder) IngestMetric(metric interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestMetric", reflect.TypeOf((*MockIngest)(nil).IngestMetric), metric)
 }

--- a/sources/openmetrics/openmetrics.go
+++ b/sources/openmetrics/openmetrics.go
@@ -114,7 +114,7 @@ func (source OpenMetricsSource) Name() string {
 	return source.name
 }
 
-func (source OpenMetricsSource) Start() error {
+func (source OpenMetricsSource) Start(ingest sources.Ingest) error {
 	ticker := time.NewTicker(source.scrapeInterval)
 intervalLoop:
 	for {
@@ -137,7 +137,7 @@ intervalLoop:
 					source.logger.WithError(err).Warn("failed to ingest metrics")
 					continue intervalLoop
 				}
-				source.server.IngestMetric(metric.Metric)
+				ingest.IngestMetric(metric.Metric)
 			}
 		case <-source.context.Done():
 			break intervalLoop

--- a/sources/proxy/server.go
+++ b/sources/proxy/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stripe/veneur/v14/forwardrpc"
 	"github.com/stripe/veneur/v14/samplers/metricpb"
+	"github.com/stripe/veneur/v14/sources"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 )
@@ -43,6 +44,8 @@ type Server struct {
 	metricOuts []MetricIngester
 	opts       *options
 }
+
+var _ sources.Source = &Server{}
 
 type options struct {
 	traceClient *trace.Client
@@ -88,7 +91,7 @@ func (s *Server) Name() string {
 // As long as both are running this is actually fine, as Start will stop
 // the gRPC server when the HTTP one exits.  When running just gRPC however,
 // the signal handling won't work.
-func (s *Server) Start() error {
+func (s *Server) Start(ingest sources.Ingest) error {
 	entry := logrus.WithFields(logrus.Fields{"address": s.address})
 	entry.Info("Starting gRPC server")
 

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -1,9 +1,15 @@
 package sources
 
+import "github.com/stripe/veneur/v14/samplers"
+
 type SourceConfig interface{}
 
 type Source interface {
 	Name() string
-	Start() error
+	Start(ingest Ingest) error
 	Stop()
+}
+
+type Ingest interface {
+	IngestMetric(metric *samplers.UDPMetric)
 }


### PR DESCRIPTION
#### Summary
This change adds a configuration field to metric sources that adds tags to metrics ingested from that source.
