### PR TITLE
Reduce test flakiness due to resource contention and timing

### DIFF
--- a/proxy/destinations/destinations_test.go
+++ b/proxy/destinations/destinations_test.go
@@ -83,7 +83,7 @@ func TestAddSingleWithFailure(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		fixture.destinations.Wait()
 		return true
-	}, 2*time.Millisecond, time.Millisecond)
+	}, 500*time.Millisecond, time.Millisecond)
 }
 
 func TestAddMultiple(t *testing.T) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
- Increase timeouts for some tests (go has timeouts as test runner first-class which can be used when we _need_ fast)
- Use assert.Eventually (this would be better than the timeouts, usually, as it will enable the test to pass as soon as it can, without trading off latency OR flakiness)


#### Motivation
<!-- Why are you making this change? -->
CI builds break a lot
<img width="177" alt="image" src="https://user-images.githubusercontent.com/110132603/207999637-9c97eea8-0232-4354-8662-df8c3833ef74.png">



#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
- [x] run tests


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
