### PR TITLE
Fix context cancelling too early in openmetrics source.

### DIFF
--- a/sources/openmetrics/openmetrics.go
+++ b/sources/openmetrics/openmetrics.go
@@ -120,12 +120,10 @@ intervalLoop:
 	for {
 		select {
 		case t := <-ticker.C:
-			results, err := func() (<-chan QueryResults, error) {
-				ctx, cancel :=
-					context.WithDeadline(source.context, t.Add(source.ScrapeTimeout))
-				defer cancel()
-				return source.Query(ctx)
-			}()
+			ctx, cancel :=
+				context.WithDeadline(source.context, t.Add(source.ScrapeTimeout))
+			defer cancel()
+			results, err := source.Query(ctx)
 
 			if err != nil {
 				source.logger.WithError(err).Warn("failed to query metrics")


### PR DESCRIPTION
#### Summary
The context in the openmetrics source is cancelled too early, causing the source to fail to scrape metrics.
