### PR TITLE
fix data race introduced on master 56b2f90a49db046cd29162591c85868615dfa2ec

### DIFF
--- a/sinks/cloudwatch/README.md
+++ b/sinks/cloudwatch/README.md
@@ -15,6 +15,7 @@ metric_sinks:
 
 ### Additional options
 
+* `aws_disable_retries` (default: false): Configure the AWS SDK to not retry
 * `cloudwatch_endpoint`: Specify a custom endpoint to use in place of the standard [monitoring endpoint](https://docs.aws.amazon.com/general/latest/gr/cw_region.html)
 * `cloudwatch_standard_unit_tag_name` (default: `cloudwatch_standard_unit`): Specify a [standard unit](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudwatch@v1.17.0/types?utm_source=gopls#StandardUnit) on a per-metric-datum basis, e.g. "Seconds", "Bytes"
 * `remote_timeout` (default: `30s`): Specify an HTTP client timeout, after which the sink will fail if it has not received a PutMetricData response

--- a/sinks/cloudwatch/cloudwatch_test.go
+++ b/sinks/cloudwatch/cloudwatch_test.go
@@ -87,6 +87,8 @@ func NewTestServer(t *testing.T, handlerDelay time.Duration) *TestServer {
 
 // Latest returns the most recent write request, or errors if there was none
 func (t *TestServer) Latest() ([]byte, error) {
+	timeout := time.After(3 * time.Second)
+	<-timeout
 	data := t.testState.GetData()
 	if data == nil {
 		return nil, errors.New("no data received")
@@ -164,6 +166,8 @@ func TestFlushNoop(t *testing.T) {
 
 	// Assert that the server was never hit
 	assert.NoError(t, err)
+	timeout := time.After(3 * time.Second)
+	<-timeout
 	assert.Equal(t, 0, server.testState.GetNumRequestsSeen())
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
r? @arnavdugar-stripe 

I think this should fix the race condition caught in https://app.circleci.com/pipelines/github/stripe/veneur/1679/workflows/b9919bfb-4c45-4799-865a-3fff8fde97b3/jobs/7162

#### Motivation
<!-- Why are you making this change? -->
`master` CI is broken

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
CI should pass