### PR TITLE
Fix importing metrics from veneur-proxy.

### DIFF
--- a/sources/mock/mock.go
+++ b/sources/mock/mock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	samplers "github.com/stripe/veneur/v14/samplers"
+	metricpb "github.com/stripe/veneur/v14/samplers/metricpb"
 	sources "github.com/stripe/veneur/v14/sources"
 )
 
@@ -131,4 +132,16 @@ func (m *MockIngest) IngestMetric(metric *samplers.UDPMetric) {
 func (mr *MockIngestMockRecorder) IngestMetric(metric interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestMetric", reflect.TypeOf((*MockIngest)(nil).IngestMetric), metric)
+}
+
+// IngestMetricProto mocks base method.
+func (m *MockIngest) IngestMetricProto(metric *metricpb.Metric) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IngestMetricProto", metric)
+}
+
+// IngestMetricProto indicates an expected call of IngestMetricProto.
+func (mr *MockIngestMockRecorder) IngestMetricProto(metric interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestMetricProto", reflect.TypeOf((*MockIngest)(nil).IngestMetricProto), metric)
 }

--- a/sources/proxy/server.go
+++ b/sources/proxy/server.go
@@ -6,7 +6,6 @@
 package proxy
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"time"
@@ -14,13 +13,11 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/segmentio/fasthash/fnv1a"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/stripe/veneur/v14/forwardrpc"
-	"github.com/stripe/veneur/v14/samplers/metricpb"
 	"github.com/stripe/veneur/v14/sources"
 	"github.com/stripe/veneur/v14/ssf"
 	"github.com/stripe/veneur/v14/trace"
@@ -30,21 +27,18 @@ const (
 	responseDurationMetric = "import.response_duration_ns"
 )
 
-// MetricIngester reads metrics from protobufs
-type MetricIngester interface {
-	IngestMetrics([]*metricpb.Metric)
-}
-
 // Server wraps a gRPC server and implements the forwardrpc.Forward service.
 // It reads a list of metrics, and based on the provided key chooses a
 // MetricIngester to send it to.  A unique metric (name, tags, and type)
 // should always be routed to the same MetricIngester.
 type Server struct {
 	*grpc.Server
-	address    string
-	logger     *logrus.Entry
-	metricOuts []MetricIngester
-	opts       *options
+	address      string
+	ingest       sources.Ingest
+	listener     net.Listener
+	logger       *logrus.Entry
+	opts         *options
+	readyChannel chan struct{}
 }
 
 var _ sources.Source = &Server{}
@@ -59,13 +53,13 @@ type Option func(*options)
 
 // New creates an unstarted Server with the input MetricIngester's to send
 // output to.
