### PR TITLE
changed logic to flush of # of metrics is less than batch size

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -184,7 +184,7 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 		span.Add(ssf.Count(sinks.MetricKeyTotalMetricsDropped, float32(droppedMetrics), metricKeyTags))
 	}()
 
-	if s.batchWriteSize == 0 || len(metrics) == s.batchWriteSize {
+	if s.batchWriteSize == 0 || len(metrics) <= s.batchWriteSize {
 		err := s.writeMetrics(ctx, metrics)
 		if err == nil {
 			flushedMetrics = len(metrics)

--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -121,7 +121,7 @@ func TestChunkNumOfMetricsLessThanBatchSize(t *testing.T) {
 	// Perform the flush to the test server
 	assert.NoError(t, sink.Flush(context.Background(), metrics))
 
-	// There are 12 writes in input and our batch size is 3 so we expect 4 write requests
+	// There are 12 writes in input and our batch size is 15 so we expect 1 write request
 	assert.Equal(t, 1, len(server.History()))
 }
 


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Changed logic so that flushes where number of metrics is less than the batch size don't go through the chunking process. 


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
