### PR TITLE
Deduplicating add tags

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -183,7 +183,19 @@ func (s *Server) flushSink(
 					maxTagLengthCount += 1
 					continue metricLoop
 				}
-				filteredTags = append(filteredTags, tag)
+
+				replaced := false
+				for i, ft := range filteredTags {
+					if ft[0:len(k)] == k {
+						filteredTags[i] = tag
+						replaced = true
+						break
+					}
+				}
+
+				if !replaced {
+					filteredTags = append(filteredTags, tag)
+				}
 			}
 
 			if sink.maxTags != 0 && len(filteredTags) > sink.maxTags {

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -972,6 +972,104 @@ func TestFlushWithAddTags(t *testing.T) {
 	})
 }
 
+func TestFlushWithAddTagsDedupes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	channel := make(chan []samplers.InterMetric)
+	mockStatsd := scopedstatsd.NewMockClient(ctrl)
+	server, err := NewFromConfig(ServerConfig{
+		Logger: logrus.New(),
+		Config: Config{
+			Debug: true,
+			Features: Features{
+				EnableMetricSinkRouting: true,
+			},
+			Hostname: "localhost",
+			Interval: DefaultFlushInterval,
+			MetricSinkRouting: []SinkRoutingConfig{{
+				Name: "default",
+				Match: []matcher.Matcher{{
+					Name: matcher.CreateNameMatcher(&matcher.NameMatcherConfig{
+						Kind: "any",
+					}),
+					Tags: []matcher.TagMatcher{},
+				}},
+				Sinks: SinkRoutingSinks{
+					Matched: []string{"channel"},
+				},
+			}},
+			MetricSinks: []SinkConfig{{
+				Kind:    "channel",
+				Name:    "channel",
+				AddTags: map[string]string{"foo": "bar", "env": "qa"},
+			}},
+			StatsAddress: "localhost:8125",
+		},
+		MetricSinkTypes: MetricSinkTypes{
+			"channel": {
+				Create: func(
+					server *Server, name string, logger *logrus.Entry, config Config,
+					sinkConfig MetricSinkConfig,
+				) (sinks.MetricSink, error) {
+					sink, err := NewChannelMetricSink(channel)
+					if err != nil {
+						return nil, err
+					}
+					return sink, nil
+				},
+				ParseConfig: func(
+					name string, config interface{},
+				) (MetricSinkConfig, error) {
+					return nil, nil
+				},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	server.Statsd = mockStatsd
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		server.Start()
+		wg.Done()
+	}()
+	defer func() {
+		server.Shutdown()
+		wg.Wait()
+	}()
+
+	mockStatsd.EXPECT().Count(gomock.Any(), gomock.All(), gomock.All(), gomock.All()).AnyTimes()
+	mockStatsd.EXPECT().Gauge(gomock.Any(), gomock.All(), gomock.All(), gomock.All()).AnyTimes()
+	mockStatsd.EXPECT().Timing(gomock.Any(), gomock.All(), gomock.All(), gomock.All()).AnyTimes()
+
+	server.Workers[0].PacketChan <- samplers.UDPMetric{
+		MetricKey: samplers.MetricKey{
+			Name:       "test.metric",
+			Type:       "counter",
+			JoinedTags: "foo:not_bar",
+		},
+		Digest:     0,
+		Scope:      samplers.LocalOnly,
+		Tags:       []string{"first:tag", "foo:not_bar", "env:foo", "not_matched:oo"},
+		Value:      1.0,
+		SampleRate: 1.0,
+	}
+
+	result := <-channel
+	if assert.Len(t, result, 1) {
+		assert.Equal(t, "test.metric", result[0].Name)
+		if assert.Len(t, result[0].Tags, 4) {
+			assert.Equal(t, "first:tag", result[0].Tags[0])
+			assert.Equal(t, "foo:bar", result[0].Tags[1])
+			assert.Equal(t, "env:qa", result[0].Tags[2])
+			assert.Equal(t, "not_matched:oo", result[0].Tags[3])
+		}
+	}
+}
+
 type anyOfMatcher struct {
 	s []string
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Changes `add_tags` behavior to replace elements in the slice with the same key, if they exist, otherwise default to append. 

#### Motivation
<!-- Why are you making this change? -->
Using `add_tags` can cause us to have tags with duplicate keys (though different values), this has not been a problem because most of the sinks will transform the slice into a map which will naturally "dedupe". However, it causes a problem when we're using the `max_tags` configuration because now we don't have an accurate accounting of the number of tags. 

This doesn't solve the problem of the metric being _emitted_ with duplicate tags but that isn't something we've observed happens often. 


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Unit test.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
