### PR TITLE
Cloudwatch & SFX sinks log count of Dropped Metrics on Put failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Updated
 * Use `T.TempDir` to create temporary directory in tests ([#944](https://github.com/stripe/veneur/pull/944)).
-* When `PutMetricData` fails in Cloudwatch Sink, log metrics are dropped. 
+* When `PutMetricData` fails in Cloudwatch Sink, log the count of metrics that are dropped. 
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Updated
 * Use `T.TempDir` to create temporary directory in tests ([#944](https://github.com/stripe/veneur/pull/944)).
+* When `PutMetricData` fails in Cloudwatch Sink, log metrics are dropped. 
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Updated
 * Use `T.TempDir` to create temporary directory in tests ([#944](https://github.com/stripe/veneur/pull/944)).
-* When `PutMetricData` fails in Cloudwatch Sink, log the count of metrics that are dropped. 
+* When the request to send data from Cloudwatch & SFX sink fails, log the count of metrics that are dropped. 
 
 ## Bugfixes
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!

--- a/sinks/cloudwatch/cloudwatch.go
+++ b/sinks/cloudwatch/cloudwatch.go
@@ -177,7 +177,7 @@ func (s *cloudwatchMetricSink) Flush(ctx context.Context, metrics []samplers.Int
 		Namespace:  aws.String(s.namespace),
 		MetricData: metricData,
 	}
-	_, err := s.client.PutMetricData(ctx, input) // Put to AWS Cloudwatch
+	_, err := s.client.PutMetricData(ctx, input)
 	if err != nil {
 		return sinks.MetricFlushResult{MetricsDropped: len(metricData)}, err
 	}

--- a/sinks/cloudwatch/cloudwatch.go
+++ b/sinks/cloudwatch/cloudwatch.go
@@ -177,9 +177,9 @@ func (s *cloudwatchMetricSink) Flush(ctx context.Context, metrics []samplers.Int
 		Namespace:  aws.String(s.namespace),
 		MetricData: metricData,
 	}
-	_, err := s.client.PutMetricData(ctx, input)
+	_, err := s.client.PutMetricData(ctx, input) // Put to AWS Cloudwatch
 	if err != nil {
-		return sinks.MetricFlushResult{}, err
+		return sinks.MetricFlushResult{MetricsDropped: len(metricData)}, err
 	}
 	return sinks.MetricFlushResult{MetricsFlushed: len(metricData)}, nil
 }

--- a/sinks/cloudwatch/cloudwatch_test.go
+++ b/sinks/cloudwatch/cloudwatch_test.go
@@ -48,7 +48,7 @@ func NewTestServer(t *testing.T, handlerDelay time.Duration, reqBodyCh chan []by
 	server := httptest.NewServer(router)
 	result.URL = server.URL + "/"
 	result.server = server
-	t.Log("test server listening on", result.URL)
+	t.Log("test server listening on", server.URL)
 
 	return &result
 }

--- a/sinks/cloudwatch/cloudwatch_test.go
+++ b/sinks/cloudwatch/cloudwatch_test.go
@@ -105,14 +105,7 @@ func TestFlush(t *testing.T) {
 	// Flush the sink
 	flushResult, err := sink.Flush(context.Background(), metrics)
 	assert.NoError(t, err)
-	assert.Equal(t,
-		sinks.MetricFlushResult{
-			MetricsFlushed: 3,
-			MetricsSkipped: 0,
-			MetricsDropped: 0,
-		},
-		flushResult,
-	)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 3}, flushResult)
 
 	<-done
 }
@@ -150,14 +143,7 @@ func TestFlushWithStandardUnitTagName(t *testing.T) {
 	// Flush the sink
 	flushResult, err := sink.Flush(context.Background(), metrics)
 	assert.NoError(t, err)
-	assert.Equal(t,
-		sinks.MetricFlushResult{
-			MetricsFlushed: 1,
-			MetricsSkipped: 0,
-			MetricsDropped: 0,
-		},
-		flushResult,
-	)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1}, flushResult)
 
 	<-done
 }
@@ -198,14 +184,7 @@ func TestFlushWithStripTags(t *testing.T) {
 	// Flush the sink
 	flushResult, err := sink.Flush(context.Background(), metrics)
 	assert.NoError(t, err)
-	assert.Equal(t,
-		sinks.MetricFlushResult{
-			MetricsFlushed: 3,
-			MetricsSkipped: 0,
-			MetricsDropped: 0,
-		},
-		flushResult,
-	)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 3}, flushResult)
 
 	<-done
 }
@@ -237,14 +216,7 @@ func TestFlushNoop(t *testing.T) {
 	// Flush the sink
 	flushResult, err := sink.Flush(context.Background(), metrics)
 	assert.NoError(t, err)
-	assert.Equal(t,
-		sinks.MetricFlushResult{
-			MetricsFlushed: 0,
-			MetricsSkipped: 0,
-			MetricsDropped: 0,
-		},
-		flushResult,
-	)
+	assert.Equal(t, sinks.MetricFlushResult{}, flushResult)
 
 	<-done
 }
