### PR TITLE
Deflake some tests

### DIFF
--- a/proxy/destinations/destinations_test.go
+++ b/proxy/destinations/destinations_test.go
@@ -80,10 +80,7 @@ func TestAddSingleWithFailure(t *testing.T) {
 	fixture.destinations.Add(context.Background(), []string{"address"})
 
 	assert.Equal(t, 0, fixture.destinations.Size())
-	assert.Eventually(t, func() bool {
-		fixture.destinations.Wait()
-		return true
-	}, 2*time.Millisecond, time.Millisecond)
+	fixture.destinations.Wait()
 }
 
 func TestAddMultiple(t *testing.T) {


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
Deflakes `TestConnect`; this previously would sometimes finish before the `conn_end` metric was published, which would cause the test to fail. I've addressed this by having the test block on both `ConnectionClosed` & the metric `Count` calls being hit - these two are async wrt each other, so blocking on just one or the other is insufficient.

While trying to merge this, I also ran into another flake in `TestAddSingleWithFailure`. I've fixed this one as well - it's not entirely clear why we ever would have needed the `assert.Eventually` call here. Simply calling `Wait()` is faster and isn't flaky.

#### Motivation
Reduce toil from flaky tests.

#### Test plan
`go test ./proxy/connect ./proxy/destinations -count 1000`; this fails on master.