### PR TITLE
Add support to attach user specified HTTP handlers.

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
 	"os"
 
 	"github.com/getsentry/sentry-go"
@@ -187,6 +188,11 @@ func main() {
 			"xray": {
 				Create:      xray.Create,
 				ParseConfig: xray.ParseConfig,
+			},
+		},
+		HttpCustomHandlers: veneur.HttpCustomHandlers{
+			"/echo": func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("hello world!\n"))
 			},
 		},
 	})

--- a/http.go
+++ b/http.go
@@ -56,6 +56,10 @@ func (s *Server) Handler() http.Handler {
 		w.Write([]byte("ok\n"))
 	})
 
+	for endpoint, customHandler := range s.HttpCustomHandlers {
+		mux.HandleFunc(pat.Get(endpoint), customHandler)
+	}
+
 	mux.Handle(pat.Post("/import"), http.HandlerFunc(s.handleImport))
 
 	mux.Handle(pat.Get("/debug/pprof/cmdline"), http.HandlerFunc(pprof.Cmdline))


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->

r? @rma-stripe @arnav-stripe 

#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This PR allows users to add custom HTTP handlers and thereby build new endpoints that serves their use cases.

#### Motivation
<!-- Why are you making this change? -->
At Stripe we are building bespoke Server Sent Event (SSE) Veneur sink that allows developers to filter specific metrics using HTTP calls. This PR provides a way to register the SSE sink's HTTP endpoint.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
- Verified that server boots up whenever custom handler is provided (checkout changes in `main.go`).
- If the custom handler is not provided, it's a no-op. 


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
N.A.