@@ -279,14 +251,7 @@ func TestFlushRemoteTimeout(t *testing.T) {
 	// Assert the flush failed, and metrics were dropped
 	flushResult, err := sink.Flush(context.Background(), metrics)
 	assert.Error(t, err)
-	assert.Equal(t,
-		sinks.MetricFlushResult{
-			MetricsFlushed: 0,
-			MetricsSkipped: 0,
-			MetricsDropped: 3,
-		},
-		flushResult,
-	)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsDropped: 3}, flushResult)
 
 	<-done
 }

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -617,10 +617,11 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsSkipped, float32(countSkipped), tags))
 	err := coll.submit(subCtx, sfx.traceClient, sfx.maxPointsInBatch)
 	if err != nil {
+		span.Add(ssf.Count(sinks.MetricKeyTotalMetricsDropped, float32(numPoints), tags))
 		span.Error(err)
+		return sinks.MetricFlushResult{MetricsDropped: numPoints, MetricsSkipped: countSkipped}, err
 	}
 	span.Add(ssf.Count(sinks.MetricKeyTotalMetricsFlushed, float32(numPoints), tags))
-
 	return sinks.MetricFlushResult{MetricsFlushed: numPoints, MetricsSkipped: countSkipped}, err
 }
 

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -22,6 +22,7 @@ import (
 	veneur "github.com/stripe/veneur/v14"
 	"github.com/stripe/veneur/v14/protocol/dogstatsd"
 	"github.com/stripe/veneur/v14/samplers"
+	"github.com/stripe/veneur/v14/sinks"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/util"
 )
@@ -144,7 +145,9 @@ func TestSignalFxFlushGauge(t *testing.T) {
 		Type: samplers.GaugeMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1}, flushResult)
 
 	assert.Equal(t, 1, len(fakeSink.points))
 	point := fakeSink.points[0]
@@ -189,7 +192,9 @@ func TestSignalFxFlushCounter(t *testing.T) {
 		Type: samplers.CounterMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1}, flushResult)
 
 	assert.Equal(t, 1, len(fakeSink.points))
 	point := fakeSink.points[0]
@@ -255,7 +260,9 @@ func TestSignalFxFlushWithDrops(t *testing.T) {
 		Type: samplers.CounterMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1, MetricsSkipped: 2}, flushResult)
 
 	assert.Equal(t, 1, len(fakeSink.points))
 	point := fakeSink.points[0]
@@ -290,7 +297,9 @@ func TestSignalFxFlushStatus(t *testing.T) {
 		Type: samplers.StatusMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1}, flushResult)
 
 	assert.Equal(t, 1, len(fakeSink.points))
 	point := fakeSink.points[0]
@@ -407,7 +416,10 @@ func TestSignalFxSetExcludeTags(t *testing.T) {
 		},
 		Type: samplers.CounterMetric,
 	}}
-	sink.Flush(context.Background(), interMetrics)
+
+	flushResult, err := sink.Flush(context.Background(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 1}, flushResult)
 
 	ev := ssf.SSFSample{
 		Name:      "Test Event",
@@ -489,7 +501,9 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 		Type: samplers.GaugeMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 2}, flushResult)
 
 	assert.Equal(t, 1, len(fallback.points))
 	assert.Equal(t, 1, len(specialized.points))
@@ -566,8 +580,9 @@ func TestSignalFxFlushBatches(t *testing.T) {
 		Type: samplers.GaugeMetric,
 	}}
 
-	_, err = sink.Flush(context.TODO(), interMetrics)
-	require.NoError(t, err)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 2}, flushResult)
 
 	assert.Equal(t, 2, len(fallback.points))
 	assert.Equal(t, 2, fallback.pointAdds)
@@ -624,8 +639,9 @@ func TestSignalFxFlushBatchHang(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
-	_, err = sink.Flush(ctx, interMetrics)
-	require.Error(t, err)
+	flushResult, err := sink.Flush(ctx, interMetrics)
+	assert.Error(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsDropped: 2}, flushResult)
 }
 
 func TestNewSinkDoubleSlashes(t *testing.T) {
@@ -862,7 +878,9 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 		Type:      samplers.GaugeMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 2}, flushResult)
 
 	assert.Equal(t, 0, len(defaultFakeSink.points))
 	assert.Equal(t, 1, len(customFakeSinkFoo.points))
@@ -913,7 +931,9 @@ func TestSignalFxVaryByOverridePreferringCommonDimensions(t *testing.T) {
 		Type:      samplers.GaugeMetric,
 	}}
 
-	sink.Flush(context.TODO(), interMetrics)
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 2}, flushResult)
 
 	assert.Equal(t, 0, len(defaultFakeSink.points))
 	assert.Equal(t, 1, len(customFakeSinkFoo.points))


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
When `PutMetricData` fails in the Cloudwatch Sink `Flush` function, we now log all those metrics as being Dropped. 
Similarly, when the `submit` to SFX fails, we log the lost metrics as dropped.

Edit: Audited Cortex sink `cortex.go`, and Signalfx sink `signalfx.go` to ensure they also log number of Flushed/Dropped/Skipped metrics. 

Edit: Thanks to @rma-stripe found that SFX also had an issue where, on failure, the SFX sink would report metrics as "Flushed" rather than as dropped.

#### Motivation
We found an issue when trying to push to Cloudwatch, and the request failed, the generated logs indicated that the request had no associated metrics. However, there is a scenario where the request fails and metrics were actually dropped.


#### Test plan
Extend the existing tests to count the number of metrics flushed/dropped/skipped, and compare that to the expected value. 


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
We will rollout this change to one host to see how the veneur client is behaving (whether it crashes and emits the correct logs). 