### PR TITLE
chore: upgrade to Go 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   "stable":
     docker:
-      - image: golang:1.18
+      - image: golang:1.19
 
 commands:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 14.2.0, UNRELEASED
+# 14.2.0, 2022-05-09
 
 ## Added
 * A flag -print-secrets to disable redacting config secrets.
@@ -34,7 +34,7 @@
 * Upgrade to Goji 2.0.2 and use the modern Goji mux API. Thanks [hans-stripe](https://github.com/hans-stripe)!
 * Increase the timeout of TestCountActiveHandlers from 3 seconds to 10 seconds. Helps some tests pass in certain environments. Thanks [sushain97](https://github.com/sushain97)!
 
-# 14.0.0, 2020-01-14
+# 14.0.0, 2021-01-14
 
 ## Updated
 * Migrated from dep to Go modules. Clients must now use the updated import path `github.com/stripe/veneur/v14`. Thanks, [andybons](https://github.com/andybons)!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For running Veneur under Docker, you probably want either the pre-built images
 # published at https://hub.docker.com/r/stripe/veneur/
 # or the Dockerfiles in https://github.com/stripe/veneur/tree/master/public-docker-images
-FROM golang:1.18
+FROM golang:1.19
 LABEL maintainer="The Stripe Observability Team <support@stripe.com>"
 
 ENV GOPATH=/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stripe/veneur/v14
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DataDog/datadog-go v3.7.2+incompatible

--- a/public-docker-images/Dockerfile-alpine
+++ b/public-docker-images/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS build
+FROM golang:1.19-alpine3.16 AS build
 WORKDIR /veneur/
 COPY . .
 RUN CGO_ENABLED=0 go build -a -ldflags "-X github.com/stripe/veneur/v14/util/build.VERSION=${VERSION} -X github.com/stripe/veneur/v14/util/build.BUILD_DATE=$(date +%s)" -o /build/veneur ./cmd/veneur &&\

--- a/public-docker-images/Dockerfile-debian-sid
+++ b/public-docker-images/Dockerfile-debian-sid
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.19 AS build
 WORKDIR /veneur/
 COPY . .
 RUN go build -a -ldflags "-X github.com/stripe/veneur.VERSION=${VERSION}" -o /build/veneur ./cmd/veneur &&\

--- a/public-docker-images/README.md
+++ b/public-docker-images/README.md
@@ -5,12 +5,12 @@ This folder holds the Docker resources for building [Veneur](https://github.com/
 ## Building
 For the Debian-based image:
 ```
-docker build --build-arg=VERSION=$(git rev-parse HEAD) --no-cache -t veneur:local -f public-docker-images/Dockerfile-debian-sid .
+docker build --build-arg "VERSION=$(git rev-parse HEAD)" --no-cache -t veneur:local -f public-docker-images/Dockerfile-debian-sid .
 ```
 
 For the Alpine Linux-based image:
 ```
-docker build --build-arg=VERSION=$(git rev-parse HEAD) --no-cache -t veneur:local -f public-docker-images/Dockerfile-alpine .
+docker build --build-arg "VERSION=$(git rev-parse HEAD)" --no-cache -t veneur:local -f public-docker-images/Dockerfile-alpine .
 ```
 
 ## Running


### PR DESCRIPTION
_(excerpts from the commit)_

#### Summary

> The release post (ref) indicates that nothing really needs fixing other than any
possible usage of relative paths in `PATH`, for security reasons.
>
> Ref: https://go.dev/blog/go1.19

#### Motivation

> Go 1.19 brings improvements to documentation, GC, and RISC performance (e.g. arm64).

#### Test plan

> Only done minimal testing by ensuring the Docker builds succeed using the given
commands in `public-docker-images/`. The maintainers should feel free to do any
further testing necessary.