### PR TITLE
attach flush duration metadata to sinks.FlushCompleteMessage

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -156,11 +156,12 @@ func (s *Server) Flush(ctx context.Context) {
 			flushStart := time.Now()
 			flushResult, err := sink.sink.Flush(span.Attach(ctx), filteredMetrics)
 			flushCompleteMessageFields := logrus.Fields{
-				"sink_name": sink.sink.Name(),
-				"sink_kind": sink.sink.Kind(),
-				"flushed":   flushResult.MetricsFlushed,
-				"skipped":   flushResult.MetricsSkipped,
-				"dropped":   flushResult.MetricsDropped,
+				"sink_name":  sink.sink.Name(),
+				"sink_kind":  sink.sink.Kind(),
+				"flushed":    flushResult.MetricsFlushed,
+				"skipped":    flushResult.MetricsSkipped,
+				"dropped":    flushResult.MetricsDropped,
+				"duration_s": fmt.Sprintf("%.2f", time.Since(flushStart).Seconds()),
 			}
 			if err == nil {
 				s.logger.WithFields(flushCompleteMessageFields).WithField("success", true).Info(sinks.FlushCompleteMessage)


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Attaches field `duration_s` to the sink flush message

r? @arnavdugar-stripe 

#### Motivation
<!-- Why are you making this change? -->
Enrich existing logs

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Introduced artifical latency to a sink, confirmed the change works locally:

```
INFO[0013] Flush complete                                dropped=0 duration_s=3.00 flushed=0 sink_kind=debug sink_name=default_sink_routing skipped=0 success=true
```