### PR TITLE
Allow multiple GrpcForwardAddress values in Veneur Proxy.

### DIFF
--- a/config_proxy.go
+++ b/config_proxy.go
@@ -15,7 +15,7 @@ type ProxyConfig struct {
 	ForwardAddress               string               `yaml:"forward_address"`
 	ForwardTimeout               string               `yaml:"forward_timeout"`
 	GrpcAddress                  string               `yaml:"grpc_address"`
-	GrpcForwardAddress           string               `yaml:"grpc_forward_address"`
+	GrpcForwardAddress           []string             `yaml:"grpc_forward_address"`
 	HTTPAddress                  string               `yaml:"http_address"`
 	IdleConnectionTimeout        string               `yaml:"idle_connection_timeout"`
 	IgnoreTags                   []matcher.TagMatcher `yaml:"ignore_tags"`

--- a/example_proxy.yaml
+++ b/example_proxy.yaml
@@ -27,7 +27,8 @@ consul_forward_service_name: "forwardServiceName"
 
 ### gRPC forwarding
 # Use a static host for forwarding (without a prefix)
-grpc_forward_address: "veneur-grpc.example.com:8128"
+grpc_forward_address:
+  - "veneur-grpc.example.com:8128"
 # Or use a consul service for consistent forwarding.
 consul_forward_grpc_service_name: "grpcForwardServiceName"
 

--- a/forward_grpc_test.go
+++ b/forward_grpc_test.go
@@ -154,7 +154,7 @@ func newForwardGRPCFixture(
 		HTTPAddress:            "127.0.0.1:0",
 		GrpcAddress:            unusedLocalTCPAddress(t),
 		StatsAddress:           "127.0.0.1:8201",
-		GrpcForwardAddress:     globalConfig.GrpcAddress,
+		GrpcForwardAddress:     []string{globalConfig.GrpcAddress},
 	}
 	proxy, err := veneur.NewProxyFromConfig(logrus.New(), proxyConfig)
 	assert.NoError(t, err)

--- a/proxy.go
+++ b/proxy.go
@@ -147,7 +147,7 @@ func NewProxyFromConfig(
 	if proxy.ConsulTraceService != "" || conf.TraceAddress != "" {
 		proxy.AcceptingTraces = true
 	}
-	if proxy.ConsulForwardGRPCService != "" || conf.GrpcForwardAddress != "" {
+	if proxy.ConsulForwardGRPCService != "" || len(conf.GrpcForwardAddress) > 0 {
 		proxy.AcceptingGRPCForwards = true
 	}
 
@@ -196,8 +196,10 @@ func NewProxyFromConfig(
 	if proxy.ConsulTraceService == "" && conf.TraceAddress != "" {
 		proxy.TraceDestinations.Add(conf.TraceAddress)
 	}
-	if proxy.ConsulForwardGRPCService == "" && conf.GrpcForwardAddress != "" {
-		proxy.ForwardGRPCDestinations.Add(conf.GrpcForwardAddress)
+	if proxy.ConsulForwardGRPCService == "" {
+		for _, address := range conf.GrpcForwardAddress {
+			proxy.ForwardGRPCDestinations.Add(address)
+		}
 	}
 
 	if !proxy.AcceptingForwards &&


### PR DESCRIPTION
#### Summary
This change allows for multiple GrpcForwardAddress values in Veneur Proxy.

#### Motivation
Without this change, it is difficult to test Veneur Proxy sharding logic locally.