-func New(address string, metricOuts []MetricIngester, logger *logrus.Entry, opts ...Option) *Server {
+func New(address string, logger *logrus.Entry, opts ...Option) *Server {
 	res := &Server{
-		address:    address,
-		logger:     logger,
-		metricOuts: metricOuts,
-		opts:       &options{},
-		Server:     grpc.NewServer(),
+		address:      address,
+		logger:       logger,
+		opts:         &options{},
+		Server:       grpc.NewServer(),
+		readyChannel: make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -94,21 +88,34 @@ func (s *Server) Name() string {
 // the gRPC server when the HTTP one exits.  When running just gRPC however,
 // the signal handling won't work.
 func (s *Server) Start(ingest sources.Ingest) error {
-	entry := logrus.WithFields(logrus.Fields{"address": s.address})
-	entry.Info("Starting gRPC server")
+	s.ingest = ingest
 
-	listener, err := net.Listen("tcp", s.address)
+	var err error
+	s.listener, err = net.Listen("tcp", s.address)
 	if err != nil {
-		return fmt.Errorf("failed to bind the import server to '%s': %v",
-			s.address, err)
+		s.logger.WithError(err).WithField("address", s.address).
+			Errorf("failed to bind import server")
+		return err
 	}
 
-	err = s.Server.Serve(listener)
+	logger := s.logger.WithFields(logrus.Fields{"address": s.listener.Addr()})
+	logger.Info("Starting gRPC server")
+
+	close(s.readyChannel)
+	err = s.Server.Serve(s.listener)
 	if err != nil {
-		entry.WithError(err).Error("gRPC server was not shut down cleanly")
+		logger.WithError(err).Error("gRPC server was not shut down cleanly")
 	}
-	entry.Info("Stopped gRPC server")
+	logger.Info("Stopped gRPC server")
 	return err
+}
+
+func (s *Server) GetAddress() string {
+	return s.listener.Addr().String()
+}
+
+func (s *Server) Ready() <-chan struct{} {
+	return s.readyChannel
 }
 
 // Try to perform a graceful stop of the gRPC server.  If it takes more than
@@ -132,11 +139,7 @@ func (s *Server) Stop() {
 
 // Static maps of tags used in the SendMetrics handler
 var (
-	grpcTags          = map[string]string{"protocol": "grpc"}
-	responseGroupTags = map[string]string{
-		"protocol": "grpc",
-		"part":     "group",
-	}
+	grpcTags         = map[string]string{"protocol": "grpc"}
 	responseSendTags = map[string]string{
 		"protocol": "grpc",
 		"part":     "send",
@@ -150,24 +153,9 @@ func (s *Server) SendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) 
 	span.SetTag("protocol", "grpc")
 	defer span.ClientFinish(s.opts.traceClient)
 
-	dests := make([][]*metricpb.Metric, len(s.metricOuts))
-
-	// group metrics by their destination
-	groupStart := time.Now()
-	for _, m := range mlist.Metrics {
-		workerIdx := s.hashMetric(m) % uint32(len(dests))
-		dests[workerIdx] = append(dests[workerIdx], m)
-	}
-	span.Add(ssf.Timing(responseDurationMetric, time.Since(groupStart), time.Nanosecond, responseGroupTags))
-
-	// send each set of metrics to its destination.  Since this is typically
-	// implemented with channels, batching the metrics together avoids
-	// repeated channel send operations
 	sendStart := time.Now()
-	for i, ms := range dests {
-		if len(ms) > 0 {
-			s.metricOuts[i].IngestMetrics(ms)
-		}
+	for _, metric := range mlist.Metrics {
+		s.ingest.IngestMetricProto(metric)
 	}
 
 	span.Add(
@@ -181,38 +169,19 @@ func (s *Server) SendMetrics(ctx context.Context, mlist *forwardrpc.MetricList) 
 func (s *Server) SendMetricsV2(
 	server forwardrpc.Forward_SendMetricsV2Server,
 ) error {
-	metrics := []*metricpb.Metric{}
 	for {
 		metric, err := server.Recv()
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			s.logger.WithError(err).Error("error recieving metrics")
-			break
+			return err
 		}
-		metrics = append(metrics, metric)
+		s.ingest.IngestMetricProto(metric)
 	}
 	err := server.SendAndClose(&emptypb.Empty{})
 	if err != nil {
 		s.logger.WithError(err).Error("error closing stream")
 	}
-	_, err = s.SendMetrics(context.Background(), &forwardrpc.MetricList{
-		Metrics: metrics,
-	})
 	return err
-}
-
-// hashMetric returns a 32-bit hash from the input metric based on its name,
-// type, and tags.
-//
-// The fnv1a package is used as opposed to fnv from the standard library, as
-// it avoids allocations by not using the hash.Hash interface and by avoiding
-// string to []byte conversions.
-func (s *Server) hashMetric(m *metricpb.Metric) uint32 {
-	h := fnv1a.HashString32(m.Name)
-	h = fnv1a.AddString32(h, m.Type.String())
-	for _, tag := range m.Tags {
-		h = fnv1a.AddString32(h, tag)
-	}
-	return h
 }

--- a/sources/proxy/server_test.go
+++ b/sources/proxy/server_test.go
@@ -1,151 +1,146 @@
-package proxy
+package proxy_test
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/veneur/v14/forwardrpc"
 	"github.com/stripe/veneur/v14/samplers/metricpb"
-	metrictest "github.com/stripe/veneur/v14/samplers/metricpb/testutils"
-	"github.com/stripe/veneur/v14/trace"
+	"github.com/stripe/veneur/v14/sources/mock"
+	"github.com/stripe/veneur/v14/sources/proxy"
+	"google.golang.org/grpc"
 )
 
-type testMetricIngester struct {
-	metrics []*metricpb.Metric
-}
-
-func (mi *testMetricIngester) IngestMetrics(ms []*metricpb.Metric) {
-	mi.metrics = append(mi.metrics, ms...)
-}
-
-func (mi *testMetricIngester) clear() {
-	mi.metrics = mi.metrics[:0]
-}
-
-// Test that sending the same metric to a Veneur results in it being hashed
-// to the same worker every time
-func TestSendMetrics_ConsistentHash(t *testing.T) {
-	ingesters := []*testMetricIngester{{}, {}}
-
-	casted := make([]MetricIngester, len(ingesters))
-	for i, ingester := range ingesters {
-		casted[i] = ingester
-	}
+func TestName(t *testing.T) {
 	logger := logrus.NewEntry(logrus.New())
-	s := New("localhost", casted, logger)
+	server := proxy.New("localhost:0", logger)
 
-	inputs := []*metricpb.Metric{{
-		Name: "test.counter",
+	assert.Equal(t, "proxy", server.Name())
+}
+
+func TestStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIngest := mock.NewMockIngest(ctrl)
+
+	logger := logrus.NewEntry(logrus.New())
+	server := proxy.New("localhost:0", logger)
+
+	go server.Start(mockIngest)
+	<-server.Ready()
+	server.Stop()
+}
+
+func TestSendMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIngest := mock.NewMockIngest(ctrl)
+	metric := metricpb.Metric{
+		Name: "test-metric",
+		Tags: []string{"tag1:value1", "tag2:value2"},
 		Type: metricpb.Type_Counter,
-		Tags: []string{"tag:1"},
-	}, {
-		Name: "test.gauge",
-		Type: metricpb.Type_Gauge,
-	}, {
-		Name: "test.histogram",
-		Type: metricpb.Type_Histogram,
-		Tags: []string{"type:histogram"},
-	}, {
-		Name: "test.set",
-		Type: metricpb.Type_Set,
-	}, {
-		Name: "test.gauge3",
-		Type: metricpb.Type_Gauge,
-	}}
+		Value: &metricpb.Metric_Counter{
+			Counter: &metricpb.CounterValue{
+				Value: 10,
+			},
+		},
+	}
 
-	// Send the same inputs many times
+	logger := logrus.NewEntry(logrus.New())
+	server := proxy.New("localhost:0", logger)
+
+	go server.Start(mockIngest)
+	<-server.Ready()
+
+	connection, err := grpc.Dial(server.GetAddress(), grpc.WithInsecure())
+	assert.NoError(t, err)
+	client := forwardrpc.NewForwardClient(connection)
+
+	mockIngest.EXPECT().IngestMetricProto(&metric)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err = client.SendMetrics(ctx, &forwardrpc.MetricList{
+		Metrics: []*metricpb.Metric{&metric},
+	})
+	assert.NoError(t, err)
+
+	server.Stop()
+}
+
+func TestSendMetricsV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIngest := mock.NewMockIngest(ctrl)
+	metric := metricpb.Metric{
+		Name: "test-metric",
+		Tags: []string{"tag1:value1", "tag2:value2"},
+		Type: metricpb.Type_Counter,
+		Value: &metricpb.Metric_Counter{
+			Counter: &metricpb.CounterValue{
+				Value: 10,
+			},
+		},
+	}
+
+	logger := logrus.NewEntry(logrus.New())
+	server := proxy.New("localhost:0", logger)
+
+	go server.Start(mockIngest)
+	<-server.Ready()
+
+	connection, err := grpc.Dial(server.GetAddress(), grpc.WithInsecure())
+	assert.NoError(t, err)
+	client := forwardrpc.NewForwardClient(connection)
+
+	mockIngest.EXPECT().IngestMetricProto(&metric).Times(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sendClient, err := client.SendMetricsV2(ctx)
+	assert.NoError(t, err)
+
 	for i := 0; i < 10; i++ {
-		s.SendMetrics(context.Background(), &forwardrpc.MetricList{Metrics: inputs})
-
-		assert.Equal(t, []*metricpb.Metric{inputs[0], inputs[4]},
-			ingesters[0].metrics, "Ingester 0 has the wrong metrics")
-		assert.Equal(t, []*metricpb.Metric{inputs[1], inputs[2], inputs[3]},
-			ingesters[1].metrics, "Ingester 1 has the wrong metrics")
-
-		for _, ingester := range ingesters {
-			ingester.clear()
-		}
+		err = sendClient.Send(&metric)
+		assert.NoError(t, err)
 	}
+
+	_, err = sendClient.CloseAndRecv()
+	assert.NoError(t, err)
+
+	server.Stop()
 }
 
-func TestSendMetrics_Empty(t *testing.T) {
-	ingester := &testMetricIngester{}
+func TestSendMetricsV2ContextCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIngest := mock.NewMockIngest(ctrl)
+
 	logger := logrus.NewEntry(logrus.New())
-	s := New("localhost", []MetricIngester{ingester}, logger)
-	s.SendMetrics(context.Background(), &forwardrpc.MetricList{})
+	server := proxy.New("localhost:0", logger)
 
-	assert.Empty(t, ingester.metrics,
-		"The server shouldn't have submitted any metrics")
-}
+	go server.Start(mockIngest)
+	<-server.Ready()
 
-func TestOptions_WithTraceClient(t *testing.T) {
-	logger := logrus.NewEntry(logrus.New())
-	c, err := trace.NewClient(trace.DefaultVeneurAddress)
-	assert.NoError(t, err, "failed to initialize a trace client")
+	connection, err := grpc.Dial(server.GetAddress(), grpc.WithInsecure())
+	assert.NoError(t, err)
+	client := forwardrpc.NewForwardClient(connection)
 
-	s := New("localhost", []MetricIngester{}, logger, WithTraceClient(c))
-	assert.Equal(t, c, s.opts.traceClient,
-		"WithTraceClient didn't correctly set the trace client")
-}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-type noopChannelMetricIngester struct {
-	in   chan []*metricpb.Metric
-	quit chan struct{}
-}
+	sendClient, err := client.SendMetricsV2(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, sendClient)
 
-func newNoopChannelMetricIngester() *noopChannelMetricIngester {
-	return &noopChannelMetricIngester{
-		in:   make(chan []*metricpb.Metric),
-		quit: make(chan struct{}),
-	}
-}
-
-func (mi *noopChannelMetricIngester) start() {
-	go func() {
-		for {
-			select {
-			case <-mi.in:
-			case <-mi.quit:
-				return
-			}
-		}
-	}()
-}
-
-func (mi *noopChannelMetricIngester) stop() {
-	mi.quit <- struct{}{}
-}
-
-func (mi *noopChannelMetricIngester) IngestMetrics(ms []*metricpb.Metric) {
-	mi.in <- ms
-}
-
-func BenchmarkImportServerSendMetrics(b *testing.B) {
-	rand.Seed(time.Now().Unix())
-
-	metrics := metrictest.RandomForwardMetrics(10000)
-	for _, inputSize := range []int{10, 100, 1000, 10000} {
-		ingesters := make([]MetricIngester, 100)
-		for i := range ingesters {
-			ingester := newNoopChannelMetricIngester()
-			ingester.start()
-			defer ingester.stop()
-			ingesters[i] = ingester
-		}
-		logger := logrus.NewEntry(logrus.New())
-		s := New("localhost", ingesters, logger)
-		ctx := context.Background()
-		input := &forwardrpc.MetricList{Metrics: metrics[:inputSize]}
-
-		b.Run(fmt.Sprintf("InputSize=%d", inputSize), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				s.SendMetrics(ctx, input)
-			}
-		})
-	}
+	server.Stop()
 }

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -1,6 +1,9 @@
 package sources
 
-import "github.com/stripe/veneur/v14/samplers"
+import (
+	"github.com/stripe/veneur/v14/samplers"
+	"github.com/stripe/veneur/v14/samplers/metricpb"
+)
 
 type SourceConfig interface{}
 
@@ -12,4 +15,5 @@ type Source interface {
 
 type Ingest interface {
 	IngestMetric(metric *samplers.UDPMetric)
+	IngestMetricProto(metric *metricpb.Metric)
 }


### PR DESCRIPTION
#### Summary
This change prevents metrics imported via gRPC streaming from `veneur-proxy` from buffering in the `proxy` source.
