### PR TITLE
instrument RemoteWrite retry functionality in the cortex sink

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -364,7 +364,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 
 		b, err := ioutil.ReadAll(r.Body)
 		if err == nil {
-			errorFields["response_body"] = b
+			errorFields["response_body"] = string(b)
 		} else {
 			errorFields["additional_errors"] = err.Error()
 		}
@@ -379,7 +379,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 
 		b, err := ioutil.ReadAll(r.Body)
 		if err == nil {
-			errorFields["response_body"] = b
+			errorFields["response_body"] = string(b)
 		} else {
 			errorFields["additional_errors"] = err.Error()
 		}

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -356,7 +356,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 	// Resource leak can occur if body isn't closed explicitly
 	defer r.Body.Close()
 
-	if r.StatusCode == 429 || r.StatusCode >= 500 {
+	if (r.StatusCode == 429 && s.retryOnHTTP429) || r.StatusCode >= 500 {
 		errorFields := logrus.Fields{
 			"status_code": r.StatusCode,
 			"will_retry":  true,

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -360,6 +360,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 		errorFields := logrus.Fields{
 			"status_code": r.StatusCode,
 			"will_retry":  true,
+			"samples":     len(retryableMetrics),
 		}
 
 		b, err := ioutil.ReadAll(r.Body)
@@ -375,6 +376,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 		errorFields := logrus.Fields{
 			"status_code": r.StatusCode,
 			"will_retry":  false,
+			"samples":     len(retryableMetrics),
 		}
 
 		b, err := ioutil.ReadAll(r.Body)
@@ -391,6 +393,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, retryableMetrics []
 			"status_code":       r.StatusCode,
 			"will_retry":        false,
 			"additional_errors": "client should follow redirects",
+			"samples":           len(retryableMetrics),
 		}
 		s.logger.WithFields(errorFields).Errorf("Flush failed")
 		return nil, fmt.Errorf("Flush failed")


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
cc @stripe/observability 
r? @arnavdugar-stripe 

#### Motivation
<!-- Why are you making this change? -->
[Prometheus Remote Write Specification v0.1](https://docs.google.com/document/d/1LPhVRSFkGNSuU1fBd81ulhsCPR4hkSZyyBj1SZ8fWOM/edit#heading=h.p12mxouu8g0h) specifies:

> Prometheus Remote Write-compatible senders MUST retry write requests on HTTP 5xx responses and MUST use a backoff algorithm to prevent overwhelming the server. They MUST NOT retry write requests on HTTP 2xx and 4xx responses other than [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429). They MAY retry on HTTP 429 responses, which could result in senders “falling behind” if the server cannot keep up. This is done to ensure data is not lost when there are server side errors, and progress is made when there are client side errors.

This PR implements this specification, with the following given example config:

```yaml
- kind: cortex
  name: service-networking
  prometheus:
    url: http://some_url
    remote_timeout: 5s
    retry:
      backoff_strategy: count
      retry_on_http_429: false
      count_opts:
        abandonment_threshold: 5
```

"Count" is the only backoff strategy. "Abandonment threshold" is an option pertaining to the "Count" backoff strategy, which specifies how many times to retry RemoteWrite a sample before Veneur gives up and drops it.

A few notes on this implementation:

- This retry implementation is solely at the sink level, and does not aggregate samples together. As a result, enabling this setting will increase Veneur's memory usage in the worst case (the upstream is failing) linearly with the abandonment threshold.
- In order to enable aggregation cleanly, we would most likely want to implement retries at the [source](https://github.com/stripe/veneur/blob/ff8ee44523ed179ce2e5868d9c465bcfeb68f8bc/sources/sources.go) level, and allow sinks to feed into sources. This is a substantially more complex implementation because it requires making sinks (or some other piece of state between the source and sinks) retry-aware, because it is not guaranteed that all upstreams will fail at the same time intervals.
- The Remote Write spec is pretty light on what "backoff" means. We went for a count based backoff here rather than an exponential backoff due to (1) memory concerns (2) desire not to introduce syncopation into Veneur; i.e. cron-shaped things that are not tied to the global Veneur flush loop

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Wrote automated tests