### PR TITLE
Remove legacy debug sink configuration.

### DIFF
--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -85,9 +85,6 @@ func main() {
 	if *validateConfig {
 		os.Exit(0)
 	}
-	if !conf.Features.MigrateMetricSinks {
-		debug.MigrateConfig(&conf)
-	}
 
 	server, err := veneur.NewFromConfig(veneur.ServerConfig{
 		Config: conf,

--- a/config.go
+++ b/config.go
@@ -12,15 +12,11 @@ type Config struct {
 	BlockProfileRate      int      `yaml:"block_profile_rate"`
 	CountUniqueTimeseries bool     `yaml:"count_unique_timeseries"`
 	Debug                 bool     `yaml:"debug"`
-	DebugFlushedMetrics   bool     `yaml:"debug_flushed_metrics"`
-	DebugIngestedSpans    bool     `yaml:"debug_ingested_spans"`
 	EnableProfiling       bool     `yaml:"enable_profiling"`
 	ExtendTags            []string `yaml:"extend_tags"`
 	Features              struct {
 		DiagnosticsMetricsEnabled bool   `yaml:"diagnostics_metrics_enabled"`
 		EnableMetricSinkRouting   bool   `yaml:"enable_metric_sink_routing"`
-		MigrateMetricSinks        bool   `yaml:"migrate_metric_sinks"`
-		MigrateSpanSinks          bool   `yaml:"migrate_span_sinks"`
 		ProxyProtocol             string `yaml:"proxy_protocol"`
 	} `yaml:"features"`
 	FlushOnShutdown             bool                `yaml:"flush_on_shutdown"`

--- a/example.yaml
+++ b/example.yaml
@@ -236,16 +236,6 @@ read_buffer_size_bytes: 2097152
 # Sets the log level to DEBUG
 debug: false
 
-# Log (at level DEBUG) information about every ingested span. Be
-# careful with this setting in a real deployment - it is extremely
-# verbose.
-debug_ingested_spans: false
-
-# Log (at level DEBUG) information about every batch of flushed
-# metrics. Be careful with this setting in a real deployment - it is
-# extremely verbose.
-debug_flushed_metrics: false
-
 # runtime.SetMutexProfileFraction
 # The fraction of mutex contention events that are reported in the mutex profile.
 # On average, 1/n events are reported, so higher numbers will sample fewer events.

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -107,7 +107,6 @@ func TestServerFlushGRPC(t *testing.T) {
 	defer testServer.Stop()
 
 	localCfg := localConfig()
-	localCfg.DebugFlushedMetrics = true
 	localCfg.ForwardAddress = testServer.Addr().String()
 	localCfg.ForwardUseGrpc = true
 	local := setupVeneurServer(t, localCfg, nil, nil, nil, nil)
@@ -168,7 +167,6 @@ func TestServerFlushGRPCTimeout(t *testing.T) {
 
 	localCfg := localConfig()
 	localCfg.Interval = time.Duration(20 * time.Microsecond)
-	localCfg.DebugFlushedMetrics = true
 	localCfg.ForwardAddress = testServer.Addr().String()
 	localCfg.ForwardUseGrpc = true
 	local := setupVeneurServer(t, localCfg, nil, nil, nil, cl)

--- a/sinks/debug/debug.go
+++ b/sinks/debug/debug.go
@@ -15,21 +15,6 @@ import (
 	"github.com/stripe/veneur/v14/trace"
 )
 
-func MigrateConfig(conf *veneur.Config) {
-	if conf.DebugFlushedMetrics {
-		conf.MetricSinks = append(conf.MetricSinks, veneur.SinkConfig{
-			Kind: "debug",
-			Name: "debug",
-		})
-	}
-	if conf.DebugIngestedSpans {
-		conf.SpanSinks = append(conf.SpanSinks, veneur.SinkConfig{
-			Kind: "debug",
-			Name: "debug",
-		})
-	}
-}
-
 type debugMetricSink struct {
 	log  *logrus.Entry
 	mtx  *sync.Mutex

--- a/testdata/http_test_config.json
+++ b/testdata/http_test_config.json
@@ -7,15 +7,11 @@
   "BlockProfileRate": 0,
   "CountUniqueTimeseries": false,
   "Debug": false,
-  "DebugFlushedMetrics": false,
-  "DebugIngestedSpans": false,
   "EnableProfiling": false,
   "ExtendTags": null,
   "Features": {
     "DiagnosticsMetricsEnabled": false,
     "EnableMetricSinkRouting": false,
-    "MigrateMetricSinks": false,
-    "MigrateSpanSinks": false,
     "ProxyProtocol": ""
   },
   "FlushOnShutdown": false,

--- a/testdata/http_test_config.yaml
+++ b/testdata/http_test_config.yaml
@@ -5,15 +5,11 @@ aggregates:
 block_profile_rate: 0
 count_unique_timeseries: false
 debug: false
-debug_flushed_metrics: false
-debug_ingested_spans: false
 enable_profiling: false
 extend_tags: []
 features:
   diagnostics_metrics_enabled: false
   enable_metric_sink_routing: false
-  migrate_metric_sinks: false
-  migrate_span_sinks: false
   proxy_protocol: ""
 flush_on_shutdown: false
 flush_watchdog_missed_flushes: 0


### PR DESCRIPTION
#### Summary
This change removes additional legacy sink configuration, and is a follow up to https://github.com/stripe/veneur/pull/986.
