### PR TITLE
Set scope to mixed for json histogram and timer metrics.

### DIFF
--- a/proxy/json/json.go
+++ b/proxy/json/json.go
@@ -143,7 +143,7 @@ func ConvertJsonMetric(metric *samplers.JSONMetric) (*metricpb.Metric, error) {
 					TDigest: value.Data(),
 				},
 			},
-			Scope: metricpb.Scope_Global,
+			Scope: metricpb.Scope_Mixed,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown metric type: %s", metric.Type)


### PR DESCRIPTION
#### Summary
Set scope to mixed for json histogram and timer metrics.
