### PR TITLE
Fix typo in comment on Cloudwatch sink tests

### DIFF
--- a/sinks/cloudwatch/cloudwatch_test.go
+++ b/sinks/cloudwatch/cloudwatch_test.go
@@ -151,7 +151,7 @@ func TestFlushWithStripTags(t *testing.T) {
 	server := NewTestServer(t, 0, reqBodyCh)
 	defer server.Close()
 
-	// input.2.json contains timeseries with tags to strip, and tags to keep
+	// input.3.json contains timeseries with tags to strip, and tags to keep
 	jsInput, err := ioutil.ReadFile("testdata/input.3.json")
 	assert.NoError(t, err)
 	var metrics []samplers.InterMetric


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
As title. This change fixes typo in comment on Cloudwatch sink tests


#### Motivation
Better comments make code easier to read


#### Test plan
No testing as this changes 0 functionality 


#### Rollout/monitoring/revert plan
Can be safely reverted.
