### PR TITLE
standardize behavior of "hostname_tag" option

### DIFF
--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -80,6 +80,7 @@ type CortexMetricSinkConfig struct {
 		Type       string            `yaml:"type"`
 		Credential util.StringSecret `yaml:"credentials"`
 	} `yaml:"authorization"`
+	HostnameTag string `yaml:"hostname_tag"`
 }
 
 // Create creates a new Cortex sink.
@@ -95,8 +96,10 @@ func Create(
 
 	// TagsAsMap is a set of configurable common tags applied to every metric
 	tags := server.TagsAsMap
-	// Host has to be supplied especially
-	tags["host"] = config.Hostname
+
+	if conf.HostnameTag != "" {
+		tags[conf.HostnameTag] = config.Hostname
+	}
 
 	headers := make(map[string]string)
 	if conf.Authorization.Type != "" {

--- a/sinks/cortex/testdata/expected_with_hostname.json
+++ b/sinks/cortex/testdata/expected_with_hostname.json
@@ -1,0 +1,22 @@
+{
+  "timeseries": [
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "a_b_gauge"
+        },
+        {
+          "name": "custom_hostname_tag",
+          "value": "myhostname.local"
+        }
+      ],
+      "samples": [
+        {
+          "value": 100,
+          "timestamp": 1000
+        }
+      ]
+    }
+  ]
+}

--- a/sinks/cortex/testdata/input_with_hostname.json
+++ b/sinks/cortex/testdata/input_with_hostname.json
@@ -1,0 +1,12 @@
+[
+  {
+    "Name": "a.b.gauge",
+    "Timestamp": 1,
+    "Value": 100,
+    "Tags": [],
+    "Type": 1,
+    "Message": "",
+    "HostName": "",
+    "Sinks": null
+  }
+]

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -522,8 +522,12 @@ METRICLOOP: // Convenience label so that inner nested loops and `continue` easil
 			}
 		}
 		dims := map[string]string{}
-		// Set the hostname as a tag, since SFx doesn't have a first-class hostname field
-		dims[sfx.hostnameTag] = sfx.hostname
+
+		if sfx.hostnameTag != "" {
+			// Set the hostname as a tag, since SFx doesn't have a first-class hostname field
+			dims[sfx.hostnameTag] = sfx.hostname
+		}
+
 		for _, tag := range metric.Tags {
 			kv := strings.SplitN(tag, ":", 2)
 			key := kv[0]
@@ -655,8 +659,11 @@ func (sfx *SignalFxSink) reportEvent(ctx context.Context, sample *ssf.SSFSample)
 	for k, v := range sfx.commonDimensions {
 		dims[k] = v
 	}
+
 	// And hostname
-	dims[sfx.hostnameTag] = sfx.hostname
+	if sfx.hostnameTag != "" {
+		dims[sfx.hostnameTag] = sfx.hostname
+	}
 
 	for k, v := range sample.Tags {
 		if k == dogstatsd.EventIdentifierKey {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
* [for signalfx sink, no-op if hostname_tag is not specified](https://github.com/stripe/veneur/commit/4466a818a30642018fb2a6d4dd90ab7229e2ed37)
* [for cortex, add hostname_tag option, respect the value if it is specified, and no-op if it is not specified](https://github.com/stripe/veneur/commit/e088210d34204f895edae8fb4d713c09420be483)

#### Motivation
<!-- Why are you making this change? -->
standardize (to an extent) behavior of "hostname_tag" option

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
* added an automated test for cortex sink
* case where "hostname_tag" is not specified should already be exercised by existing automated tests