### PR TITLE
Configure stripping tags in metric sinks.

### DIFF
--- a/config.go
+++ b/config.go
@@ -165,7 +165,8 @@ type SourceConfig struct {
 }
 
 type SinkConfig struct {
-	Kind   string      `yaml:"kind"`
-	Name   string      `yaml:"name"`
-	Config interface{} `yaml:"config"`
+	Kind      string       `yaml:"kind"`
+	Name      string       `yaml:"name"`
+	Config    interface{}  `yaml:"config"`
+	StripTags []TagMatcher `yaml:"strip_tags"`
 }

--- a/server_test.go
+++ b/server_test.go
@@ -167,7 +167,9 @@ func setupVeneurServer(t testing.TB, config Config, transport http.RoundTripper,
 		bhs, _ := blackhole.NewBlackholeMetricSink()
 		mSink = bhs
 	}
-	server.metricSinks = append(server.metricSinks, mSink)
+	server.metricSinks = append(server.metricSinks, internalMetricSink{
+		sink: mSink,
+	})
 
 	if sSink == nil {
 		// Install a blackhole sink if we have no other sinks
@@ -1223,7 +1225,10 @@ func BenchmarkServerFlush(b *testing.B) {
 	f := newFixture(b, config, nil, nil)
 
 	bhs, _ := blackhole.NewBlackholeMetricSink()
-	f.server.metricSinks = []sinks.MetricSink{bhs}
+
+	f.server.metricSinks = []internalMetricSink{{
+		sink: bhs,
+	}}
 	defer f.Close()
 
 	b.ResetTimer()

--- a/sink_routing.go
+++ b/sink_routing.go
@@ -48,6 +48,16 @@ type SinkRoutingSinks struct {
 	NotMatched []string `yaml:"not_matched"`
 }
 
+func CreateNameMatcher(config *NameMatcherConfig) NameMatcher {
+	nameMatcher := NameMatcher{}
+	nameMatcher.UnmarshalYAML(func(c interface{}) error {
+		nameMatcherConfig := c.(*NameMatcherConfig)
+		*nameMatcherConfig = *config
+		return nil
+	})
+	return nameMatcher
+}
+
 // UnmarshalYAML unmarshals and validates the yaml config for matching the name
 // of a metric.
 func (matcher *NameMatcher) UnmarshalYAML(
@@ -95,6 +105,16 @@ func (matcher *NameMatcher) matchPrefix(value string) bool {
 
 func (matcher *NameMatcher) matchRegex(value string) bool {
 	return matcher.regex.MatchString(value)
+}
+
+func CreateTagMatcher(config *TagMatcherConfig) TagMatcher {
+	tagMatcher := TagMatcher{}
+	tagMatcher.UnmarshalYAML(func(c interface{}) error {
+		tagMatcherConfig := c.(*TagMatcherConfig)
+		*tagMatcherConfig = *config
+		return nil
+	})
+	return tagMatcher
 }
 
 // UnmarshalYAML unmarshals and validates the yaml config for matching tags

--- a/sinks/datadog/datadog.go
+++ b/sinks/datadog/datadog.go
@@ -109,11 +109,7 @@ func CreateMetricSink(
 // removed.
 func MigrateConfig(conf *veneur.Config) {
 	if conf.DatadogAPIKey.Value != "" && conf.DatadogAPIHostname != "" {
-		conf.MetricSinks = append(conf.MetricSinks, struct {
-			Kind   string      "yaml:\"kind\""
-			Name   string      "yaml:\"name\""
-			Config interface{} "yaml:\"config\""
-		}{
+		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
 			Kind: "datadog",
 			Name: "datadog",
 			Config: DatadogMetricSinkConfig{
@@ -128,11 +124,7 @@ func MigrateConfig(conf *veneur.Config) {
 
 	// configure Datadog as a Span sink
 	if conf.DatadogAPIKey.Value != "" && conf.DatadogTraceAPIAddress != "" {
-		conf.SpanSinks = append(conf.SpanSinks, struct {
-			Kind   string      "yaml:\"kind\""
-			Name   string      "yaml:\"name\""
-			Config interface{} "yaml:\"config\""
-		}{
+		conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
 			Kind: "datadog",
 			Name: "datadog",
 			Config: DatadogSpanSinkConfig{

--- a/sinks/localfile/localfile.go
+++ b/sinks/localfile/localfile.go
@@ -56,11 +56,7 @@ func MigrateConfig(config *veneur.Config) {
 	if config.FlushFile == "" {
 		return
 	}
-	config.MetricSinks = append(config.MetricSinks, struct {
-		Kind   string      "yaml:\"kind\""
-		Name   string      "yaml:\"name\""
-		Config interface{} "yaml:\"config\""
-	}{
+	config.MetricSinks = append(config.MetricSinks, veneur.SinkConfig{
 		Kind: "localfile",
 		Name: "localfile",
 		Config: LocalFileSinkConfig{

--- a/sinks/newrelic/newrelic.go
+++ b/sinks/newrelic/newrelic.go
@@ -21,11 +21,7 @@ const (
 // removed.
 func MigrateConfig(conf *veneur.Config) {
 	if conf.NewrelicInsertKey.Value != "" && conf.NewrelicAccountID > 0 {
-		conf.MetricSinks = append(conf.MetricSinks, struct {
-			Kind   string      "yaml:\"kind\""
-			Name   string      "yaml:\"name\""
-			Config interface{} "yaml:\"config\""
-		}{
+		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
 			Kind: "newrelic",
 			Name: "newrelic",
 			Config: NewRelicMetricSinkConfig{

--- a/sinks/s3/s3.go
+++ b/sinks/s3/s3.go
@@ -45,11 +45,7 @@ func MigrateConfig(config *veneur.Config) {
 	if config.AwsS3Bucket == "" {
 		return
 	}
-	config.MetricSinks = append(config.MetricSinks, struct {
-		Kind   string      "yaml:\"kind\""
-		Name   string      "yaml:\"name\""
-		Config interface{} "yaml:\"config\""
-	}{
+	config.MetricSinks = append(config.MetricSinks, veneur.SinkConfig{
 		Kind: "s3",
 		Name: "s3",
 		Config: S3SinkConfig{

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -217,11 +217,7 @@ func MigrateConfig(conf *veneur.Config) error {
 		conf.SignalfxDynamicPerTagAPIKeysRefreshPeriod == 0 {
 		conf.SignalfxDynamicPerTagAPIKeysRefreshPeriod = time.Duration(10 * time.Minute)
 	}
-	conf.MetricSinks = append(conf.MetricSinks, struct {
-		Kind   string      "yaml:\"kind\""
-		Name   string      "yaml:\"name\""
-		Config interface{} "yaml:\"config\""
-	}{
+	conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
 		Kind: "signalfx",
 		Name: "signalfx",
 		Config: SignalFxSinkConfig{

--- a/sinks/splunk/splunk.go
+++ b/sinks/splunk/splunk.go
@@ -100,11 +100,7 @@ func MigrateConfig(conf *veneur.Config) error {
 	if conf.SplunkHecToken == "" || conf.SplunkHecAddress == "" {
 		return fmt.Errorf("both hec_address and hec_token must be set")
 	}
-	conf.SpanSinks = append(conf.MetricSinks, struct {
-		Kind   string      "yaml:\"kind\""
-		Name   string      "yaml:\"name\""
-		Config interface{} "yaml:\"config\""
-	}{
+	conf.SpanSinks = append(conf.MetricSinks, veneur.SinkConfig{
 		Kind: "signalfx",
 		Name: "signalfx",
 		Config: SplunkSinkConfig{

--- a/sinks/xray/xray.go
+++ b/sinks/xray/xray.go
@@ -96,11 +96,7 @@ func MigrateConfig(conf *veneur.Config) {
 	if conf.XrayAddress == "" {
 		return
 	}
-	conf.SpanSinks = append(conf.SpanSinks, struct {
-		Kind   string      "yaml:\"kind\""
-		Name   string      "yaml:\"name\""
-		Config interface{} "yaml:\"config\""
-	}{
+	conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
 		Kind: "xray",
 		Name: "xray",
 		Config: XRaySinkConfig{


### PR DESCRIPTION
#### Summary
This change adds a `strip_tags` field to the sink configuration for specifying tags that should be dropped by that sink.