### PR TITLE
Change AddTags to skip over existing tags

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -186,15 +186,15 @@ func (s *Server) flushSink(
 					continue metricLoop
 				}
 
-				metricHasAddTagsKey := false
-				for _, currentTag := range filteredTags {
-					if strings.HasPrefix(currentTag, k) {
-						metricHasAddTagsKey = true
+				skipped := false
+				for _, ft := range filteredTags {
+					if strings.HasPrefix(ft, k) {
+						skipped = true
 						break
 					}
 				}
 
-				if !metricHasAddTagsKey {
+				if !skipped {
 					filteredTags = append(filteredTags, tag)
 				}
 			}

--- a/flusher.go
+++ b/flusher.go
@@ -177,6 +177,8 @@ func (s *Server) flushSink(
 				}
 			}
 
+			// For any addTag, append our filteredTags, unless it would overwrite an existing tag
+			// Note: if a tag was removed from stripTags above, then that tag could effectively be overwritten
 			for k, v := range sink.addTags {
 				tag := fmt.Sprintf("%s:%s", k, v)
 				if sink.maxTagLength != 0 && len(tag) > sink.maxTagLength {
@@ -184,7 +186,6 @@ func (s *Server) flushSink(
 					continue metricLoop
 				}
 
-				// Choose to skip addTags if tag already exists on the metric
 				metricHasAddTagsKey := false
 				for _, currentTag := range filteredTags {
 					if strings.HasPrefix(currentTag, k) {

--- a/flusher.go
+++ b/flusher.go
@@ -184,16 +184,16 @@ func (s *Server) flushSink(
 					continue metricLoop
 				}
 
-				replaced := false
-				for i, ft := range filteredTags {
-					if len(ft) >= len(k) && ft[0:len(k)] == k {
-						filteredTags[i] = tag
-						replaced = true
+				// Choose to skip addTags if tag already exists on the metric
+				metricHasAddTagsKey := false
+				for _, currentTag := range filteredTags {
+					if strings.HasPrefix(currentTag, k) {
+						metricHasAddTagsKey = true
 						break
 					}
 				}
 
-				if !replaced {
+				if !metricHasAddTagsKey {
 					filteredTags = append(filteredTags, tag)
 				}
 			}

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -917,6 +917,8 @@ func TestFlushWithAddTags(t *testing.T) {
 		}
 	})
 
+	// Current behavior is to first StripTags, then AddTags.
+	// Together this can be used to override tags
 	t.Run("WithAddTagsAndStripTags", func(t *testing.T) {
 		mockStatsd.EXPECT().Count("flushed_metrics", int64(0), []string{
 			"sink_name:channel",
@@ -1102,7 +1104,8 @@ func TestFlushWithAddTagsDedupes(t *testing.T) {
 		if assert.Len(t, result, 1) {
 			assert.Equal(t, "test.metric", result[0].Name)
 			if assert.Len(t, result[0].Tags, 2) {
-				assert.Equal(t, "foo:bar", result[0].Tags[0])
+				assert.Equal(t, "foo:baz", result[0].Tags[0])
+				assert.Equal(t, "anotha:one", result[0].Tags[1])
 			}
 		}
 	})
@@ -1155,7 +1158,7 @@ func TestFlushWithAddTagsDedupes(t *testing.T) {
 		if assert.Len(t, result, 1) {
 			assert.Equal(t, "test.metric", result[0].Name)
 			if assert.Len(t, result[0].Tags, 3) {
-				assert.Equal(t, "foo:bar", result[0].Tags[0])
+				assert.Equal(t, "foo:baz", result[0].Tags[0])
 				assert.Equal(t, "f:a", result[0].Tags[1])
 			}
 		}
@@ -1209,8 +1212,9 @@ func TestFlushWithAddTagsDedupes(t *testing.T) {
 		if assert.Len(t, result, 1) {
 			assert.Equal(t, "test.metric", result[0].Name)
 			if assert.Len(t, result[0].Tags, 3) {
-				assert.Equal(t, "anotha:one", result[0].Tags[0])
-				assert.Equal(t, "foo:bar", result[0].Tags[1])
+				assert.Equal(t, "anotha:thing", result[0].Tags[0])
+				assert.Equal(t, "foo:baz", result[0].Tags[1])
+				assert.Equal(t, "more:tags", result[0].Tags[2])
 			}
 		}
 	})
@@ -1263,8 +1267,8 @@ func TestFlushWithAddTagsDedupes(t *testing.T) {
 		if assert.Len(t, result, 1) {
 			assert.Equal(t, "test.metric", result[0].Name)
 			if assert.Len(t, result[0].Tags, 5) {
-				assert.Equal(t, "anotha:one", result[0].Tags[0])
-				assert.Equal(t, "foo:bar", result[0].Tags[1])
+				assert.Equal(t, "anotha:thing", result[0].Tags[0])
+				assert.Equal(t, "foo:baz", result[0].Tags[1])
 				assert.Equal(t, "more:tags", result[0].Tags[2])
 				assert.Equal(t, "tags:fordays", result[0].Tags[3])
 				assert.Equal(t, "last:one", result[0].Tags[4])


### PR DESCRIPTION
<!-- Checklist For PRs
* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This changes the behavior of `AddTags` to prefer skipping over replacing when deduping. 


#### Motivation
<!-- Why are you making this change? -->
Some tags end up getting overwritten since the outgoing metric's tags collides with the ones specified in `AddTags`.  This behavior of replacing can still be achieved by including the tags-to-replace as part of `StripTags`

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
I updated the existing test cases to assert that if the tag was already on the metric, AddTags is not overriding it.  


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
