### PR TITLE
Append ".bucket" to OpenMetrics histogram buckets.

### DIFF
--- a/sources/openmetrics/openmetrics.go
+++ b/sources/openmetrics/openmetrics.go
@@ -340,7 +340,7 @@ func (source *OpenMetricsSource) convertHistogram(
 			metrics <- &convertResults{
 				Metric: &samplers.UDPMetric{
 					MetricKey: samplers.MetricKey{
-						Name: *metricFamily.Name,
+						Name: fmt.Sprintf("%s.bucket", *metricFamily.Name),
 						Type: "counter",
 					},
 					SampleRate: 1.0,

--- a/sources/openmetrics/openmetrics_test.go
+++ b/sources/openmetrics/openmetrics_test.go
@@ -481,7 +481,7 @@ func TestConvertHistogram(t *testing.T) {
 
 	if assert.Len(t, results, 4) {
 		assert.Equal(t, "counter", results[0].Type)
-		assert.Equal(t, "metric_name", results[0].Name)
+		assert.Equal(t, "metric_name.bucket", results[0].Name)
 		if assert.Len(t, results[0].Tags, 3) {
 			assert.Equal(t, "tag1:value1", results[0].Tags[0])
 			assert.Equal(t, "tag2:value2", results[0].Tags[1])
@@ -491,7 +491,7 @@ func TestConvertHistogram(t *testing.T) {
 		assert.Equal(t, int64(149), results[0].Timestamp)
 
 		assert.Equal(t, "counter", results[1].Type)
-		assert.Equal(t, "metric_name", results[1].Name)
+		assert.Equal(t, "metric_name.bucket", results[1].Name)
 		if assert.Len(t, results[1].Tags, 3) {
 			assert.Equal(t, "tag1:value1", results[1].Tags[0])
 			assert.Equal(t, "tag2:value2", results[1].Tags[1])


### PR DESCRIPTION
#### Summary
This change appends `.bucket` to OpenMetrics histogram buckets.

#### Motivation
This is consistent with how OpenMetrics identifies values that are histogram buckets.

#### Test plan
```
go test github.com/stripe/veneur/v14/sources/openmetrics
```