### PR TITLE
Simplify logic for ingesting metrics via http in `veneur-proxy` and `veneur`.

### DIFF
--- a/forward_test.go
+++ b/forward_test.go
@@ -37,7 +37,7 @@ func newForwardingFixture(t testing.TB, localConfig Config, transport http.Round
 
 	// Make the global veneur:
 	ff.global = setupVeneurServer(t, globalConfig(), transport, globalSink, nil, nil)
-	ff.globalTS = httptest.NewServer(handleImport(ff.global))
+	ff.globalTS = httptest.NewServer(http.HandlerFunc(ff.global.handleImport))
 
 	// Make the proxy that sends to the global veneur:
 	proxyCfg := generateProxyConfig()

--- a/http_test.go
+++ b/http_test.go
@@ -126,8 +126,7 @@ func testServerImport(t *testing.T, filename string, contentEncoding string) {
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(s)
-	handler.ServeHTTP(w, r)
+	s.handleImport(w, r)
 
 	assert.Equal(t, http.StatusAccepted, w.Code, "Test server returned wrong HTTP response code")
 }
@@ -167,8 +166,7 @@ func TestServerImportGzip(t *testing.T) {
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(s)
-	handler.ServeHTTP(w, r)
+	s.handleImport(w, r)
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code, "Test server returned wrong HTTP response code")
 }
@@ -192,8 +190,7 @@ func TestServerImportCompressedInvalid(t *testing.T) {
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(s)
-	handler.ServeHTTP(w, r)
+	s.handleImport(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
 }
@@ -217,8 +214,7 @@ func TestServerImportUncompressedInvalid(t *testing.T) {
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(s)
-	handler.ServeHTTP(w, r)
+	s.handleImport(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
 }
@@ -366,8 +362,7 @@ func testServerImportHelper(t *testing.T, data interface{}) {
 	s := setupVeneurServer(t, config, nil, nil, nil, nil)
 	defer s.Shutdown()
 
-	handler := handleImport(s)
-	handler.ServeHTTP(w, r)
+	s.handleImport(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Test server returned wrong HTTP response code")
 }


### PR DESCRIPTION
#### Summary
Simplify logic for ingesting metrics via http in `veneur-proxy` and `veneur`.
