### PR TITLE
[cortex] don't attempt to RemoteWrite if there are no metrics to flush

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -198,6 +198,10 @@ func (s *CortexMetricSink) Flush(ctx context.Context, metrics []samplers.InterMe
 		span.Add(ssf.Count(sinks.MetricKeyTotalMetricsDropped, float32(droppedMetrics), metricKeyTags))
 	}()
 
+	if len(metrics) == 0 {
+		return sinks.MetricFlushResult{}, nil
+	}
+
 	if s.batchWriteSize == 0 || len(metrics) <= s.batchWriteSize {
 		err := s.writeMetrics(ctx, metrics)
 		if err == nil {


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
[cortex] don't attempt to RemoteWrite if there are no metrics to flush

r? @andresgalindo-stripe 

#### Motivation
<!-- Why are you making this change? -->
remove unnecessary RemoteWrite API call
