### PR TITLE
allow only a single flush to process at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Authentication support for Cortex remote-write sink. Thanks, [oscil8](https://github.com/oscil8)!
 * Option to flush sinks on shutdown. Thanks, [csolidum](https://github.com/csolidum)!
 * `trace.StartTrace` and `trace.StartChildSpan` now scale better across multiple goroutines.  Thanks [bpowers](https://github.com/bpowers)
+* Ensure concurrent flushes finish in order.  This prevents metric drops when flush on shutdown is enabled.  Thanks, [akutta](https://github.com/akutta)!
 
 ## Updated
 * Use `T.TempDir` to create temporary directory in tests ([#944](https://github.com/stripe/veneur/pull/944)).

--- a/flusher.go
+++ b/flusher.go
@@ -24,6 +24,9 @@ import (
 
 // Flush collects sampler's metrics and passes them to sinks.
 func (s *Server) Flush(ctx context.Context) {
+	s.flushMutex.Lock()
+	defer s.flushMutex.Unlock()
+
 	span := tracer.StartSpan("flush").(*trace.Span)
 	defer span.ClientFinish(s.TraceClient)
 

--- a/server.go
+++ b/server.go
@@ -169,6 +169,8 @@ type Server struct {
 	lastFlushUnix  int64
 
 	parser samplers.Parser
+
+	flushMutex *sync.Mutex
 }
 
 type internalSource struct {
@@ -499,6 +501,8 @@ func NewFromConfig(config ServerConfig) (*Server, error) {
 		synchronizeInterval: conf.SynchronizeWithInterval,
 		// Allocate the slice, we'll fill it with workers later.
 		Workers: make([]*Worker, max(1, conf.NumWorkers)),
+
+		flushMutex: &sync.Mutex{},
 	}
 
 	ret.HistogramAggregates.Value = 0


### PR DESCRIPTION
#### Summary
Wrap Flush in a mutex.  In general this is called only in the flusher goroutine; however, if flush on shutdown is enabled we could prematurely shutdown veneur without waiting for the Flush to complete.


#### Motivation
Discovered dropped metrics for short lived services and veneur running as a sidecar.


#### Test plan
I have automated tests in a different branch.  Requires either introducing a delayed blackhole sink, or introducing mocks which adds additional vendored deps.  The test asserts order of flushes while using different delays during the Flush call.  

Additionally, we have two testbeds to validate this behaviour:
* AWS Lambdas - Running veneur in a Lambda Layer to collect and flush metrics.  On single invocation lambdas we have noticed that metrics are dropped on occasion. We can hide some of this behaviour by reducing the flush interval, but would rather fix the root cause.
* AWS EKS - Running short lived pods w/ veneur as a sidecar.  When application finishes call /quitquitquit and notice that metrics do not flush.


#### Rollout/monitoring/revert plan
* Testing in EKS first followed by Lambda both in dev/staging first.  Will update 
