### PR TITLE
[Minor] Update circleci test_stable host env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
     executor:
       name: stable
     working_directory: /go/src/github.com/stripe/veneur
+    resource_class: medium+
     environment:
       GO111MODULE: "on"
     steps:


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
According to [recent runs](https://app.circleci.com/pipelines/github/stripe/veneur/2032/workflows/f7a8311a-522c-401f-b688-c35b02e74f87/jobs/8331/resources) our CI maxes out the CPU and hits 50% memory.
As CPU is maxed out, assumption is that it becomes the bottleneck. Increasing `test_stable` machine SKU via `resource_class` setting ought to remove(/reduce, since I chose only +1 level) the bottleneck.


#### Motivation
<!-- Why are you making this change? -->
Noticed 100% CPU in CI pipeline


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
I'm relying on ...
- [x] Assuming PR pipeline validating the CI run
- [x] Code Reviewers' direction on how to test circleCI changes


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Safe to revert.
