### PR TITLE
Add a tag matcher for ignoring tags while sharding metrics in Veneur Proxy.

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stripe/veneur/v14/util"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
 type Config struct {
@@ -158,6 +159,16 @@ type HttpConfig struct {
 	Config bool `yaml:"config"`
 }
 
+type SinkRoutingConfig struct {
+	Name  string            `yaml:"name"`
+	Match []matcher.Matcher `yaml:"match"`
+	Sinks SinkRoutingSinks  `yaml:"sinks"`
+}
+
+type SinkRoutingSinks struct {
+	Matched    []string `yaml:"matched"`
+	NotMatched []string `yaml:"not_matched"`
+}
 type SourceConfig struct {
 	Kind   string      `yaml:"kind"`
 	Name   string      `yaml:"name"`
@@ -166,8 +177,8 @@ type SourceConfig struct {
 }
 
 type SinkConfig struct {
-	Kind      string       `yaml:"kind"`
-	Name      string       `yaml:"name"`
-	Config    interface{}  `yaml:"config"`
-	StripTags []TagMatcher `yaml:"strip_tags"`
+	Kind      string               `yaml:"kind"`
+	Name      string               `yaml:"name"`
+	Config    interface{}          `yaml:"config"`
+	StripTags []matcher.TagMatcher `yaml:"strip_tags"`
 }

--- a/config_proxy.go
+++ b/config_proxy.go
@@ -1,29 +1,33 @@
 package veneur
 
-import "github.com/stripe/veneur/v14/util"
+import (
+	"github.com/stripe/veneur/v14/util"
+	"github.com/stripe/veneur/v14/util/matcher"
+)
 
 type ProxyConfig struct {
-	ConsulForwardGrpcServiceName string   `yaml:"consul_forward_grpc_service_name"`
-	ConsulForwardServiceName     string   `yaml:"consul_forward_service_name"`
-	ConsulRefreshInterval        string   `yaml:"consul_refresh_interval"`
-	ConsulTraceServiceName       string   `yaml:"consul_trace_service_name"`
-	Debug                        bool     `yaml:"debug"`
-	EnableProfiling              bool     `yaml:"enable_profiling"`
-	ForwardAddress               string   `yaml:"forward_address"`
-	ForwardTimeout               string   `yaml:"forward_timeout"`
-	GrpcAddress                  string   `yaml:"grpc_address"`
-	GrpcForwardAddress           string   `yaml:"grpc_forward_address"`
-	HTTPAddress                  string   `yaml:"http_address"`
-	IdleConnectionTimeout        string   `yaml:"idle_connection_timeout"`
-	MaxIdleConns                 int      `yaml:"max_idle_conns"`
-	MaxIdleConnsPerHost          int      `yaml:"max_idle_conns_per_host"`
-	RuntimeMetricsInterval       string   `yaml:"runtime_metrics_interval"`
-	SentryDsn                    string   `yaml:"sentry_dsn"`
-	SsfDestinationAddress        util.Url `yaml:"ssf_destination_address"`
-	StatsAddress                 string   `yaml:"stats_address"`
-	TraceAddress                 string   `yaml:"trace_address"`
-	TraceAPIAddress              string   `yaml:"trace_api_address"`
-	TracingClientCapacity        int      `yaml:"tracing_client_capacity"`
-	TracingClientFlushInterval   string   `yaml:"tracing_client_flush_interval"`
-	TracingClientMetricsInterval string   `yaml:"tracing_client_metrics_interval"`
+	ConsulForwardGrpcServiceName string               `yaml:"consul_forward_grpc_service_name"`
+	ConsulForwardServiceName     string               `yaml:"consul_forward_service_name"`
+	ConsulRefreshInterval        string               `yaml:"consul_refresh_interval"`
+	ConsulTraceServiceName       string               `yaml:"consul_trace_service_name"`
+	Debug                        bool                 `yaml:"debug"`
+	EnableProfiling              bool                 `yaml:"enable_profiling"`
+	ForwardAddress               string               `yaml:"forward_address"`
+	ForwardTimeout               string               `yaml:"forward_timeout"`
+	GrpcAddress                  string               `yaml:"grpc_address"`
+	GrpcForwardAddress           string               `yaml:"grpc_forward_address"`
+	HTTPAddress                  string               `yaml:"http_address"`
+	IdleConnectionTimeout        string               `yaml:"idle_connection_timeout"`
+	IgnoreTags                   []matcher.TagMatcher `yaml:"ignore_tags"`
+	MaxIdleConns                 int                  `yaml:"max_idle_conns"`
+	MaxIdleConnsPerHost          int                  `yaml:"max_idle_conns_per_host"`
+	RuntimeMetricsInterval       string               `yaml:"runtime_metrics_interval"`
+	SentryDsn                    string               `yaml:"sentry_dsn"`
+	SsfDestinationAddress        util.Url             `yaml:"ssf_destination_address"`
+	StatsAddress                 string               `yaml:"stats_address"`
+	TraceAddress                 string               `yaml:"trace_address"`
+	TraceAPIAddress              string               `yaml:"trace_api_address"`
+	TracingClientCapacity        int                  `yaml:"tracing_client_capacity"`
+	TracingClientFlushInterval   string               `yaml:"tracing_client_flush_interval"`
+	TracingClientMetricsInterval string               `yaml:"tracing_client_metrics_interval"`
 }

--- a/flusher.go
+++ b/flusher.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stripe/veneur/v14/sinks"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
+	"github.com/stripe/veneur/v14/util/matcher"
 	"google.golang.org/grpc/status"
 )
 
@@ -110,7 +111,7 @@ func (s *Server) Flush(ctx context.Context) {
 			metric.Sinks = make(samplers.RouteInformation)
 			for _, config := range s.Config.MetricSinkRouting {
 				var sinks []string
-				if config.Match(metric.Name, metric.Tags) {
+				if matcher.Match(config.Match, metric.Name, metric.Tags) {
 					sinks = config.Sinks.Matched
 				} else {
 					sinks = config.Sinks.NotMatched
@@ -141,7 +142,7 @@ func (s *Server) Flush(ctx context.Context) {
 					tagLoop:
 						for _, tag := range metric.Tags {
 							for _, tagMatcher := range sink.stripTags {
-								if tagMatcher.match(tag) {
+								if tagMatcher.Match(tag) {
 									continue tagLoop
 								}
 							}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/util"
+	"github.com/stripe/veneur/v14/util/matcher"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -347,19 +348,19 @@ func TestStripTags(t *testing.T) {
 	config.MetricSinks = []SinkConfig{{
 		Kind: "channel",
 		Name: "channel",
-		StripTags: []TagMatcher{
-			CreateTagMatcher(&TagMatcherConfig{
+		StripTags: []matcher.TagMatcher{
+			matcher.CreateTagMatcher(&matcher.TagMatcherConfig{
 				Kind:  "prefix",
 				Value: "foo",
 			})},
 	}}
 	config.MetricSinkRouting = []SinkRoutingConfig{{
 		Name: "default",
-		MatchConfigs: []MatcherConfig{{
-			Name: CreateNameMatcher(&NameMatcherConfig{
+		Match: []matcher.Matcher{{
+			Name: matcher.CreateNameMatcher(&matcher.NameMatcherConfig{
 				Kind: "any",
 			}),
-			Tags: []TagMatcher{},
+			Tags: []matcher.TagMatcher{},
 		}},
 		Sinks: SinkRoutingSinks{
 			Matched: []string{"channel"},

--- a/proxysrv/options.go
+++ b/proxysrv/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/veneur/v14/trace"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
 // WithForwardTimeout sets the time after which an individual RPC to a
@@ -12,6 +13,14 @@ import (
 func WithForwardTimeout(d time.Duration) Option {
 	return func(opts *options) {
 		opts.forwardTimeout = d
+	}
+}
+
+// WithIgnoredTags sets matching rules to ignore tags for sharding metrics
+// across global veneur instances.
+func WithIgnoredTags(ignoredTags []matcher.TagMatcher) Option {
+	return func(opts *options) {
+		opts.ignoredTags = ignoredTags
 	}
 }
 

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
 const (
@@ -63,6 +64,7 @@ type options struct {
 	forwardTimeout time.Duration
 	traceClient    *trace.Client
 	statsInterval  time.Duration
+	ignoredTags    []matcher.TagMatcher
 }
 
 // New creates a new Server with the provided destinations. The server returned
@@ -295,7 +297,7 @@ func (s *Server) sendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) 
 
 // destForMetric returns a destination for the input metric.
 func (s *Server) destForMetric(m *metricpb.Metric) (string, error) {
-	key := samplers.NewMetricKeyFromMetric(m)
+	key := samplers.NewMetricKeyFromMetric(m, s.opts.ignoredTags)
 	dest, err := s.destinations.Get(key.String())
 	if err != nil {
 		return "", fmt.Errorf("failed to hash the MetricKey '%s' to a "+

--- a/samplers/parser_test.go
+++ b/samplers/parser_test.go
@@ -1,15 +1,56 @@
-package samplers
+package samplers_test
 
 import (
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/v14/samplers"
+	"github.com/stripe/veneur/v14/samplers/metricpb"
 	"github.com/stripe/veneur/v14/ssf"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
+func TestNewMetricKeyFromMetric(t *testing.T) {
+	key := samplers.NewMetricKeyFromMetric(&metricpb.Metric{
+		Name: "metric_name",
+		Tags: []string{
+			"key1:value1",
+			"key2:value2",
+			"le:5",
+		},
+		Type: metricpb.Type_Counter,
+	}, []matcher.TagMatcher{})
+
+	assert.Equal(t, key.JoinedTags, "key1:value1,key2:value2,le:5")
+	assert.Equal(t, key.Type, "counter")
+	assert.Equal(t, key.Name, "metric_name")
+}
+
+func TestNewMetricKeyFromMetricWithIgnoredTag(t *testing.T) {
+	key := samplers.NewMetricKeyFromMetric(&metricpb.Metric{
+		Name: "metric_name",
+		Tags: []string{
+			"key1:value1",
+			"key2:value2",
+			"le:5",
+		},
+		Type: metricpb.Type_Counter,
+	}, []matcher.TagMatcher{
+		matcher.CreateTagMatcher(&matcher.TagMatcherConfig{
+			Kind:  "prefix",
+			Value: "le:",
+		}),
+	})
+
+	assert.Equal(t, key.JoinedTags, "key1:value1,key2:value2")
+	assert.Equal(t, key.Type, "counter")
+	assert.Equal(t, key.Name, "metric_name")
+}
+
 func BenchmarkConvertSpanUniquenessMetrics(b *testing.B) {
-	p := Parser{}
+	p := samplers.Parser{}
 
 	const LEN = 10000
 

--- a/server.go
+++ b/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stripe/veneur/v14/tagging"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
 // VERSION stores the current veneur version.
@@ -191,7 +192,7 @@ type internalSource struct {
 
 type internalMetricSink struct {
 	sink      sinks.MetricSink
-	stripTags []TagMatcher
+	stripTags []matcher.TagMatcher
 }
 
 type GlobalListeningPerProtocolMetrics struct {

--- a/util/matcher/matcher_test.go
+++ b/util/matcher/matcher_test.go
@@ -1,4 +1,4 @@
-package veneur_test
+package matcher_test
 
 import (
 	"regexp/syntax"
@@ -6,30 +6,34 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/veneur/v14"
+	"github.com/stripe/veneur/v14/util/matcher"
 	"gopkg.in/yaml.v3"
 )
 
+type config struct {
+	Match []matcher.Matcher `yaml:"match"`
+}
+
 func CreateNameMatcher(
-	t *testing.T, matcher *veneur.NameMatcher,
+	t *testing.T, nameMatcher *matcher.NameMatcher,
 ) error {
-	return matcher.UnmarshalYAML(func(matcher interface{}) error {
-		assert.IsType(t, &veneur.NameMatcher{}, matcher)
+	return nameMatcher.UnmarshalYAML(func(nameMmatcher interface{}) error {
+		assert.IsType(t, &matcher.NameMatcher{}, nameMatcher)
 		return nil
 	})
 }
 
 func CreateTagMatcher(
-	t *testing.T, matcher *veneur.TagMatcher,
+	t *testing.T, tagMatcher *matcher.TagMatcher,
 ) error {
-	return matcher.UnmarshalYAML(func(matcher interface{}) error {
-		assert.IsType(t, &veneur.TagMatcher{}, matcher)
+	return tagMatcher.UnmarshalYAML(func(tagMatcher interface{}) error {
+		assert.IsType(t, &matcher.TagMatcher{}, tagMatcher)
 		return nil
 	})
 }
 
 func TestMatchNameAny(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -37,14 +41,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("aaa", []string{}))
-	assert.True(t, config.Match("aab", []string{}))
-	assert.True(t, config.Match("aaba", []string{}))
-	assert.True(t, config.Match("abb", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aaa", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aab", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aaba", []string{}))
+	assert.True(t, matcher.Match(config.Match, "abb", []string{}))
 }
 
 func TestMatchNameExact(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -53,14 +57,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("aaa", []string{}))
-	assert.True(t, config.Match("aab", []string{}))
-	assert.False(t, config.Match("aaba", []string{}))
-	assert.False(t, config.Match("abb", []string{}))
+	assert.False(t, matcher.Match(config.Match, "aaa", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aab", []string{}))
+	assert.False(t, matcher.Match(config.Match, "aaba", []string{}))
+	assert.False(t, matcher.Match(config.Match, "abb", []string{}))
 }
 
 func TestMatchNamePrefix(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -69,14 +73,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("aaa", []string{}))
-	assert.True(t, config.Match("aab", []string{}))
-	assert.True(t, config.Match("aaba", []string{}))
-	assert.False(t, config.Match("abb", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aaa", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aab", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aaba", []string{}))
+	assert.False(t, matcher.Match(config.Match, "abb", []string{}))
 }
 
 func TestMatchNameRegex(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -85,14 +89,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("aaa", []string{}))
-	assert.True(t, config.Match("aab", []string{}))
-	assert.False(t, config.Match("aaba", []string{}))
-	assert.True(t, config.Match("abb", []string{}))
+	assert.False(t, matcher.Match(config.Match, "aaa", []string{}))
+	assert.True(t, matcher.Match(config.Match, "aab", []string{}))
+	assert.False(t, matcher.Match(config.Match, "aaba", []string{}))
+	assert.True(t, matcher.Match(config.Match, "abb", []string{}))
 }
 
 func TestMatchNameInvalidRegex(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -107,7 +111,7 @@ match:
 }
 
 func TestMatchNameInvalidKind(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -119,7 +123,7 @@ match:
 }
 
 func TestMatchTagExact(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -130,14 +134,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("name", []string{"aaa"}))
-	assert.True(t, config.Match("name", []string{"aab"}))
-	assert.False(t, config.Match("name", []string{"aaba"}))
-	assert.False(t, config.Match("name", []string{"abb"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNameExactUnset(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -149,14 +153,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("name", []string{"aaa"}))
-	assert.False(t, config.Match("name", []string{"aab"}))
-	assert.True(t, config.Match("name", []string{"aaba"}))
-	assert.True(t, config.Match("name", []string{"abb"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNamePrefix(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -167,14 +171,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("name", []string{"aaa"}))
-	assert.True(t, config.Match("name", []string{"aab"}))
-	assert.True(t, config.Match("name", []string{"aaba"}))
-	assert.False(t, config.Match("name", []string{"abb"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNamePrefixUnset(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -186,14 +190,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("name", []string{"aaa"}))
-	assert.False(t, config.Match("name", []string{"aab"}))
-	assert.False(t, config.Match("name", []string{"aaba"}))
-	assert.True(t, config.Match("name", []string{"abb"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNameRegex(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -204,14 +208,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("name", []string{"aaa"}))
-	assert.True(t, config.Match("name", []string{"aab"}))
-	assert.False(t, config.Match("name", []string{"aaba"}))
-	assert.True(t, config.Match("name", []string{"abb"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNameRegexUnset(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -223,14 +227,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("name", []string{"aaa"}))
-	assert.False(t, config.Match("name", []string{"aab"}))
-	assert.True(t, config.Match("name", []string{"aaba"}))
-	assert.False(t, config.Match("name", []string{"abb"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaa"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aab"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"abb"}))
 }
 
 func TestMatchTagNameInvalidRegex(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -247,7 +251,7 @@ match:
 }
 
 func TestMatchTagNameInvalidKind(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -261,7 +265,7 @@ match:
 }
 
 func TestMatchTagMultiple(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -272,13 +276,13 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.True(t, config.Match("name", []string{"aaab", "baba"}))
-	assert.True(t, config.Match("name", []string{"baba", "aaab"}))
-	assert.False(t, config.Match("name", []string{"abba", "baba"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"aaab", "baba"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"baba", "aaab"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"abba", "baba"}))
 }
 
 func TestMatchTagUnsetMultiple(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -290,13 +294,13 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("name", []string{"aaab", "baba"}))
-	assert.False(t, config.Match("name", []string{"baba", "aaab"}))
-	assert.True(t, config.Match("name", []string{"abba", "baba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaab", "baba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"baba", "aaab"}))
+	assert.True(t, matcher.Match(config.Match, "name", []string{"abba", "baba"}))
 }
 
 func TestMultipleTagMatchers(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -309,13 +313,14 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("name", []string{"ab", "baab"}))
-	assert.False(t, config.Match("name", []string{"aaab", "baba"}))
-	assert.True(t, config.Match("name", []string{"ab", "aaab", "baba"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"ab", "baab"}))
+	assert.False(t, matcher.Match(config.Match, "name", []string{"aaab", "baba"}))
+	assert.True(t, matcher.Match(
+		config.Match, "name", []string{"ab", "aaab", "baba"}))
 }
 
 func TestMultipleMatcherConfigs(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
+	config := config{}
 	err := yaml.Unmarshal([]byte(`---
 match:
   - name:
@@ -333,16 +338,15 @@ match:
 `), &config)
 
 	require.Nil(t, err)
-	assert.False(t, config.Match("aa", []string{"aaab", "baba"}))
-	assert.True(t, config.Match("bb", []string{"aaab", "baba"}))
-	assert.True(t, config.Match("aa", []string{"ab", "baab"}))
-	assert.False(t, config.Match("bb", []string{"ab", "baab"}))
+	assert.False(t, matcher.Match(config.Match, "aa", []string{"aaab", "baba"}))
+	assert.True(t, matcher.Match(config.Match, "bb", []string{"aaab", "baba"}))
+	assert.True(t, matcher.Match(config.Match, "aa", []string{"ab", "baab"}))
+	assert.False(t, matcher.Match(config.Match, "bb", []string{"ab", "baab"}))
 }
 
 func TestMarshall(t *testing.T) {
-	config := veneur.SinkRoutingConfig{}
-	yamlString := `name: test
-match:
+	config := config{}
+	yamlString := `match:
     - name:
         kind: exact
         value: aa
@@ -357,11 +361,6 @@ match:
         - kind: prefix
           unset: true
           value: aa
-sinks:
-    matched:
-        - sink1
-    not_matched:
-        - sink2
 `
 
 	require.NoError(t, yaml.Unmarshal([]byte(yamlString), &config))

--- a/worker.go
+++ b/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
 	"github.com/stripe/veneur/v14/trace/metrics"
+	"github.com/stripe/veneur/v14/util/matcher"
 )
 
 const (
@@ -456,7 +457,7 @@ func (w *Worker) ImportMetricGRPC(other *metricpb.Metric) (err error) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	key := samplers.NewMetricKeyFromMetric(other)
+	key := samplers.NewMetricKeyFromMetric(other, []matcher.TagMatcher{})
 
 	scope := samplers.ScopeFromPB(other.Scope)
 	if other.Type == metricpb.Type_Counter || other.Type == metricpb.Type_Gauge {


### PR DESCRIPTION
#### Summary
This change adds a configuration field to ignore tags when sharding metrics in Veneur Proxy. As a part of this change, tag matching logic was moved into its own directory.
