### PR TITLE
Add preferred_vary_by_key to SFX sink

### DIFF
--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -577,7 +577,8 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 				metricOverrodeVaryBy = true
 				clientKey = val
 			}
-		} else if sfx.varyBy != "" {
+		}
+		if sfx.varyBy != "" && clientKey == "" {
 			if val, ok := dims[sfx.varyBy]; ok {
 				metricOverrodeVaryBy = true
 				clientKey = val

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -571,16 +571,15 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 		// vary_key_by_favor_common_dimensions is set to true
 		metricOverrodeVaryBy := false
 
-		// Want to prefer to use the tag associated with preferred_vary_by
-		if sfx.preferredVaryBy != "" {
-			if val, ok := dims[sfx.preferredVaryBy]; ok {
+		// If preferred_vary_by is available, will override clientKey retrieved via vary_by
+		if sfx.varyBy != "" {
+			if val, ok := dims[sfx.varyBy]; ok {
 				metricOverrodeVaryBy = true
 				clientKey = val
 			}
 		}
-		if sfx.varyBy != "" && clientKey == "" {
-			if val, ok := dims[sfx.varyBy]; ok {
-				metricOverrodeVaryBy = true
+		if sfx.preferredVaryBy != "" {
+			if val, ok := dims[sfx.preferredVaryBy]; ok {
 				clientKey = val
 			}
 		}
@@ -593,15 +592,15 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 			dims[k] = v
 		}
 
-		// If fields were updated from commonDimensions, update clientKey as well.
-		// First try to update from preferred_vary_by, if possible, then vary_by, if possible
-		if sfx.preferredVaryBy != "" && clientKey == "" {
-			if val, ok := dims[sfx.preferredVaryBy]; ok {
+		// If vary_by was updated, want to update clientKey here
+		// but if preferred_vary_by is available, will override clientKey retrieved via vary_by
+		if sfx.varyBy != "" && clientKey == "" {
+			if val, ok := dims[sfx.varyBy]; ok {
 				clientKey = val
 			}
 		}
-		if sfx.varyBy != "" && clientKey == "" {
-			if val, ok := dims[sfx.varyBy]; ok {
+		if sfx.preferredVaryBy != "" && clientKey == "" {
+			if val, ok := dims[sfx.preferredVaryBy]; ok {
 				clientKey = val
 			}
 		}

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -1026,11 +1026,13 @@ func TestSignalFxVaryByWithPreferredVaryByKey(t *testing.T) {
 	assert.Equal(t, "baz", customFakeSinkFoo.points[1].Dimensions["vary_by"])
 
 	assert.Equal(t, "a.b.e", customFakeSinkFoo.points[2].Metric)
-	assert.Equal(t, "", customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"])
+	_, preferredVaryByIsPresent := customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"]
+	assert.False(t, preferredVaryByIsPresent)
 	assert.Equal(t, "foo", customFakeSinkFoo.points[2].Dimensions["vary_by"])
 
 	assert.Equal(t, "a.b.f", customFakeSinkBar.points[0].Metric)
-	assert.Equal(t, "", customFakeSinkBar.points[0].Dimensions["preferred_vary_by"])
+	_, preferredVaryByIsPresent = customFakeSinkBar.points[0].Dimensions["preferred_vary_by"]
+	assert.False(t, preferredVaryByIsPresent)
 	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
 }
 
@@ -1112,10 +1114,12 @@ func TestSignalFxVaryByWithPreferredVaryByKeyAndOverridePreferringCommonDimensio
 	assert.Equal(t, "bar", customFakeSinkFoo.points[1].Dimensions["vary_by"])
 
 	assert.Equal(t, "a.b.e", customFakeSinkFoo.points[2].Metric)
-	assert.Equal(t, "", customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"])
+	_, preferredVaryByIsPresent := customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"]
+	assert.False(t, preferredVaryByIsPresent)
 	assert.Equal(t, "bar", customFakeSinkFoo.points[2].Dimensions["vary_by"])
 
 	assert.Equal(t, "a.b.f", customFakeSinkBar.points[0].Metric)
-	assert.Equal(t, "", customFakeSinkBar.points[0].Dimensions["preferred_vary_by"])
+	_, preferredVaryByIsPresent = customFakeSinkBar.points[0].Dimensions["preferred_vary_by"]
+	assert.False(t, preferredVaryByIsPresent)
 	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
 }

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -886,7 +886,10 @@ func TestSignalFxVaryByOverride(t *testing.T) {
 	assert.Equal(t, 1, len(customFakeSinkFoo.points))
 	assert.Equal(t, 1, len(customFakeSinkBar.points))
 
+	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
 	assert.Equal(t, "foo", customFakeSinkFoo.points[0].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.d", customFakeSinkBar.points[0].Metric)
 	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
 }
 
@@ -939,6 +942,180 @@ func TestSignalFxVaryByOverridePreferringCommonDimensions(t *testing.T) {
 	assert.Equal(t, 1, len(customFakeSinkFoo.points))
 	assert.Equal(t, 1, len(customFakeSinkBar.points))
 
+	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
 	assert.Equal(t, "bar", customFakeSinkFoo.points[0].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.d", customFakeSinkBar.points[0].Metric)
 	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
+}
+
+func TestSignalFxVaryByWithPreferredVaryByKey(t *testing.T) {
+	preferredVaryByTagKey := "preferred_vary_by"
+	varyByTagKey := "vary_by"
+	commonDimensions := map[string]string{"vary_by": "bar"}
+	defaultFakeSink := NewFakeSink()
+	customFakeSinkFoo := NewFakeSink()
+	customFakeSinkBar := NewFakeSink()
+	perTagClients := make(map[string]DPClient)
+	perTagClients["foo"] = customFakeSinkFoo
+	perTagClients["bar"] = customFakeSinkBar
+
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		PreferredVaryKeyBy:                preferredVaryByTagKey,
+		VaryKeyBy:                         varyByTagKey,
+	}, "signalfx-hostname", commonDimensions, logrus.NewEntry(logrus.New()), defaultFakeSink, perTagClients, nil)
+	assert.NoError(t, err)
+
+	interMetrics := []samplers.InterMetric{{
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"preferred_vary_by:foo",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.d",
+		Timestamp: 1476119059,
+		Value:     float64(100),
+		Tags: []string{
+			"preferred_vary_by:foo",
+			"vary_by:baz",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.e",
+		Timestamp: 1476119600,
+		Value:     float64(100),
+		Tags: []string{
+			// No preferred_vary_by
+			"vary_by:foo",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.f",
+		Timestamp: 1476119601,
+		Value:     float64(100),
+		Tags:      []string{}, // No tags
+		Type:      samplers.GaugeMetric,
+	}}
+
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 4}, flushResult)
+
+	assert.Equal(t, 0, len(defaultFakeSink.points))
+	assert.Equal(t, 3, len(customFakeSinkFoo.points))
+	assert.Equal(t, 1, len(customFakeSinkBar.points))
+
+	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
+	assert.Equal(t, "foo", customFakeSinkFoo.points[0].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "", customFakeSinkFoo.points[0].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.d", customFakeSinkFoo.points[1].Metric)
+	assert.Equal(t, "foo", customFakeSinkFoo.points[1].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "baz", customFakeSinkFoo.points[1].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.e", customFakeSinkFoo.points[2].Metric)
+	assert.Equal(t, "", customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "foo", customFakeSinkFoo.points[2].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.f", customFakeSinkBar.points[0].Metric)
+	assert.Equal(t, "", customFakeSinkBar.points[0].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
+}
+
+func TestSignalFxVaryByWithPreferredVaryByKeyAndOverridePreferringCommonDimensions(t *testing.T) {
+	preferredVaryByTagKey := "preferred_vary_by"
+	varyByTagKey := "vary_by"
+	commonDimensions := map[string]string{"vary_by": "bar"}
+	defaultFakeSink := NewFakeSink()
+	customFakeSinkFoo := NewFakeSink()
+	customFakeSinkBar := NewFakeSink()
+	perTagClients := make(map[string]DPClient)
+	perTagClients["foo"] = customFakeSinkFoo
+	perTagClients["bar"] = customFakeSinkBar
+
+	sink, err := newSignalFxSink("signalfx", SignalFxSinkConfig{
+		APIKey:                            util.StringSecret{Value: ""},
+		DynamicPerTagAPIKeysEnable:        false,
+		DynamicPerTagAPIKeysRefreshPeriod: time.Second,
+		EndpointAPI:                       "",
+		EndpointBase:                      "",
+		FlushMaxPerBody:                   0,
+		HostnameTag:                       "host",
+		MetricNamePrefixDrops:             nil,
+		MetricTagPrefixDrops:              nil,
+		PreferredVaryKeyBy:                preferredVaryByTagKey,
+		VaryKeyBy:                         varyByTagKey,
+		VaryKeyByFavorCommonDimensions:    true,
+	}, "signalfx-hostname", commonDimensions, logrus.NewEntry(logrus.New()), defaultFakeSink, perTagClients, nil)
+	assert.NoError(t, err)
+
+	interMetrics := []samplers.InterMetric{{
+		Name:      "a.b.c",
+		Timestamp: 1476119058,
+		Value:     float64(100),
+		Tags: []string{
+			"preferred_vary_by:foo",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.d",
+		Timestamp: 1476119059,
+		Value:     float64(100),
+		Tags: []string{
+			"preferred_vary_by:foo",
+			"vary_by:baz",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.e",
+		Timestamp: 1476119600,
+		Value:     float64(100),
+		Tags: []string{
+			// No preferred_vary_by
+			"vary_by:foo",
+		},
+		Type: samplers.GaugeMetric,
+	}, {
+		Name:      "a.b.f",
+		Timestamp: 1476119601,
+		Value:     float64(100),
+		Tags:      []string{}, // No tags
+		Type:      samplers.GaugeMetric,
+	}}
+
+	flushResult, err := sink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 4}, flushResult)
+
+	assert.Equal(t, 0, len(defaultFakeSink.points))
+	assert.Equal(t, 2, len(customFakeSinkFoo.points))
+	assert.Equal(t, 2, len(customFakeSinkBar.points))
+
+	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
+	assert.Equal(t, "foo", customFakeSinkFoo.points[0].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkFoo.points[0].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.d", customFakeSinkFoo.points[1].Metric)
+	assert.Equal(t, "foo", customFakeSinkFoo.points[1].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkFoo.points[1].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.e", customFakeSinkBar.points[0].Metric)
+	assert.Equal(t, "", customFakeSinkBar.points[0].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.f", customFakeSinkBar.points[1].Metric)
+	assert.Equal(t, "", customFakeSinkBar.points[1].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkBar.points[1].Dimensions["vary_by"])
 }

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -1019,7 +1019,7 @@ func TestSignalFxVaryByWithPreferredVaryByKey(t *testing.T) {
 
 	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
 	assert.Equal(t, "foo", customFakeSinkFoo.points[0].Dimensions["preferred_vary_by"])
-	assert.Equal(t, "", customFakeSinkFoo.points[0].Dimensions["vary_by"])
+	assert.Equal(t, "bar", customFakeSinkFoo.points[0].Dimensions["vary_by"])
 
 	assert.Equal(t, "a.b.d", customFakeSinkFoo.points[1].Metric)
 	assert.Equal(t, "foo", customFakeSinkFoo.points[1].Dimensions["preferred_vary_by"])

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -1100,8 +1100,8 @@ func TestSignalFxVaryByWithPreferredVaryByKeyAndOverridePreferringCommonDimensio
 	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 4}, flushResult)
 
 	assert.Equal(t, 0, len(defaultFakeSink.points))
-	assert.Equal(t, 2, len(customFakeSinkFoo.points))
-	assert.Equal(t, 2, len(customFakeSinkBar.points))
+	assert.Equal(t, 3, len(customFakeSinkFoo.points))
+	assert.Equal(t, 1, len(customFakeSinkBar.points))
 
 	assert.Equal(t, "a.b.c", customFakeSinkFoo.points[0].Metric)
 	assert.Equal(t, "foo", customFakeSinkFoo.points[0].Dimensions["preferred_vary_by"])
@@ -1111,11 +1111,11 @@ func TestSignalFxVaryByWithPreferredVaryByKeyAndOverridePreferringCommonDimensio
 	assert.Equal(t, "foo", customFakeSinkFoo.points[1].Dimensions["preferred_vary_by"])
 	assert.Equal(t, "bar", customFakeSinkFoo.points[1].Dimensions["vary_by"])
 
-	assert.Equal(t, "a.b.e", customFakeSinkBar.points[0].Metric)
+	assert.Equal(t, "a.b.e", customFakeSinkFoo.points[2].Metric)
+	assert.Equal(t, "", customFakeSinkFoo.points[2].Dimensions["preferred_vary_by"])
+	assert.Equal(t, "bar", customFakeSinkFoo.points[2].Dimensions["vary_by"])
+
+	assert.Equal(t, "a.b.f", customFakeSinkBar.points[0].Metric)
 	assert.Equal(t, "", customFakeSinkBar.points[0].Dimensions["preferred_vary_by"])
 	assert.Equal(t, "bar", customFakeSinkBar.points[0].Dimensions["vary_by"])
-
-	assert.Equal(t, "a.b.f", customFakeSinkBar.points[1].Metric)
-	assert.Equal(t, "", customFakeSinkBar.points[1].Dimensions["preferred_vary_by"])
-	assert.Equal(t, "bar", customFakeSinkBar.points[1].Dimensions["vary_by"])
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This code uses a new preferred_vary_by_key to allow the SFX sink to prefer another tag as higher priority over an existing tag when choosing which client to tag on a metric. 

#### Motivation
<!-- Why are you making this change? -->
We want to create a mechanism by which we can update the SFX sink to use the new key, but in the event of failures, the existing vary_by key will be used. 

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Added unit tests -- the tests preserve the original functionality if the key is absent. 

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
TBD