### PR TITLE
Fixing substring lookup, added tests.

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -186,7 +186,7 @@ func (s *Server) flushSink(
 
 				replaced := false
 				for i, ft := range filteredTags {
-					if ft[0:len(k)] == k {
+					if len(ft) >= len(k) && ft[0:len(k)] == k {
 						filteredTags[i] = tag
 						replaced = true
 						break


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Fixes substring look up so we only try to get the substr of `ft` if it's equal or longer in length than `k`


#### Motivation
<!-- Why are you making this change? -->
Bug in dedupe implementation. 

When metrics are going through the globalization pipeline metrics from veneur local will have tags added to them by the `add_tags` functionality when these same metrics arrive at the globalization pipeline if veneur global has its own `add_tags` specified that overlap with those from veneur local we would end up with duplicate tags. See the original fix [here](https://github.com/stripe/veneur/pull/1009).

As to why this PR: when accessing a substring of ft where `len(k)` is longer than `ft` itself we'll receive an out of bounds error, I was operating under the assumption they'd behave a lot like python strings where this behavior is valid:
```
Python 3.9.11 (main, Sep 13 2022, 16:05:34)
[Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> foo = "test"
>>> foo[0:20]
'test'
```

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
