### PR TITLE
Replace proto.Marshal with direct call to Marshal's

### DIFF
--- a/file_create.go
+++ b/file_create.go
@@ -8,7 +8,6 @@ package veneur
 // 	"path/filepath"
 
 // 	"github.com/sirupsen/logrus"
-// 	"github.com/gogo/protobuf/proto"
 // 	"github.com/stripe/veneur/v14/ssf"
 // )
 
@@ -29,7 +28,7 @@ package veneur
 // 		Operation:      "operationTest",
 // 		Tags:           map[string]string{"tag1": "value1"},
 // 	}
-// 	buf, _ := proto.Marshal(span)
+// 	buf, _ := span.Marshal()
 // 	fmt.Println(buf)
 
 // 	pbFile := filepath.Join("fixtures", "protobuf", "regression.pb")

--- a/sinks/cortex/cortex.go
+++ b/sinks/cortex/cortex.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
@@ -275,7 +274,7 @@ func (s *CortexMetricSink) writeMetrics(ctx context.Context, metrics []samplers.
 
 	wr := s.makeWriteRequest(metrics)
 
-	data, err := proto.Marshal(wr)
+	data, err := wr.Marshal()
 	if err != nil {
 		return errors.Wrapf(err, "cortex_err=\"failed to write batch: failed to marshal proto\"")
 	}

--- a/sinks/kafka/kafka.go
+++ b/sinks/kafka/kafka.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/gogo/protobuf/proto"
 	gometrics "github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
 	veneur "github.com/stripe/veneur/v14"
@@ -410,7 +409,7 @@ func (k *KafkaSpanSink) Ingest(span *ssf.SSFSpan) error {
 		}
 		enc = sarama.StringEncoder(j)
 	case "protobuf":
-		p, err := proto.Marshal(span)
+		p, err := span.Marshal()
 		if err != nil {
 			k.logger.Error("Error marshalling span")
 			samples.Add(ssf.Count("kafka.span_marshal_error_total", 1, nil))

--- a/trace/backend.go
+++ b/trace/backend.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stripe/veneur/v14/protocol"
 	"github.com/stripe/veneur/v14/ssf"
 )
@@ -114,7 +113,7 @@ func (s *packetBackend) SendSync(ctx context.Context, span *ssf.SSFSpan) error {
 		}
 	}
 
-	data, err := proto.Marshal(span)
+	data, err := span.Marshal()
 	if err != nil {
 		return err
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/mod/module"
 
@@ -170,7 +169,7 @@ func (t *Trace) Add(samples ...*ssf.SSFSample) {
 // ProtoMarshalTo writes the Trace as a protocol buffer
 // in text format to the specified writer.
 func (t *Trace) ProtoMarshalTo(w io.Writer) error {
-	packet, err := proto.Marshal(t.SSFSpan())
+	packet, err := t.SSFSpan().Marshal()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Replace proto.Marshal with direct call to Marshal's


#### Motivation
<!-- Why are you making this change? -->
Saw veneur prevalent in performance profiles


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
```

# before: proto.Marshal
BenchmarkSerialization/UDP_plain_span_with_metrics-10         	  464810	      2403 ns/op	     176 B/op	       2 allocs/op
BenchmarkSerialization/UDP_plain_span_no_metrics-10           	  541394	      2488 ns/op	      80 B/op	       2 allocs/op
BenchmarkSerialization/UDP_plain_empty_span_with_metrics-10   	  536200	      2497 ns/op	     112 B/op	       2 allocs/op

# span.Marshal
BenchmarkSerialization/UDP_plain_span_with_metrics-10         	  511609	      2526 ns/op	     160 B/op	       1 allocs/op
BenchmarkSerialization/UDP_plain_span_no_metrics-10           	  635616	      1916 ns/op	      64 B/op	       1 allocs/op
BenchmarkSerialization/UDP_plain_empty_span_with_metrics-10   	  572904	      2157 ns/op	      96 B/op	       1 allocs/op
```


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
- [ ] PRE merge (if accepted): CHANGELOG.md
