### PR TITLE
trace: remove contention on trace ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Migrate Prometheus to new config format; part of multi-sink routing update. Thanks, [truong-stripe](https://github.com/truong-stripe)!
 * Authentication support for Cortex remote-write sink. Thanks, [oscil8](https://github.com/oscil8)!
 * Option to flush sinks on shutdown. Thanks, [csolidum](https://github.com/csolidum)!
+* `trace.StartTrace` and `trace.StartChildSpan` now scale better across multiple goroutines.  Thanks [bpowers](https://github.com/bpowers)
 
 ## Updated
 * Use `T.TempDir` to create temporary directory in tests ([#944](https://github.com/stripe/veneur/pull/944)).

--- a/internal/fastrand/global.go
+++ b/internal/fastrand/global.go
@@ -1,0 +1,11 @@
+package fastrand
+
+var globalPool = NewRandPool()
+
+func Int63() int64 {
+	return globalPool.Int63()
+}
+
+func Float64() float64 {
+	return globalPool.Float64()
+}

--- a/internal/fastrand/rand.go
+++ b/internal/fastrand/rand.go
@@ -1,0 +1,63 @@
+package fastrand
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/stripe/veneur/v14/internal/safepool"
+)
+
+func seed() int64 {
+	var buf [8]byte
+	n, err := crand.Read(buf[:])
+	if n != 8 || err != nil {
+		panic("invariant broken: crypto/rand.Read failed")
+	}
+	i := binary.LittleEndian.Uint64(buf[:])
+	return int64(i)
+}
+
+// RandPool is a typesafe wrapper around sync.Pool for *rand.Rand instances
+type RandPool struct {
+	pool safepool.Pool[*rand.Rand]
+}
+
+// NewRandPool returns a typesafe wrapper around sync.Pool for *rand.Rand instances.
+// The API of RandPool is safe for use by concurrent goroutines, but the returned objects
+// are not.  Objects are seeded with real randomness from crypto/rand.
+func NewRandPool() *RandPool {
+	return &RandPool{
+		pool: *safepool.NewPool(func() *rand.Rand {
+			source := rand.NewSource(seed())
+			// nolint:gosec G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
+			return rand.New(source)
+		}),
+	}
+}
+
+// Get returns a *rand.Rand for random number generation.  This method is safe for use
+// from concurrent goroutines, but the returned *rand.Rand must only be used from a single
+// goroutine.
+func (p *RandPool) Get() *rand.Rand {
+	return p.pool.Get()
+}
+
+// Put returns a *rand.Rand to the pool.  This method is safe for use from concurrent goroutines.
+func (p *RandPool) Put(r *rand.Rand) {
+	p.pool.Put(r)
+}
+
+// Float64 returns, as a float64, a pseudo-random number in the half-open interval [0.0,1.0).
+func (p *RandPool) Float64() float64 {
+	r := p.Get()
+	defer p.Put(r)
+	return r.Float64()
+}
+
+// Int63 returns a non-negative pseudo-random 63-bit integer as an int64.
+func (p *RandPool) Int63() int64 {
+	r := p.Get()
+	defer p.Put(r)
+	return r.Int63()
+}

--- a/internal/fastrand/rand_test.go
+++ b/internal/fastrand/rand_test.go
@@ -1,0 +1,55 @@
+package fastrand
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandPoolUsage(t *testing.T) {
+	t.Parallel()
+
+	s := NewRandPool()
+
+	ok := false
+	// seeing four int64(0)s in a row is very (1/(2^(8*4))) unlikely, and
+	// indicates something is broken in our randomness pool
+	for i := 0; i < 4; i++ {
+		if s.Int63() != 0 {
+			ok = true
+			break
+		}
+	}
+	require.True(t, ok)
+}
+
+func TestGlobalUsage(t *testing.T) {
+	t.Parallel()
+
+	const ε = .00002
+
+	ok := false
+	// seeing four int64(0)s in a row is very (1/(2^(8*4))) unlikely, and
+	// indicates something is broken in our randomness pool
+	for i := 0; i < 4; i++ {
+		if Int63() != 0 {
+			ok = true
+			break
+		}
+	}
+	require.True(t, ok)
+
+	// same type of test for Float64, but check against ε rather than literal 0.0
+	for i := 0; i < 4; i++ {
+		n := Float64()
+		require.False(t, math.IsNaN(n))
+		// Float64's return value is in [0, 1) (always non-negative) so no Abs
+		// is needed for this comparison
+		if n > ε {
+			ok = true
+			break
+		}
+	}
+	require.True(t, ok)
+}

--- a/internal/safepool/safepool.go
+++ b/internal/safepool/safepool.go
@@ -1,0 +1,31 @@
+package safepool
+
+import (
+	"sync"
+)
+
+// Pool is a generic, safe wrapper around sync.Pool.
+type Pool[T any] struct {
+	p sync.Pool
+}
+
+// NewPool returns a safe wrapper around sync.Pool for a given type.
+func NewPool[T any](newFn func() T) *Pool[T] {
+	return &Pool[T]{
+		p: sync.Pool{
+			New: func() interface{} {
+				return newFn()
+			},
+		},
+	}
+}
+
+// Get returns an item of type T.
+func (p *Pool[T]) Get() T {
+	return p.p.Get().(T)
+}
+
+// Put returns an item of type T to the pool for reuse.
+func (p *Pool[T]) Put(item T) {
+	p.p.Put(item)
+}

--- a/internal/safepool/safepool_test.go
+++ b/internal/safepool/safepool_test.go
@@ -1,0 +1,14 @@
+package safepool
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewPool(t *testing.T) {
+	const theNumber = int(3)
+	p := NewPool(func() int { return theNumber })
+	n := p.Get()
+	require.Equal(t, theNumber, n)
+	p.Put(n)
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -3,7 +3,6 @@ package trace
 import (
 	"context"
 	"io"
-	"math/rand"
 	"path"
 	"reflect"
 	"runtime"
@@ -13,9 +12,11 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/stripe/veneur/v14/ssf"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/mod/module"
+
+	"github.com/stripe/veneur/v14/internal/fastrand"
+	"github.com/stripe/veneur/v14/ssf"
 )
 
 // Experimental
@@ -322,29 +323,28 @@ func (t *Trace) contextAsParent() *spanContext {
 // StartTrace is called by to create the root-level span
 // for a trace
 func StartTrace(resource string) *Trace {
-	traceID := proto.Int64(rand.Int63())
+	traceID := fastrand.Int63()
 
 	t := &Trace{
-		TraceID:  *traceID,
-		SpanID:   *traceID,
+		TraceID:  traceID,
+		SpanID:   traceID,
 		ParentID: 0,
 		Resource: resource,
 		Tags:     map[string]string{},
+		Start:    time.Now(),
 	}
 
-	t.Start = time.Now()
 	return t
 }
 
 // StartChildSpan creates a new Span with the specified parent
 func StartChildSpan(parent *Trace) *Trace {
-	spanID := proto.Int64(rand.Int63())
 	span := &Trace{
-		SpanID: *spanID,
+		SpanID: fastrand.Int63(),
+		Start:  time.Now(),
 	}
 
 	span.SetParent(parent)
-	span.Start = time.Now()
 
 	return span
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -327,3 +327,13 @@ func BenchmarkMarshalSSF(b *testing.B) {
 		proto.Marshal(span)
 	}
 }
+
+func BenchmarkStartChildSpan(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(b *testing.PB) {
+		root := StartTrace("benchmark")
+		for b.Next() {
+			_ = StartChildSpan(root)
+		}
+	})
+}


### PR DESCRIPTION
#### Summary
Use a `sync.Pool[*rand.Rand]` for generating `int64` trace IDs instead of the global `math/rand.Int63()`, which grabs a global mutex.  This mutex showed up as having high contention and limiting throughput in an internal benchmark.

On a 4 CPU machine, this reduces the runtime of StartChildSpan by 74%:
```
name              old time/op    new time/op    delta
StartChildSpan      72.1ns ± 1%    80.9ns ± 1%  +12.16%  (p=0.002 n=6+6)
StartChildSpan-2    92.9ns ± 1%    48.2ns ± 2%  -48.07%  (p=0.002 n=6+6)
StartChildSpan-4     125ns ± 0%      35ns ± 2%  -72.39%  (p=0.004 n=5+6)
```

#### Motivation
Improved scalability for HTTP servers that generate trace IDs for each request.

#### Test plan
Added unit tests for the new functionality, and ensured existing tests pass for the `trace` changes.

#### Rollout/monitoring/revert plan
`go get github.com/stripe/veneur@latest` in downstream repos and ensure tests pass and benchmarks improve