### PR TITLE
remove redundant cortex "flushed" log line

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -190,10 +190,6 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 	flushedMetrics := 0
 	droppedMetrics := 0
 	defer func() {
-		s.logger.WithFields(logrus.Fields{
-			"metrics_flushed": flushedMetrics,
-			"metrics_dropped": droppedMetrics,
-		}).Info("flushed")
 		span.Add(ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(flushedMetrics), metricKeyTags))
 		span.Add(ssf.Count(sinks.MetricKeyTotalMetricsDropped, float32(droppedMetrics), metricKeyTags))
 	}()


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
removes redundant log line to save log volume

r? @andresgalindo-stripe 

#### Motivation
<!-- Why are you making this change? -->
https://github.com/stripe/veneur/blob/0cdde7fa/sinks/cortex/cortex.go#L193-L196 is redundant with https://github.com/stripe/veneur/blob/0cdde7fa/flusher.go#L165-L169

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
deploy, observe redundant log line is gone