### PR TITLE
Add chunking support to cortex endpoint 

### DIFF
--- a/sinks/cortex/README.md
+++ b/sinks/cortex/README.md
@@ -13,6 +13,10 @@ metric_sinks:
       url: http://localhost:9090/api/v1/receive
 # Timeout for requests to the remote write endpoint.
       remote_timeout: 30s
+# Optional batch write size
+# note: this doesn't mean if a given flush contains 13 metrics that only 10 will be written, rather that
+# for a veneur flush interval the sink will do two writes: one for 10 metrics and another for 3 
+      batch_write_size: 10
 # Optional proxy URL.
       proxy_url: http://localhost:1080
 # Optional added headers

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -62,7 +62,7 @@ type CortexMetricSinkConfig struct {
 	URL            string            `yaml:"url"`
 	RemoteTimeout  time.Duration     `yaml:"remote_timeout"`
 	ProxyURL       string            `yaml:"proxy_url"`
-	BatchWriteSize int 				 `yaml:"batch_write_size"`
+	BatchWriteSize int               `yaml:"batch_write_size"`
 	Headers        map[string]string `yaml:"headers"`
 	BasicAuth      BasicAuthType     `yaml:"basic_auth"`
 	Authorization  struct {

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -219,7 +219,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 		})
 
 		if err != nil {
-			emitMetricKeyTotalMetricsDropped(span, len(metrics) - sentMetrics, metricKeyTags)
+			emitMetricKeyTotalMetricsDropped(span, len(metrics)-sentMetrics, metricKeyTags)
 			return err
 		}
 	}
@@ -231,7 +231,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 		})
 	}
 
-	emitPassOrFailSpan(err, len(metrics) - sentMetrics)
+	emitPassOrFailSpan(err, len(metrics)-sentMetrics)
 	return err
 }
 

--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -102,6 +102,29 @@ func TestChunkedWrites(t *testing.T)  {
 	assert.Equal(t, 4, len(server.History()))
 }
 
+func TestLeftOverBatchGetsWritten(t *testing.T) {
+	// Listen for prometheus writes
+	server := NewTestServer(t)
+	defer server.Close()
+
+	// Set up a sink
+	sink, err := NewCortexMetricSink(server.URL, 30*time.Second, "", logrus.NewEntry(logrus.New()), "test", map[string]string{"corge": "grault"}, map[string]string{}, nil, 5)
+	assert.NoError(t, err)
+	assert.NoError(t, sink.Start(trace.DefaultClient))
+
+	// input.json contains three timeseries samples in InterMetrics format
+	jsInput, err := ioutil.ReadFile("testdata/chunked_input.json")
+	assert.NoError(t, err)
+	var metrics []samplers.InterMetric
+	assert.NoError(t, json.Unmarshal(jsInput, &metrics))
+
+	// Perform the flush to the test server
+	assert.NoError(t, sink.Flush(context.Background(), metrics))
+
+	// There are 12 writes in input and our batch size is 5 so we expect 3 write requests
+	assert.Equal(t, 3, len(server.History()))
+}
+
 func TestChunkedWritesRespectContextCancellation(t *testing.T) {
 	// Listen for prometheus writes
 	server := NewTestServer(t)

--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -79,7 +79,7 @@ func TestFlush(t *testing.T) {
 	assert.Equal(t, string(expected), string(actual))
 }
 
-func TestChunkedWrites(t *testing.T)  {
+func TestChunkedWrites(t *testing.T) {
 	// Listen for prometheus writes
 	server := NewTestServer(t)
 	defer server.Close()
@@ -384,7 +384,7 @@ func BenchmarkSanitise(b *testing.B) {
 }
 
 type RequestHistory struct {
-	data 	*prompb.WriteRequest
+	data    *prompb.WriteRequest
 	headers *http.Header
 }
 

--- a/sinks/cortex/testdata/chunked_input.json
+++ b/sinks/cortex/testdata/chunked_input.json
@@ -1,0 +1,142 @@
+[
+  {
+    "Name": "a.a.gauge",
+    "Timestamp": 1,
+    "Value": 100,
+    "Tags": [
+      "foo:bar",
+      "baz:qux"
+    ],
+    "Type": 1,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "a.b.counter",
+    "Timestamp": 1,
+    "Value": 2,
+    "Tags": [
+      "foo:bar"
+    ],
+    "Type": 0,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "a.c.status",
+    "Timestamp": 1,
+    "Value": 5,
+    "Tags": null,
+    "Type": 2,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "b.a.gauge",
+    "Timestamp": 1,
+    "Value": 100,
+    "Tags": [
+      "foo:bar",
+      "baz:qux"
+    ],
+    "Type": 1,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "b.b.counter",
+    "Timestamp": 1,
+    "Value": 2,
+    "Tags": [
+      "foo:bar"
+    ],
+    "Type": 0,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "b.c.status",
+    "Timestamp": 1,
+    "Value": 5,
+    "Tags": null,
+    "Type": 2,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "c.a.gauge",
+    "Timestamp": 1,
+    "Value": 100,
+    "Tags": [
+      "foo:bar",
+      "baz:qux"
+    ],
+    "Type": 1,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "c.b.counter",
+    "Timestamp": 1,
+    "Value": 2,
+    "Tags": [
+      "foo:bar"
+    ],
+    "Type": 0,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "c.c.status",
+    "Timestamp": 1,
+    "Value": 5,
+    "Tags": null,
+    "Type": 2,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "d.a.gauge",
+    "Timestamp": 1,
+    "Value": 100,
+    "Tags": [
+      "foo:bar",
+      "baz:qux"
+    ],
+    "Type": 1,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "d.b.counter",
+    "Timestamp": 1,
+    "Value": 2,
+    "Tags": [
+      "foo:bar"
+    ],
+    "Type": 0,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  },
+  {
+    "Name": "d.c.status",
+    "Timestamp": 1,
+    "Value": 5,
+    "Tags": null,
+    "Type": 2,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  }
+]


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This adds a new `batch_write_size` config to the cortex sink, allowing metrics passed in a flush to be written in batches; useful for when the upstream remote write endpoint has size limitations.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Unit tests have been added to cover new logic.


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
