### PR TITLE
Add ServerName to tls config

### DIFF
--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	CaFile   string `yaml:"ca_file"`
-	CertFile string `yaml:"cert_file"`
-	KeyFile  string `yaml:"key_file"`
+	CaFile     string `yaml:"ca_file"`
+	CertFile   string `yaml:"cert_file"`
+	KeyFile    string `yaml:"key_file"`
+	ServerName string `yaml:"server_name"`
 }
 
 type Tls struct {
@@ -60,5 +61,6 @@ func (config *Tls) GetTlsConfig() (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{certificate},
 		RootCAs:      caCertPool,
+		ServerName:   config.ServerName,
 	}, nil
 }

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -18,6 +18,7 @@ tls:
   ca_file: "../../testdata/cacert.pem"
   cert_file: "../../testdata/servercert.pem"
   key_file:  "../../testdata/serverkey.pem"
+  server_name: "FooBarSrv"
 `)
 	data := yamlStruct{}
 	err := yaml.Unmarshal(yamlFile, &data)
@@ -26,6 +27,21 @@ tls:
 	assert.NoError(t, err)
 	assert.NotNil(t, tlsConfig)
 	assert.Len(t, tlsConfig.Certificates, 1)
+	assert.NotEqualValues(t, tlsConfig.ServerName, "")
+}
+
+func TestGetTlsConfigNoServerName(t *testing.T) {
+	yamlFile := []byte(`---
+tls:
+  ca_file: "../../testdata/cacert.pem"
+  cert_file: "../../testdata/servercert.pem"
+  key_file:  "../../testdata/serverkey.pem"
+`)
+	data := yamlStruct{}
+	err := yaml.Unmarshal(yamlFile, &data)
+	assert.NoError(t, err)
+	tlsConfig, err := data.Tls.GetTlsConfig()
+	assert.EqualValues(t, tlsConfig.ServerName, "")
 }
 
 func TestGetTlsConfigMissingField(t *testing.T) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
This lets us override the ServerName we share in TLS.
This gets configured here: https://github.com/grpc/grpc-go/blob/master/credentials/tls.go#L69

#### Motivation
<!-- Why are you making this change? -->
Setting an explicit servername is advantageous when there are one or more proxies in between the veneur proxy and client.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
```
/opt/homebrew/bin/go test -timeout 30s -run ^(TestGetTlsConfig|TestGetTlsConfigNoServerName|TestGetTlsConfigMissingField|TestGetTlsConfigEmpty|TestGetTlsConfigUnset)$ github.com/stripe/veneur/v14/util/tls
```

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
@arnav-stripe to help with this post-merge!