### PR TITLE
veneur-prometheus bugfix: Specifying multiple tags/labels with -a causes sporadic incorrect metric emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * A fix for forwarding metrics with gRPC using the kubernetes discoverer. Thanks, [androohan](https://github.com/androohan)!
 * Regenerate testing certs/CA that have expired and have broken tests. Thanks, [randallm](https://github.com/randallm)
 * The config field `trace_lightstep_access_token` is redacted if printed. Thanks [arnavdugar](https://github.com/arnavdugar)!
+* A fix for the -a flag in veneur-prometheus. Thanks, [dmarriner](https://github.com/dmarriner)
 
 # 14.1.0, 2021-03-16
 

--- a/cmd/veneur-prometheus/translate.go
+++ b/cmd/veneur-prometheus/translate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stripe/veneur/v14/sources/openmetrics"
@@ -201,8 +202,16 @@ func (t translator) Tags(labels []*dto.LabelPair) []string {
 		tags = append(tags, fmt.Sprintf("%s:%s", labelName, labelValue))
 	}
 
-	for name, value := range t.added {
-		tags = append(tags, fmt.Sprintf("%s:%s", name, value))
+	// Tags need to be returned in sorted order so that metric cache keys are consistent across metric observation
+	// sweeps
+	names := make([]string, 0, len(t.added))
+	for k := range t.added {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		tags = append(tags, fmt.Sprintf("%s:%s", name, t.added[name]))
 	}
 
 	return tags

--- a/cmd/veneur-prometheus/translate_test.go
+++ b/cmd/veneur-prometheus/translate_test.go
@@ -70,7 +70,7 @@ func TestAddTags(t *testing.T) {
 		"so:good",
 	}
 
-	assert.ElementsMatch(t, expectedTags, tags)
+	assert.Equal(t, expectedTags, tags)
 }
 
 func TestReplaceTags(t *testing.T) {


### PR DESCRIPTION
#### Summary

Sort the labels on a given metric before adding them to the cache.

#### Motivation
This fixes a bug in veneur-prometheus that caused diff calculations to sporadically break when multiple labels were added via the -a flag.  Labels were stored as key/values in a map and returned in a potentially different order each time since map iteration order is random in golang.  This caused the translator to sometimes emit the cumulative value instead of the diffed value, because it would seem as though the metric was new when in fact it had been previously cached with a different label ordering.  For example, the translator might look for "counter-key2:value2-key1:value1" when it had been previously cached as "counter-key1:value1-key2:value2"

#### Test plan
Wrote an integration test.

#### Rollout/monitoring/revert plan
N/A
