### PR TITLE
Fixing behavior where we bail on all batches if one fails

### DIFF
--- a/sinks/cortex/cortex_test.go
+++ b/sinks/cortex/cortex_test.go
@@ -451,7 +451,7 @@ func TestAllBatchesAreAttemptedEvenIfSomeFail(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, sinks.MetricFlushResult{MetricsFlushed: 9, MetricsDropped: 3, MetricsSkipped: 0}, flushResult)
 
-	// we're cancelling after 2 so we should only see 2 chunks written
+	// ensure we see all chunks written
 	assert.Equal(t, 4, len(server.History()))
 	assert.Equal(t, 3, len(server.History()[0].data.GetTimeseries()))
 	assert.Equal(t, 3, len(server.History()[1].data.GetTimeseries()))


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
No longer erring out if one batch fails


#### Motivation
<!-- Why are you making this change? -->
We want as many metrics to try and get written, errors may be related to things like writing duplicate time series which shouldn't stop the entire loop.


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
