### PR TITLE
Use non-blocking write when forwarding metrics in veneur-proxy.

### DIFF
--- a/proxy/handlers/handlers_test.go
+++ b/proxy/handlers/handlers_test.go
@@ -1,11 +1,12 @@
 package handlers_test
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -113,7 +114,7 @@ func TestHealthcheckSuccess(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, recorder.Result().StatusCode)
 }
 
-var metricsJson = []byte("[{\"name\":\"metric-name\",\"type\":\"counter\",\"tags\":[\"tag1:value1\",\"tag2:value2\"],\"value\":[1,0,0,0,0,0,0,0]}]")
+const metricsJson = "[{\"name\":\"metric-name\",\"type\":\"counter\",\"tags\":[\"tag1:value1\",\"tag2:value2\"],\"value\":[1,0,0,0,0,0,0,0]}]"
 
 func TestProxyJson(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -129,7 +130,10 @@ func TestProxyJson(t *testing.T) {
 		gomock.Any(), []string{"protocol:http"}, 1.0)
 	fixture.Statsd.EXPECT().Count(
 		"veneur_proxy.ingest.metrics_count",
-		int64(1), []string{"error:false", "protocol:http"}, 1.0)
+		int64(1), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:false"}, 1.0)
 
 	fixture.Destinations.EXPECT().
 		Get("metric-namecountertag1:value1,tag2:value2").
@@ -138,7 +142,8 @@ func TestProxyJson(t *testing.T) {
 	fixture.Destination.EXPECT().SendChannel().Return(sendChannel)
 
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest("GET", "/import", bytes.NewReader(metricsJson))
+	request := httptest.NewRequest(
+		"GET", "/import", strings.NewReader(metricsJson))
 	handleJsonMetricsChannel := make(chan struct{})
 	go func() {
 		fixture.Handlers.HandleJsonMetrics(recorder, request)
@@ -162,23 +167,71 @@ func TestProxyJson(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Result().StatusCode)
 }
 
-func TestProxyGrpcSingle(t *testing.T) {
+func TestProxyJsonBadRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
 
-	metric := &metricpb.Metric{
-		Name: "metric-name",
-		Tags: []string{"tag1:value1", "tag2:value2"},
-		Type: metricpb.Type_Counter,
-		Value: &metricpb.Metric_Counter{
-			Counter: &metricpb.CounterValue{
-				Value: 1,
-			},
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_error_count",
+		int64(1), []string{"protocol:http", "status:error_decode"}, 1.0)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/import", strings.NewReader("["))
+	fixture.Handlers.HandleJsonMetrics(recorder, request)
+}
+
+const metricsJsonBadType = "[{\"name\":\"metric-name\",\"type\":\"unknown\"}]"
+
+func TestProxyJsonConvertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
+
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.metrics_count",
+		int64(1), []string{"protocol:http"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:json_convert"}, 1.0)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		"GET", "/import", strings.NewReader(metricsJsonBadType))
+	fixture.Handlers.HandleJsonMetrics(recorder, request)
+}
+
+var metric = &metricpb.Metric{
+	Name: "metric-name",
+	Tags: []string{"tag1:value1", "tag2:value2"},
+	Type: metricpb.Type_Counter,
+	Value: &metricpb.Metric_Counter{
+		Counter: &metricpb.CounterValue{
+			Value: 1,
 		},
-		Scope: metricpb.Scope_Global,
-	}
+	},
+	Scope: metricpb.Scope_Global,
+}
+
+func TestProxyGrpcSingle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
 
 	fixture.Statsd.EXPECT().Count(
 		"veneur_proxy.ingest.request_count",
@@ -188,7 +241,10 @@ func TestProxyGrpcSingle(t *testing.T) {
 		gomock.Any(), []string{"protocol:grpc-single"}, 1.0)
 	fixture.Statsd.EXPECT().Count(
 		"veneur_proxy.ingest.metrics_count",
-		int64(1), []string{"error:false", "protocol:grpc-single"}, 1.0)
+		int64(1), []string{"protocol:grpc-single"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:false"}, 1.0)
 
 	fixture.Destinations.EXPECT().
 		Get("metric-namecountertag1:value1,tag2:value2").
@@ -218,18 +274,6 @@ func TestProxyGrpcStream(t *testing.T) {
 
 	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
 
-	metric := &metricpb.Metric{
-		Name: "metric-name",
-		Tags: []string{"tag1:value1", "tag2:value2"},
-		Type: metricpb.Type_Counter,
-		Value: &metricpb.Metric_Counter{
-			Counter: &metricpb.CounterValue{
-				Value: 1,
-			},
-		},
-		Scope: metricpb.Scope_Global,
-	}
-
 	fixture.Statsd.EXPECT().Count(
 		"veneur_proxy.ingest.request_count",
 		int64(1), []string{"protocol:grpc-stream"}, 1.0)
@@ -238,7 +282,10 @@ func TestProxyGrpcStream(t *testing.T) {
 		gomock.Any(), []string{"protocol:grpc-stream"}, 1.0)
 	fixture.Statsd.EXPECT().Count(
 		"veneur_proxy.ingest.metrics_count",
-		int64(1), []string{"error:false", "protocol:grpc-stream"}, 1.0)
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:false"}, 1.0)
 
 	fixture.Destinations.EXPECT().
 		Get("metric-namecountertag1:value1,tag2:value2").
@@ -263,6 +310,51 @@ func TestProxyGrpcStream(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestProxyGrpcStreamError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
+
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.metrics_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:false"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_error_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+
+	fixture.Destinations.EXPECT().
+		Get("metric-namecountertag1:value1,tag2:value2").
+		Return(fixture.Destination, nil)
+	sendChannel := make(chan connect.SendRequest)
+	fixture.Destination.EXPECT().SendChannel().Return(sendChannel)
+
+	mockServer := forwardrpc.NewMockForward_SendMetricsV2Server(ctrl)
+	mockServer.EXPECT().Recv().Times(1).Return(metric, nil)
+	mockServer.EXPECT().Recv().Times(1).Return(nil, errors.New("stream error"))
+	mockServer.EXPECT().SendAndClose(&emptypb.Empty{}).Return(nil)
+
+	sendMetricsChannel := make(chan error)
+	go func() {
+		sendMetricsChannel <- fixture.Handlers.SendMetricsV2(mockServer)
+	}()
+	sendRequest := <-sendChannel
+	sendRequest.ErrorChannel <- nil
+	err := <-sendMetricsChannel
+
+	assert.Equal(t, metric, sendRequest.Metric)
+	assert.Error(t, err)
+}
+
 func TestProxyGrpcStreamIgnoreTags(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -274,18 +366,6 @@ func TestProxyGrpcStreamIgnoreTags(t *testing.T) {
 			Value: "tag1",
 		}),
 	})
-
-	metric := &metricpb.Metric{
-		Name: "metric-name",
-		Tags: []string{"tag1:value1", "tag2:value2"},
-		Type: metricpb.Type_Counter,
-		Value: &metricpb.Metric_Counter{
-			Counter: &metricpb.CounterValue{
-				Value: 1,
-			},
-		},
-		Scope: metricpb.Scope_Global,
-	}
 
 	fixture.Statsd.EXPECT().Count(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -312,5 +392,113 @@ func TestProxyGrpcStreamIgnoreTags(t *testing.T) {
 	err := <-sendMetricsChannel
 
 	assert.Equal(t, metric, sendRequest.Metric)
+	assert.NoError(t, err)
+}
+
+func TestNoDestination(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
+
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.metrics_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:destination"}, 1.0)
+
+	fixture.Destinations.EXPECT().
+		Get("metric-namecountertag1:value1,tag2:value2").
+		Return(nil, errors.New("no destination"))
+
+	mockServer := forwardrpc.NewMockForward_SendMetricsV2Server(ctrl)
+	mockServer.EXPECT().Recv().Times(1).Return(metric, nil)
+	mockServer.EXPECT().Recv().Times(1).Return(nil, io.EOF)
+	mockServer.EXPECT().SendAndClose(&emptypb.Empty{}).Return(nil)
+
+	err := fixture.Handlers.SendMetricsV2(mockServer)
+	assert.NoError(t, err)
+}
+
+func TestForwardError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
+
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.metrics_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:forward"}, 1.0)
+
+	fixture.Destinations.EXPECT().
+		Get("metric-namecountertag1:value1,tag2:value2").
+		Return(fixture.Destination, nil)
+	sendChannel := make(chan connect.SendRequest)
+	fixture.Destination.EXPECT().SendChannel().Return(sendChannel)
+
+	mockServer := forwardrpc.NewMockForward_SendMetricsV2Server(ctrl)
+	mockServer.EXPECT().Recv().Times(1).Return(metric, nil)
+	mockServer.EXPECT().Recv().Times(1).Return(nil, io.EOF)
+	mockServer.EXPECT().SendAndClose(&emptypb.Empty{}).Return(nil)
+
+	sendMetricsChannel := make(chan error)
+	go func() {
+		sendMetricsChannel <- fixture.Handlers.SendMetricsV2(mockServer)
+	}()
+	sendRequest := <-sendChannel
+	sendRequest.ErrorChannel <- errors.New("forward error")
+	err := <-sendMetricsChannel
+
+	assert.Equal(t, metric, sendRequest.Metric)
+	assert.NoError(t, err)
+}
+
+func TestChannelBufferFull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fixture := CreateTestHandlers(ctrl, []matcher.TagMatcher{})
+
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.request_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Timing(
+		"veneur_proxy.ingest.request_latency_ms",
+		gomock.Any(), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.ingest.metrics_count",
+		int64(1), []string{"protocol:grpc-stream"}, 1.0)
+	fixture.Statsd.EXPECT().Count(
+		"veneur_proxy.handle.metrics_count",
+		int64(1), []string{"error:enqueue"}, 1.0)
+
+	fixture.Destinations.EXPECT().
+		Get("metric-namecountertag1:value1,tag2:value2").
+		Return(fixture.Destination, nil)
+	sendChannel := make(chan connect.SendRequest)
+	fixture.Destination.EXPECT().SendChannel().Return(sendChannel)
+
+	mockServer := forwardrpc.NewMockForward_SendMetricsV2Server(ctrl)
+	mockServer.EXPECT().Recv().Times(1).Return(metric, nil)
+	mockServer.EXPECT().Recv().Times(1).Return(nil, io.EOF)
+	mockServer.EXPECT().SendAndClose(&emptypb.Empty{}).Return(nil)
+
+	err := fixture.Handlers.SendMetricsV2(mockServer)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### Summary
Use non-blocking write when forwarding metrics in veneur-proxy.